### PR TITLE
Travis: Run `graph auth` as part of the test commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,17 @@ node_js:
   - "10"
 cache: yarn
 before_install:
-  - sudo apt-get install libsecret-1-dev
+  - sudo apt-get install libsecret-1-dev dbus gnome-keyring python-keyring python-gnomekeyring
+before_script:
+  # Create a new 'login' keyring; this appearas to be necessary for gnome-keyring to auto-launch
+  # properly when needed
+  - dbus-launch /usr/bin/python -c "import gnomekeyring;gnomekeyring.create_sync('login', '');"
 script:
   - yarn test
   - cd examples/example-subgraph
   - yarn
   - ../../graph.js codegen --output-dir src/types --debug
   - ../../graph.js build --debug
+  # Run `graph auth` inside `dbus-launch` to be able to access gnome-keyring
+  # secrets via keytar
+  - dbus-launch bash -c '../../graph.js auth http://some-node-ip.org test-access-token'


### PR DESCRIPTION
This requires a 'login' keyring to be created upfront using gnome-keyring.