### PR TITLE
Validate subgraph manifests using a GraphQL schema

### DIFF
--- a/manifest-schema.graphql
+++ b/manifest-schema.graphql
@@ -1,0 +1,46 @@
+scalar String
+scalar File
+
+type Schema {
+  file: File!
+}
+
+union DataSource = EthereumContractDataSource
+
+type EthereumContractDataSource {
+  kind: String!
+  name: String!
+  source: EthereumContractSource!
+  mapping: EthereumContractMapping!
+}
+
+type EthereumContractSource {
+  address: String!
+  abi: String!
+}
+
+type EthereumContractMapping {
+  kind: String!
+  apiVersion: String!
+  language: String!
+  file: File!
+  entities: [String!]!
+  abis: [EthereumContractAbi!]!
+  eventHandlers: [EthereumContractEventHandlers]!
+}
+
+type EthereumContractAbi {
+  name: String!
+  file: File!
+}
+
+type EthereumContractEventHandlers {
+  event: String!
+  handler: String!
+}
+
+type SubgraphManifest {
+  specVersion: String!
+  schema: Schema!
+  dataSources: [DataSource!]!
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "debug": "^3.1.0",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
+    "graphql": "^14.0.2",
     "immutable": "^3.8.2",
     "ipfs-api": "^22.2.1",
     "jayson": "^2.0.6",

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -70,7 +70,7 @@ class Compiler {
     try {
       return Subgraph.load(this.options.subgraphManifest)
     } catch (e) {
-      throw Error('Failed to load subgraph')
+      throw Error(`Failed to load subgraph: ${e.message}`)
     }
   }
 

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -3,7 +3,6 @@ let immutable = require('immutable')
 let path = require('path')
 let yaml = require('js-yaml')
 let graphql = require('graphql/language')
-//let validate = require('@graphprotocol/graphql-data-validation')
 let validation = require('./validation')
 
 module.exports = class Subgraph {

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -6,7 +6,7 @@ let graphql = require('graphql/language')
 let validation = require('./validation')
 
 module.exports = class Subgraph {
-  static validate(data) {
+  static validate(filename, data) {
     // Parse the default subgraph schema
     let schema = graphql.parse(
       fs.readFileSync(path.join(__dirname, '..', 'manifest-schema.graphql'), 'utf-8')
@@ -23,10 +23,11 @@ module.exports = class Subgraph {
       throw new Error(
         errors.reduce(
           (msg, e) =>
-            `${msg}\n\nError at ${e.path.length === 0 ? '/' : e.path.join('/')}:\n${
-              e.message
-            }`,
-          ''
+            `${msg}
+
+  Path: ${e.path.length === 0 ? '/' : ['/', ...e.path].join(' > ')}
+  ${e.message}`,
+          `Error in ${filename}:`
         )
       )
     }
@@ -34,7 +35,7 @@ module.exports = class Subgraph {
 
   static load(filename) {
     let data = yaml.safeLoad(fs.readFileSync(filename, 'utf-8'))
-    Subgraph.validate(data)
+    Subgraph.validate(filename, data)
     return immutable.fromJS(data)
   }
 

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -1,14 +1,45 @@
 let fs = require('fs-extra')
 let immutable = require('immutable')
+let path = require('path')
 let yaml = require('js-yaml')
+let graphql = require('graphql/language')
+//let validate = require('@graphprotocol/graphql-data-validation')
+let validation = require('./validation')
 
 module.exports = class Subgraph {
-  static load(path) {
-    let data = yaml.safeLoad(fs.readFileSync(path, 'utf-8'))
+  static validate(data) {
+    // Parse the default subgraph schema
+    let schema = graphql.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'manifest-schema.graphql'), 'utf-8')
+    )
+
+    // Obtain the root `SubgraphManifest` type from the schema
+    let rootType = schema.definitions.find(definition => {
+      return definition.name.value === 'SubgraphManifest'
+    })
+
+    // Validate the subgraph definition using this schema
+    let errors = validation.validateManifest(data, rootType, schema)
+    if (errors.length > 0) {
+      throw new Error(
+        errors.reduce(
+          (msg, e) =>
+            `${msg}\n\nError at ${e.path.length === 0 ? '/' : e.path.join('/')}:\n${
+              e.message
+            }`,
+          ''
+        )
+      )
+    }
+  }
+
+  static load(filename) {
+    let data = yaml.safeLoad(fs.readFileSync(filename, 'utf-8'))
+    Subgraph.validate(data)
     return immutable.fromJS(data)
   }
 
-  static write(subgraph, path) {
-    fs.writeFileSync(path, yaml.safeDump(subgraph.toJS(), { indent: 2 }))
+  static write(subgraph, filename) {
+    fs.writeFileSync(filename, yaml.safeDump(subgraph.toJS(), { indent: 2 }))
   }
 }

--- a/src/validation.js
+++ b/src/validation.js
@@ -14,9 +14,12 @@ const typeName = value =>
  * Converts an immutable or plain JavaScript value to a YAML string.
  */
 const toYAML = x =>
-  yaml.safeDump(typeName(x) === 'list' || typeName(x) === 'map' ? x.toJS() : x, {
-    indent: 2,
-  })
+  yaml
+    .safeDump(typeName(x) === 'list' || typeName(x) === 'map' ? x.toJS() : x, {
+      indent: 2,
+    })
+    .replace(/\n/g, '\n  ')
+    .trim()
 
 /**
  * Looks up the type of a field in a GraphQL object type.
@@ -89,7 +92,7 @@ const validators = immutable.fromJS({
       : immutable.fromJS([
           {
             path: ctx.get('path'),
-            message: `Expected list, found ${typeName(value)}:\n${toYAML(value)}`,
+            message: `Expected list, found ${typeName(value)}:\n  ${toYAML(value)}`,
           },
         ]),
 
@@ -120,7 +123,7 @@ const validators = immutable.fromJS({
       : immutable.fromJS([
           {
             path: ctx.get('path'),
-            message: `Expected map, found ${typeName(value)}:\n${toYAML(value)}`,
+            message: `Expected map, found ${typeName(value)}:\n  ${toYAML(value)}`,
           },
         ])
   },
@@ -131,7 +134,7 @@ const validators = immutable.fromJS({
       : immutable.fromJS([
           {
             path: ctx.get('path'),
-            message: `Expected string, found ${typeName(value)}:\n${toYAML(value)}`,
+            message: `Expected string, found ${typeName(value)}:\n  ${toYAML(value)}`,
           },
         ]),
 
@@ -148,7 +151,7 @@ const validators = immutable.fromJS({
       : immutable.fromJS([
           {
             path: ctx.get('path'),
-            message: `Expected filename, found ${typeName(value)}:\n${value}`,
+            message: `Expected filename, found ${typeName(value)}:\n  ${value}`,
           },
         ]),
 })
@@ -183,7 +186,7 @@ const validateManifest = (value, type, schema) =>
     : [
         {
           path: [],
-          message: `Expected non-empty value, found ${typeName(value)}:\n${value}`,
+          message: `Expected non-empty value, found ${typeName(value)}:\n  ${value}`,
         },
       ]
 

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,0 +1,192 @@
+const immutable = require('immutable')
+const yaml = require('js-yaml')
+
+const List = immutable.List
+const Map = immutable.Map
+
+/**
+ * Returns a user-friendly type name for a value.
+ */
+const typeName = value =>
+  List.isList(value) ? 'list' : Map.isMap(value) ? 'map' : typeof value
+
+/**
+ * Converts an immutable or plain JavaScript value to a YAML string.
+ */
+const toYAML = x =>
+  yaml.safeDump(typeName(x) === 'list' || typeName(x) === 'map' ? x.toJS() : x, {
+    indent: 2,
+  })
+
+/**
+ * Looks up the type of a field in a GraphQL object type.
+ */
+const getFieldType = (type, fieldName) => {
+  let fieldDef = type
+    .get('fields')
+    .find(field => field.getIn(['name', 'value']) === fieldName)
+
+  return fieldDef !== undefined ? fieldDef.get('type') : undefined
+}
+
+/**
+ * Resolves a type in the GraphQL schema.
+ */
+const resolveType = (schema, type) =>
+  type.has('type')
+    ? resolveType(schema, type.get('type'))
+    : type.get('kind') === 'NamedType'
+      ? schema
+          .get('definitions')
+          .find(def => def.getIn(['name', 'value']) === type.getIn(['name', 'value']))
+      : 'resolveType: unimplemented'
+
+/**
+ * A map of supported validators.
+ */
+const validators = immutable.fromJS({
+  ScalarTypeDefinition: (value, ctx) =>
+    validators.get(ctx.getIn(['type', 'name', 'value']))(value, ctx),
+
+  UnionTypeDefinition: (value, ctx) =>
+    ctx
+      .getIn(['type', 'types'])
+      .reduce(
+        (errors, type) => errors.concat(validateValue(value, ctx.set('type', type))),
+        immutable.fromJS([])
+      ),
+
+  NamedType: (value, ctx) =>
+    validateValue(
+      value,
+      ctx.update('type', type => resolveType(ctx.get('schema'), type))
+    ),
+
+  NonNullType: (value, ctx) =>
+    value !== null && value !== undefined
+      ? validateValue(value, ctx.update('type', type => type.get('type')))
+      : immutable.fromJS([
+          {
+            path: ctx.get('path'),
+            message: `No value provided`,
+          },
+        ]),
+
+  ListType: (value, ctx) =>
+    List.isList(value)
+      ? value.reduce(
+          (errors, value, i) =>
+            errors.concat(
+              validateValue(
+                value,
+                ctx
+                  .update('path', path => path.push(i))
+                  .update('type', type => type.get('type'))
+              )
+            ),
+          immutable.fromJS([])
+        )
+      : immutable.fromJS([
+          {
+            path: ctx.get('path'),
+            message: `Expected list, found ${typeName(value)}:\n${toYAML(value)}`,
+          },
+        ]),
+
+  ObjectTypeDefinition: (value, ctx) => {
+    return Map.isMap(value)
+      ? ctx
+          .getIn(['type', 'fields'])
+          .map(fieldDef => fieldDef.getIn(['name', 'value']))
+          .concat(value.keySeq())
+          .toSet()
+          .reduce((errors, key) => {
+            return getFieldType(ctx.get('type'), key)
+              ? errors.concat(
+                  validateValue(
+                    value.get(key),
+                    ctx
+                      .update('path', path => path.push(key))
+                      .set('type', getFieldType(ctx.get('type'), key))
+                  )
+                )
+              : errors.push(
+                  immutable.fromJS({
+                    path: ctx.get('path'),
+                    message: `Unexpected key in map: ${key}`,
+                  })
+                )
+          }, immutable.fromJS([]))
+      : immutable.fromJS([
+          {
+            path: ctx.get('path'),
+            message: `Expected map, found ${typeName(value)}:\n${toYAML(value)}`,
+          },
+        ])
+  },
+
+  String: (value, ctx) =>
+    typeof value === 'string'
+      ? immutable.fromJS([])
+      : immutable.fromJS([
+          {
+            path: ctx.get('path'),
+            message: `Expected string, found ${typeName(value)}:\n${toYAML(value)}`,
+          },
+        ]),
+
+  File: (value, ctx) =>
+    typeof value === 'string'
+      ? require('fs').existsSync(value)
+        ? immutable.fromJS([])
+        : immutable.fromJS([
+            {
+              path: ctx.get('path'),
+              message: `File does not exist: ${value}`,
+            },
+          ])
+      : immutable.fromJS([
+          {
+            path: ctx.get('path'),
+            message: `Expected filename, found ${typeName(value)}:\n${value}`,
+          },
+        ]),
+})
+
+const validateValue = (value, ctx) => {
+  let kind = ctx.getIn(['type', 'kind'])
+  let validator = validators.get(kind)
+
+  if (validator !== undefined) {
+    return validator(value, ctx)
+  } else {
+    return immutable.fromJS([
+      {
+        path: ctx.get('path'),
+        message: `No validator for unsupported schema type: ${kind}`,
+      },
+    ])
+  }
+}
+
+const validateManifest = (value, type, schema) =>
+  value !== null && value !== undefined
+    ? validateValue(
+        immutable.fromJS(value),
+        immutable.fromJS({
+          schema: schema,
+          type: type,
+          path: [],
+          errors: [],
+        })
+      ).toJS()
+    : [
+        {
+          path: [],
+          message: `Expected non-empty value, found ${typeName(value)}:\n${value}`,
+        },
+      ]
+
+module.exports = {
+  validateManifest,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,6 +834,12 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+graphql@^14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.0.2.tgz#7dded337a4c3fd2d075692323384034b357f5650"
+  dependencies:
+    iterall "^1.2.2"
+
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -1191,6 +1197,10 @@ isobject@^3.0.0, isobject@^3.0.1:
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+
+iterall@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
 
 jayson@^2.0.6:
   version "2.0.6"


### PR DESCRIPTION
This validates subgraph manifests when loading them, using a GraphQL schema ([manifest-schema.graphql](https://github.com/graphprotocol/graph-cli/blob/jannis/subgraph-validation/manifest-schema.graphql)).

We'll want to perform more validation for the GraphQL schema, the ABIs and the mappings. I'll create an epic for this.

Some of the error messages this generates:

## Value with incorrect type

```sh
➜  ens-subgraph git:(master) ✗ graph build subgraph.yaml
Failed to load subgraph:

Error at specVersion:
Expected string, found list:
- 1
- 2
```

```sh
➜  ens-subgraph git:(master) ✗ graph build subgraph.yaml
Failed to load subgraph:

Error at dataSources:
Expected list, found map:
kind: ethereum/contract
name: ENSRegistrar
source:
  address: '0x314159265dd8dbb310642f98f50c066173c1259b'
  abi: EnsRegistrar
mapping:
  kind: ethereum/events
  apiVersion: 0.0.1
  language: wasm/assemblyscript
  file: ./src/ensRegistrar.ts
  entities:
    - Domain
    - Transfer
  abis:
    - name: EnsRegistrar
      file: ./abis/EtherscanAbi.json
  eventHandlers:
    - event: 'Transfer(bytes32,address)'
      handler: transfer
    - event: 'NewOwner(bytes32,bytes32,address)'
      handler: newOwner
```

## Missing file

```sh
➜  ens-subgraph git:(master) ✗ graph build subgraph.yaml
Failed to load subgraph:

Error at schema/file:
File does not exist: ./schema.graphql1
```

## Missing value

```sh
➜  ens-subgraph git:(master) ✗ graph build subgraph.yaml
Failed to load subgraph:

Error at dataSources/0/name:
No value provided
```