### PR TITLE
Add Database class with bind(blockHash) constructor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,17 @@
 /// <reference path="./node_modules/assemblyscript/std/assembly.d.ts" />
 
-/** Host database interface */
-declare namespace database {
+/**
+ * Host database interface
+ */
+declare class Database {
+  /**
+   * Creates a database object to add/update/remove Entities
+   * to/from the database.
+   *
+   * @param blockHash Hash of the current Ethereum block.
+   */
+  static bind(blockHash: H256): Database
+
   /**
    * Creates an entity in the host database.
    *
@@ -9,7 +19,7 @@ declare namespace database {
    * @param id Entity ID.
    * @param data Entity data.
    */
-  function create(entity: string, id: string, data: Entity): void
+  create(entity: string, id: string, data: Entity): void
 
   /**
    * Updates an entity in the host database.
@@ -18,7 +28,7 @@ declare namespace database {
    * @param id Entity ID.
    * @param data Entity data.
    */
-  function update(entity: string, id: string, data: Entity): void
+  update(entity: string, id: string, data: Entity): void
 
   /**
    * Removes ane entity from the host database.
@@ -26,7 +36,7 @@ declare namespace database {
    * @param entity Name of the entity type.
    * @param id Entity ID.
    */
-  function remove(entity: string, id: string): void
+  remove(entity: string, id: string, data: Entity): void
 }
 
 /**

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -5,9 +5,9 @@ export { allocate_memory, free_memory }
 
 /** Host database interface */
 declare namespace database {
-  function create(entity: string, id: string, data: Entity): void
-  function update(entity: string, id: string, data: Entity): void
-  function remove(entity: string, id: string): void
+  function create(blockHash: H256, entity: string, id: string, data: Entity): void
+  function update(blockHash: H256, entity: string, id: string, data: Entity): void
+  function remove(blockHash: H256, entity: string, id: string): void
 }
 
 /** Host ethereum interface */
@@ -613,5 +613,32 @@ class SmartContract {
       params
     )
     return ethereum.call(call)
+  }
+}
+
+/**
+ * Host database interface.
+ */
+class Database {
+  blockHash: H256
+
+  protected constructor(blockHash: H256) {
+    this.blockHash = blockHash
+  }
+
+  static bind(blockHash: H256): Database {
+    return new Database(blockHash)
+  }
+
+  create(entity: string, id: string, data: Entity): void {
+    database.create(this.blockHash, entity, id, data)
+  }
+
+  update(entity: string, id: string, data: Entity): void {
+    database.update(this.blockHash, entity, id, data)
+  }
+
+  remove(entity: string, id: string): void {
+    database.remove(this.blockHash, entity, id)
   }
 }


### PR DESCRIPTION
This resolves #54 (changes need to be made on the Rust side to accept the block hash and pass it on).

Instead of just doing
```typescript
database.create("EntityName", "some-id", ...)
```
you now do
```typescript
let db = Database.bind(event.blockHash)
db.create("EntityName, "some-id", ...)
```