### PR TITLE
Fix bugs in --watch mode for `codegen` and `build`

### DIFF
--- a/graph-build.js
+++ b/graph-build.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+let args = require('commander')
 let app = require('./src/app')
 
 app.initApp()
@@ -8,7 +8,7 @@ app.parse()
 let compiler = app.compilerFromArgs()
 
 // Watch subgraph files for changes or additions, trigger compile (if watch argument specified)
-if (app.watch) {
+if (args.watch) {
   compiler.watchAndCompile()
 } else {
   compiler.compile()

--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -6,6 +6,7 @@ let prettier = require('prettier')
 let ABI = require('./abi')
 let Logger = require('./logger')
 let Subgraph = require('./subgraph')
+let Watcher = require('./watcher')
 
 module.exports = class TypeGenerator {
   constructor(options) {
@@ -160,8 +161,8 @@ module.exports = class TypeGenerator {
     let watcher = new Watcher({
       onReady: () => generator.logger.status('Watching subgraph files'),
       onTrigger: async changedFile => {
-        if (file !== undefined) {
-          generator.logger.status('File change detected:', this.displayPath(file))
+        if (changedFile !== undefined) {
+          generator.logger.status('File change detected:', this.displayPath(changedFile))
         }
         await generator.generateTypes()
       },


### PR DESCRIPTION
This PR fixes the bugs in "watch mode" resolving #136.

---

### codegen bugs 
/src/type-generator.js
  - In `watchAndGenerateTypes` the `onTrigger` input variable did not match the input name.
  - `Watcher` was not being imported from `./watcher`

### build bugs 
/graph-build.js
  - The `-watch` arg was not being referenced correctly, so `compiler.watchAndCompile()` never ran 