### PR TITLE
Update graph-cli node_module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ An example of this can be found in the [Decentraland repository](https://github.
 4.  Add the following `tsconfig.json`:
     ```json
     {
-      "extends": "./node_modules/graph-cli/tsconfig.json",
-      "files": ["mapping.ts"]
+      "extends": "./node_modules/@graphprotocol/graph-cli/tsconfig.json",
+      "compilerOptions": {
+        "types": ["graph-cli"]
+      }
     }
     ```
-    _Note: Replace `"mapping.ts"` with your own mapping fil(e)s._
 5.  Add the following to `package.json`:
     ```json
     {

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ An example of this can be found in the [Decentraland repository](https://github.
     {
       "extends": "./node_modules/@graphprotocol/graph-cli/tsconfig.json",
       "compilerOptions": {
-        "types": ["graph-cli"]
+        "types": ["@graphprotocol/graph-cli"]
       }
     }
     ```


### PR DESCRIPTION
Updating the docs to reflect what worked for me. The `graph-cli` package is nested inside `@graphprotocol` when installing using `@graphprotocol/graph-cli`. A few of the examples pull `graph-cli` directly from the repo though.