### PR TITLE
*: Rename Token type to EthereumValue

### DIFF
--- a/cli-lib/abi.js
+++ b/cli-lib/abi.js
@@ -30,7 +30,7 @@ module.exports = class ABI {
             [],
             codegen.simpleType(input.get('type')),
             `
-            return ${codegen.tokenToCoercion(
+            return ${codegen.ethereumValueToCoercion(
               `this.params[${index}].value`,
               input.get('type')
             )}
@@ -97,19 +97,19 @@ module.exports = class ABI {
                 )
               )
 
-              // Add a `toMap(): TypedMap<string,Token>` function to the return type
+              // Add a `toMap(): TypedMap<string,EthereumValue>` function to the return type
               returnType.addMethod(
                 codegen.method(
                   'toMap',
                   [],
-                  codegen.namedType('TypedMap<string,Token>'),
+                  codegen.namedType('TypedMap<string,EthereumValue>'),
                   `
-                  let map = new TypedMap<string,Token>();
+                  let map = new TypedMap<string,EthereumValue>();
                   ${member
                     .get('outputs')
                     .map(
                       (output, index) =>
-                        `map.set('value${index}', ${codegen.tokenFromCoercion(
+                        `map.set('value${index}', ${codegen.ethereumValueFromCoercion(
                           `this.value${index}`,
                           output.get('type')
                         )})`
@@ -158,7 +158,7 @@ module.exports = class ABI {
                       ? member
                           .get('inputs')
                           .map((input, index) =>
-                            codegen.tokenFromCoercion(
+                            codegen.ethereumValueFromCoercion(
                               paramName(input.get('name'), index),
                               input.get('type')
                             )
@@ -170,7 +170,7 @@ module.exports = class ABI {
                 );
                 return ${
                   simpleReturnType
-                    ? codegen.tokenToCoercion(
+                    ? codegen.ethereumValueToCoercion(
                         'result[0]',
                         member
                           .get('outputs')
@@ -181,7 +181,7 @@ module.exports = class ABI {
                   ${member
                     .get('outputs')
                     .map((output, index) =>
-                      codegen.tokenToCoercion(`result[${index}]`, output.get('type'))
+                      codegen.ethereumValueToCoercion(`result[${index}]`, output.get('type'))
                     )
                     .join(', ')}
                 )`

--- a/cli-lib/codegen.js
+++ b/cli-lib/codegen.js
@@ -23,34 +23,34 @@ const TYPE_MAP = {
   uint: 'U256',
 }
 
-const TOKEN_FROM_TYPE_FUNCTION_MAP = {
-  address: 'Token.fromAddress',
-  bool: 'Token.fromBoolean',
-  byte: 'Token.fromBytes',
-  '/bytes([0-9]+)?/': 'Token.fromBytes',
-  int8: 'Token.fromI8',
-  int16: 'Token.fromI16',
-  int32: 'Token.fromI32',
-  int64: 'Token.fromI64',
-  int128: 'Token.fromI128',
-  int256: 'Token.fromI256',
-  int: 'Token.fromI256',
-  h256: 'Token.fromH256',
-  string: 'Token.fromString',
-  uint8: 'Token.fromU8',
-  uint16: 'Token.fromU16',
-  uint32: 'Token.fromU32',
-  uint64: 'Token.fromU64',
-  uint128: 'Token.fromU128',
-  uint256: 'Token.fromU256',
-  uint: 'Token.fromU256',
+const ETHEREUM_VALUE_FROM_TYPE_FUNCTION_MAP = {
+  address: 'EthereumValue.fromAddress',
+  bool: 'EthereumValue.fromBoolean',
+  byte: 'EthereumValue.fromBytes',
+  '/bytes([0-9]+)?/': 'EthereumValue.fromBytes',
+  int8: 'EthereumValue.fromI8',
+  int16: 'EthereumValue.fromI16',
+  int32: 'EthereumValue.fromI32',
+  int64: 'EthereumValue.fromI64',
+  int128: 'EthereumValue.fromI128',
+  int256: 'EthereumValue.fromI256',
+  int: 'EthereumValue.fromI256',
+  h256: 'EthereumValue.fromH256',
+  string: 'EthereumValue.fromString',
+  uint8: 'EthereumValue.fromU8',
+  uint16: 'EthereumValue.fromU16',
+  uint32: 'EthereumValue.fromU32',
+  uint64: 'EthereumValue.fromU64',
+  uint128: 'EthereumValue.fromU128',
+  uint256: 'EthereumValue.fromU256',
+  uint: 'EthereumValue.fromU256',
 }
 
-const TOKEN_TO_TYPE_FUNCTION_MAP = {
+const ETHEREUM_VALUE_TO_TYPE_FUNCTION_MAP = {
   address: 'toAddress',
   bool: 'toBoolean',
   byte: 'toBytes',
-  '/bytes([0-9]+)?/': 'Token.toBytes',
+  '/bytes([0-9]+)?/': 'EthereumValue.toBytes',
   int8: 'toI8',
   int16: 'toI16',
   int32: 'toI32',
@@ -95,27 +95,28 @@ const typeToString = type => {
   }
 }
 
-const tokenFromTypeFunction = type => {
+const ethereumValueFromTypeFunction = type => {
   let fromFunction =
-    TOKEN_FROM_TYPE_FUNCTION_MAP[type] || findMatch(TOKEN_FROM_TYPE_FUNCTION_MAP, type)
+    ETHEREUM_VALUE_FROM_TYPE_FUNCTION_MAP[type] ||
+    findMatch(ETHEREUM_VALUE_FROM_TYPE_FUNCTION_MAP, type)
 
   if (fromFunction !== undefined) {
     return fromFunction
   } else {
-    throw `Unsupported Token from type coercion for type: ${type}`
+    throw `Unsupported EthereumValue from type coercion for type: ${type}`
   }
 }
 
-const tokenToTypeFunction = type => {
+const ethereumValueToTypeFunction = type => {
   let [isArray, innerType] = maybeInspectArray(type)
   let toFunction =
-    TOKEN_TO_TYPE_FUNCTION_MAP[innerType] ||
-    findMatch(TOKEN_TO_TYPE_FUNCTION_MAP, innerType)
+    ETHEREUM_VALUE_TO_TYPE_FUNCTION_MAP[innerType] ||
+    findMatch(ETHEREUM_VALUE_TO_TYPE_FUNCTION_MAP, innerType)
 
   if (toFunction !== undefined) {
     return isArray ? `${toFunction}Array` : toFunction
   } else {
-    throw `Unsupported Token to type coercion for type: ${type}`
+    throw `Unsupported EthereumValue to type coercion for type: ${type}`
   }
 }
 
@@ -141,25 +142,25 @@ class ReturnType {
   }
 }
 
-class TokenFromCoercion {
+class EthereumValueFromCoercion {
   constructor(expr, type) {
     this.expr = expr
     this.type = type
   }
 
   toString() {
-    return `${tokenFromTypeFunction(this.type)}(${this.expr})`
+    return `${ethereumValueFromTypeFunction(this.type)}(${this.expr})`
   }
 }
 
-class TokenToCoercion {
+class EthereumValueToCoercion {
   constructor(expr, type) {
     this.expr = expr
     this.type = type
   }
 
   toString() {
-    return `${this.expr}.${tokenToTypeFunction(this.type)}()`
+    return `${this.expr}.${ethereumValueToTypeFunction(this.type)}()`
   }
 }
 
@@ -285,8 +286,9 @@ const staticMethod = (name, params, returnType, body) =>
   new StaticMethod(name, params, returnType, body)
 const klass = (name, options) => new Class(name, options)
 const klassMember = (name, type) => new ClassMember(name, type)
-const tokenFromCoercion = (expr, type) => new TokenFromCoercion(expr, type)
-const tokenToCoercion = (expr, type) => new TokenToCoercion(expr, type)
+const ethereumValueFromCoercion = (expr, type) =>
+  new EthereumValueFromCoercion(expr, type)
+const ethereumValueToCoercion = (expr, type) => new EthereumValueToCoercion(expr, type)
 const unionType = (...types) => new UnionType(types)
 
 module.exports = {
@@ -297,7 +299,7 @@ module.exports = {
   method,
   staticMethod,
   param,
-  tokenFromCoercion,
-  tokenToCoercion,
+  ethereumValueFromCoercion,
+  ethereumValueToCoercion,
   unionType,
 }

--- a/examples/memefactory/types/MemeRegistry/Meme.types.ts
+++ b/examples/memefactory/types/MemeRegistry/Meme.types.ts
@@ -34,18 +34,18 @@ class Meme__loadRegistryEntryChallengeResult {
     this.value9 = value9;
   }
 
-  toMap(): TypedMap<string, Token> {
-    let map = new TypedMap<string, Token>();
-    map.set("value0", Token.fromU256(this.value0));
-    map.set("value1", Token.fromAddress(this.value1));
-    map.set("value2", Token.fromU256(this.value2));
-    map.set("value3", Token.fromBytes(this.value3));
-    map.set("value4", Token.fromU256(this.value4));
-    map.set("value5", Token.fromU256(this.value5));
-    map.set("value6", Token.fromU256(this.value6));
-    map.set("value7", Token.fromU256(this.value7));
-    map.set("value8", Token.fromU256(this.value8));
-    map.set("value9", Token.fromU256(this.value9));
+  toMap(): TypedMap<string, EthereumValue> {
+    let map = new TypedMap<string, EthereumValue>();
+    map.set("value0", EthereumValue.fromU256(this.value0));
+    map.set("value1", EthereumValue.fromAddress(this.value1));
+    map.set("value2", EthereumValue.fromU256(this.value2));
+    map.set("value3", EthereumValue.fromBytes(this.value3));
+    map.set("value4", EthereumValue.fromU256(this.value4));
+    map.set("value5", EthereumValue.fromU256(this.value5));
+    map.set("value6", EthereumValue.fromU256(this.value6));
+    map.set("value7", EthereumValue.fromU256(this.value7));
+    map.set("value8", EthereumValue.fromU256(this.value8));
+    map.set("value9", EthereumValue.fromU256(this.value9));
     return map;
   }
 }
@@ -71,13 +71,13 @@ class Meme__loadVoteResult {
     this.value4 = value4;
   }
 
-  toMap(): TypedMap<string, Token> {
-    let map = new TypedMap<string, Token>();
-    map.set("value0", Token.fromBytes(this.value0));
-    map.set("value1", Token.fromU8(this.value1));
-    map.set("value2", Token.fromU256(this.value2));
-    map.set("value3", Token.fromU256(this.value3));
-    map.set("value4", Token.fromU256(this.value4));
+  toMap(): TypedMap<string, EthereumValue> {
+    let map = new TypedMap<string, EthereumValue>();
+    map.set("value0", EthereumValue.fromBytes(this.value0));
+    map.set("value1", EthereumValue.fromU8(this.value1));
+    map.set("value2", EthereumValue.fromU256(this.value2));
+    map.set("value3", EthereumValue.fromU256(this.value3));
+    map.set("value4", EthereumValue.fromU256(this.value4));
     return map;
   }
 }
@@ -115,17 +115,17 @@ class Meme__challengeResult {
     this.value8 = value8;
   }
 
-  toMap(): TypedMap<string, Token> {
-    let map = new TypedMap<string, Token>();
-    map.set("value0", Token.fromAddress(this.value0));
-    map.set("value1", Token.fromU256(this.value1));
-    map.set("value2", Token.fromU256(this.value2));
-    map.set("value3", Token.fromBytes(this.value3));
-    map.set("value4", Token.fromU256(this.value4));
-    map.set("value5", Token.fromU256(this.value5));
-    map.set("value6", Token.fromU256(this.value6));
-    map.set("value7", Token.fromU256(this.value7));
-    map.set("value8", Token.fromU256(this.value8));
+  toMap(): TypedMap<string, EthereumValue> {
+    let map = new TypedMap<string, EthereumValue>();
+    map.set("value0", EthereumValue.fromAddress(this.value0));
+    map.set("value1", EthereumValue.fromU256(this.value1));
+    map.set("value2", EthereumValue.fromU256(this.value2));
+    map.set("value3", EthereumValue.fromBytes(this.value3));
+    map.set("value4", EthereumValue.fromU256(this.value4));
+    map.set("value5", EthereumValue.fromU256(this.value5));
+    map.set("value6", EthereumValue.fromU256(this.value6));
+    map.set("value7", EthereumValue.fromU256(this.value7));
+    map.set("value8", EthereumValue.fromU256(this.value8));
     return map;
   }
 }
@@ -151,13 +151,13 @@ class Meme__loadRegistryEntryResult {
     this.value4 = value4;
   }
 
-  toMap(): TypedMap<string, Token> {
-    let map = new TypedMap<string, Token>();
-    map.set("value0", Token.fromU256(this.value0));
-    map.set("value1", Token.fromU8(this.value1));
-    map.set("value2", Token.fromAddress(this.value2));
-    map.set("value3", Token.fromU256(this.value3));
-    map.set("value4", Token.fromU256(this.value4));
+  toMap(): TypedMap<string, EthereumValue> {
+    let map = new TypedMap<string, EthereumValue>();
+    map.set("value0", EthereumValue.fromU256(this.value0));
+    map.set("value1", EthereumValue.fromU8(this.value1));
+    map.set("value2", EthereumValue.fromAddress(this.value2));
+    map.set("value3", EthereumValue.fromU256(this.value3));
+    map.set("value4", EthereumValue.fromU256(this.value4));
     return map;
   }
 }
@@ -175,12 +175,12 @@ class Meme__loadMemeResult {
     this.value3 = value3;
   }
 
-  toMap(): TypedMap<string, Token> {
-    let map = new TypedMap<string, Token>();
-    map.set("value0", Token.fromBytes(this.value0));
-    map.set("value1", Token.fromU256(this.value1));
-    map.set("value2", Token.fromU256(this.value2));
-    map.set("value3", Token.fromU256(this.value3));
+  toMap(): TypedMap<string, EthereumValue> {
+    let map = new TypedMap<string, EthereumValue>();
+    map.set("value0", EthereumValue.fromBytes(this.value0));
+    map.set("value1", EthereumValue.fromU256(this.value1));
+    map.set("value2", EthereumValue.fromU256(this.value2));
+    map.set("value3", EthereumValue.fromU256(this.value3));
     return map;
   }
 }
@@ -227,7 +227,7 @@ class Meme extends SmartContract {
   }
 
   voteReward(_voter: Address): U256 {
-    let result = super.call("voteReward", [Token.fromAddress(_voter)]);
+    let result = super.call("voteReward", [EthereumValue.fromAddress(_voter)]);
     return result[0].toU256();
   }
 
@@ -273,7 +273,7 @@ class Meme extends SmartContract {
 
   votedWinningVoteOption(_voter: Address): boolean {
     let result = super.call("votedWinningVoteOption", [
-      Token.fromAddress(_voter)
+      EthereumValue.fromAddress(_voter)
     ]);
     return result[0].toBoolean();
   }
@@ -299,7 +299,7 @@ class Meme extends SmartContract {
   }
 
   loadVote(_voter: Address): Meme__loadVoteResult {
-    let result = super.call("loadVote", [Token.fromAddress(_voter)]);
+    let result = super.call("loadVote", [EthereumValue.fromAddress(_voter)]);
     return new Meme__loadVoteResult(
       result[0].toBytes(),
       result[1].toU8(),
@@ -315,7 +315,9 @@ class Meme extends SmartContract {
   }
 
   isVoteRewardClaimed(_voter: Address): boolean {
-    let result = super.call("isVoteRewardClaimed", [Token.fromAddress(_voter)]);
+    let result = super.call("isVoteRewardClaimed", [
+      EthereumValue.fromAddress(_voter)
+    ]);
     return result[0].toBoolean();
   }
 
@@ -380,7 +382,9 @@ class Meme extends SmartContract {
   }
 
   isVoteRevealed(_voter: Address): boolean {
-    let result = super.call("isVoteRevealed", [Token.fromAddress(_voter)]);
+    let result = super.call("isVoteRevealed", [
+      EthereumValue.fromAddress(_voter)
+    ]);
     return result[0].toBoolean();
   }
 

--- a/examples/memefactory/types/MemeRegistry/MemeRegistry.types.ts
+++ b/examples/memefactory/types/MemeRegistry/MemeRegistry.types.ts
@@ -38,7 +38,7 @@ class MemeRegistry extends SmartContract {
   }
 
   isFactory(factory: Address): boolean {
-    let result = super.call("isFactory", [Token.fromAddress(factory)]);
+    let result = super.call("isFactory", [EthereumValue.fromAddress(factory)]);
     return result[0].toBoolean();
   }
 
@@ -54,7 +54,7 @@ class MemeRegistry extends SmartContract {
 
   isRegistryEntry(registryEntry: Address): boolean {
     let result = super.call("isRegistryEntry", [
-      Token.fromAddress(registryEntry)
+      EthereumValue.fromAddress(registryEntry)
     ]);
     return result[0].toBoolean();
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -89,7 +89,7 @@ declare type U128 = U64Array
 declare type U256 = U64Array
 
 /** Type hint for Ethereum values. */
-declare enum TokenKind {
+declare enum EthereumValueKind {
   ADDRESS,
   FIXED_BYTES,
   BYTES,
@@ -101,14 +101,14 @@ declare enum TokenKind {
   ARRAY,
 }
 
-declare type TokenPayload = u64
+declare type EthereumValuePayload = u64
 
 /**
  * A dynamically typed value used when accessing Ethereum data.
  */
-declare class Token {
-  kind: TokenKind
-  data: TokenPayload
+declare class EthereumValue {
+  kind: EthereumValueKind
+  data: EthereumValuePayload
 
   toAddress(): Address
   toBoolean(): boolean
@@ -127,24 +127,24 @@ declare class Token {
   toU256(): U256
   toU256Array(): Array<U256>
   toString(): string
-  toArray(): Array<Token>
-  static fromAddress(address: Address): Token
-  static fromBoolean(b: boolean): Token
-  static fromBytes(bytes: Bytes): Token
-  static fromI8(i: i8): Token
-  static fromI16(i: i16): Token
-  static fromI32(i: i32): Token
-  static fromI64(i: i64): Token
-  static fromI128(i: I128): Token
-  static fromI256(i: I256): Token
-  static fromU8(i: u8): Token
-  static fromU16(i: u16): Token
-  static fromU32(i: u32): Token
-  static fromU64(i: u64): Token
-  static fromU128(i: U128): Token
-  static fromU256(u: U256): Token
-  static fromString(s: string): Token
-  static fromArray(arr: Token): Token
+  toArray(): Array<EthereumValue>
+  static fromAddress(address: Address): EthereumValue
+  static fromBoolean(b: boolean): EthereumValue
+  static fromBytes(bytes: Bytes): EthereumValue
+  static fromI8(i: i8): EthereumValue
+  static fromI16(i: i16): EthereumValue
+  static fromI32(i: i32): EthereumValue
+  static fromI64(i: i64): EthereumValue
+  static fromI128(i: I128): EthereumValue
+  static fromI256(i: I256): EthereumValue
+  static fromU8(i: u8): EthereumValue
+  static fromU16(i: u16): EthereumValue
+  static fromU32(i: u32): EthereumValue
+  static fromU64(i: u64): EthereumValue
+  static fromU128(i: U128): EthereumValue
+  static fromU256(u: U256): EthereumValue
+  static fromString(s: string): EthereumValue
+  static fromArray(arr: EthereumValue): EthereumValue
 }
 
 /**
@@ -215,5 +215,5 @@ declare class EthereumEvent {
  */
 declare interface EthereumEventParam {
   name: string
-  value: Token
+  value: EthereumValue
 }


### PR DESCRIPTION
Token is pretty confusing, since it is mostly used for cryptocurrencies.
EthereumValue should convey a clear meaning.

This resolves graphprotocol/the-graph-network#176 (which was created in the wrong repo by accident).