### PR TITLE
cli-lib/abi: Fix code generation for unnamed function parameters

### DIFF
--- a/cli-lib/abi.js
+++ b/cli-lib/abi.js
@@ -19,7 +19,7 @@ module.exports = class ABI {
     let types = immutable.List()
 
     const paramName = (name, index) =>
-      name === undefined || name === null || name === '' ? `param${name}` : name
+      name === undefined || name === null || name === '' ? `param${index}` : name
 
     klass.addMethod(
       codegen.staticMethod(


### PR DESCRIPTION
This resolves #29. The problem was that contract ABIs don't always provide names for function arguments. This resulted in arguments like `: U256` being generated, with the name missing.

For those parameters that don't have names, we now generate `param0: U256`, i.e., the word `param` plus the index of the parameter in the function parameter list.