### PR TITLE
Enable store.get again and allow it to return `null`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ declare namespace store {
    * @param entity Name of the entity type.
    * @param id Entity ID.
    */
-  function get(entity: string, id: string): Entity
+  function get(entity: string, id: string): Entity | null
 }
 
 /** Host IPFS interface */

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare namespace store {
 
   /**
    * Fetches a previously created entity from the host store.
-   * 
+   *
    * @param entity Name of the entity type.
    * @param id Entity ID.
    */

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -7,7 +7,7 @@ export { allocate_memory }
  * Host store interface.
  */
 declare namespace store {
-  function get(entity: string, id: string): Entity
+  function get(entity: string, id: string): Entity | null
   function set(entity: string, id: string, data: Entity): void
   function remove(entity: string, id: string): void
 }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -7,14 +7,9 @@ export { allocate_memory }
  * Host store interface.
  */
 declare namespace store {
+  function get(entity: string, id: string): Entity
   function set(entity: string, id: string, data: Entity): void
   function remove(entity: string, id: string): void
-}
-
-namespace store {
-  function get(entity: string, id: string): Entity {
-    return assert<Entity>(null, "store.get is not supported yet")
-  }
 }
 
 /** Host ethereum interface */


### PR DESCRIPTION
Since `store.get` is now supported in [graph-node](https://github.com/graphprotocol/graph-node), we can enable it again.

This PR also allows `store.get` to return `null`, e.g. if the entity wasn't found. This allows for conditional entity creation/updating. See https://github.com/graphprotocol/graph-node/pull/422 for the corresponding node PR.