### PR TITLE
Add `network` to manifest

### DIFF
--- a/examples/example-subgraph/subgraph.yaml
+++ b/examples/example-subgraph/subgraph.yaml
@@ -1,9 +1,12 @@
 specVersion: 0.0.1
+description: "example of a subgraph"
+repository: https://github.com/graphprotocol/graph-cli.git
 schema:
   file: ./schema.graphql
 dataSources:
   - kind: ethereum/contract
     name: ExampleSubgraph
+    network: mainnet
     source:
       address: '22843e74c59580b3eaf6c233fa67d8b7c561a835'
       abi: ExampleContract

--- a/manifest-schema.graphql
+++ b/manifest-schema.graphql
@@ -10,6 +10,7 @@ union DataSource = EthereumContractDataSource
 type EthereumContractDataSource {
   kind: String!
   name: String!
+  network: String
   source: EthereumContractSource!
   mapping: EthereumContractMapping!
 }


### PR DESCRIPTION
Optional because it might not be relevant to non-ethereum data sources. See https://github.com/graphprotocol/graph-node/pull/597