### PR TITLE
Validate GraphQL schema when loading subgraphs

### DIFF
--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -34,9 +34,17 @@ module.exports = class Subgraph {
   }
 
   static validateSchema(manifest) {
-    let errors = validation.validateSchema(manifest.getIn(['schema', 'file']))
+    let filename = manifest.getIn(['schema', 'file'])
+    let errors = validation.validateSchema(filename)
     if (errors.length > 0) {
-      throw new Error(errors.reduce((msg, e) => `${msg}\n\n${e.message}`, ''))
+      throw new Error(
+        errors.reduce(
+          (msg, e) => `${msg}
+
+  ${e.message}`,
+          `Error in ${filename}:`
+        )
+      )
     }
   }
 

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -33,10 +33,19 @@ module.exports = class Subgraph {
     }
   }
 
+  static validateSchema(manifest) {
+    let errors = validation.validateSchema(manifest.getIn(['schema', 'file']))
+    if (errors.length > 0) {
+      throw new Error(errors.reduce((msg, e) => `${msg}\n\n${e.message}`, ''))
+    }
+  }
+
   static load(filename) {
     let data = yaml.safeLoad(fs.readFileSync(filename, 'utf-8'))
     Subgraph.validate(filename, data)
-    return immutable.fromJS(data)
+    let manifest = immutable.fromJS(data)
+    Subgraph.validateSchema(manifest)
+    return manifest
   }
 
   static write(subgraph, filename) {

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  validateSchema: require('./schema').validateSchema,
+  validateManifest: require('./manifest').validateManifest,
+}

--- a/src/validation/manifest.js
+++ b/src/validation/manifest.js
@@ -190,6 +190,4 @@ const validateManifest = (value, type, schema) =>
         },
       ]
 
-module.exports = {
-  validateManifest,
-}
+module.exports = { validateManifest }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -25,7 +25,8 @@ const typeDefinitionValidators = {
       : immutable.fromJS([
           {
             loc: def.loc,
-            message: `Type '${def.name.value}' defined without @entity directive`,
+            message: `Type '${def.name.value}':
+  Defined without @entity directive`,
           },
         ]),
 }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -1,0 +1,50 @@
+const fs = require('fs')
+const graphql = require('graphql/language')
+const immutable = require('immutable')
+
+const loadSchema = filename => {
+  try {
+    return fs.readFileSync(filename, 'utf-8')
+  } catch (e) {
+    throw new Error(`Failed to load GraphQL schema: ${e}`)
+  }
+}
+
+const parseSchema = doc => {
+  try {
+    return graphql.parse(doc)
+  } catch (e) {
+    throw new Error(`Invalid GraphQL schema: ${e}`)
+  }
+}
+
+const typeDefinitionValidators = {
+  ObjectTypeDefinition: def =>
+    def.directives.find(directive => directive.name.value === 'entity')
+      ? immutable.fromJS([])
+      : immutable.fromJS([
+          {
+            loc: def.loc,
+            message: `Type '${def.name.value}' defined without @entity directive`,
+          },
+        ]),
+}
+
+const validateTypeDefinition = def =>
+  typeDefinitionValidators[def.kind] !== undefined
+    ? typeDefinitionValidators[def.kind](def)
+    : immutable.fromJS([])
+
+const validateTypeDefinitions = defs =>
+  defs.reduce(
+    (errors, def) => errors.concat(validateTypeDefinition(def)),
+    immutable.fromJS([])
+  )
+
+const validateSchema = filename => {
+  let doc = loadSchema(filename)
+  let schema = parseSchema(doc)
+  return validateTypeDefinitions(schema.definitions).toJS()
+}
+
+module.exports = { validateSchema }


### PR DESCRIPTION
This adds the following validation steps to subgraph loading:

1. Validate that the GraphQL schema can be loaded / read from its file.
2. Validate that the GraphQL schema can be parsed (i.e. is valid GraphQL).
3. Validate that all types have the `@entity` directive.