### PR TITLE
cli, runtime: Generate a `FixedBytes` token for `bytes32` function args

### DIFF
--- a/src/cli/codegen.js
+++ b/src/cli/codegen.js
@@ -27,7 +27,10 @@ const ETHEREUM_VALUE_FROM_TYPE_FUNCTION_MAP = {
   address: 'EthereumValue.fromAddress',
   bool: 'EthereumValue.fromBoolean',
   byte: 'EthereumValue.fromBytes',
-  '/bytes([0-9]+)?/': 'EthereumValue.fromBytes',
+  // FIXME: The regex doesn't seem to be working so as a workaround include
+  // `bytes32` literally.
+  bytes32: 'EthereumValue.fromFixedBytes',
+  '/bytes([0-9]+)?/': 'EthereumValue.fromFixedBytes',
   int8: 'EthereumValue.fromI8',
   int16: 'EthereumValue.fromI16',
   int32: 'EthereumValue.fromI32',

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -328,6 +328,13 @@ class EthereumValue {
     return token
   }
 
+  static fromFixedBytes(bytes: Bytes): EthereumValue {
+    let token = new EthereumValue()
+    token.kind = EthereumValueKind.FIXED_BYTES
+    token.data = bytes as u64
+    return token
+  }
+
   static fromI8(i: i8): EthereumValue {
     let token = new EthereumValue()
     token.kind = EthereumValueKind.INT


### PR DESCRIPTION
Fixes bug where contract calls were failing to type check because they were receiving a `Bytes` instead of `FixedBytes`.