### PR TITLE
Make `graph auth` and `--access-token` useful for IPFS as well

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -196,6 +196,8 @@ app
   .option('-t, --output-format <wasm|wast>', 'Output format (wasm, wast)', 'wasm')
   .option('-w, --watch', 'Rebuild automatically when files change')
   .action(async (subgraphManifest, cmd) => {
+    let logger = new Logger(0, { verbosity: getVerbosity(app) })
+
     // Connect to the IPFS node (if an IPFS address was provided)
     let accessToken = await getAccessToken(cmd, cmd.ipfs, logger)
     let ipfs = createIpfsClient(app, cmd, accessToken)

--- a/graph.js
+++ b/graph.js
@@ -371,10 +371,10 @@ app
 app
   .command('remove')
   .description('Removes subgraph from node')
-  .option('-k, --api-key <KEY>', 'Graph API key authorized to manage the subgraph name')
+  .option('--access-token <TOKEN>', 'Graph access token')
   .option('-g, --node <URL>[:PORT]', 'Graph node to remove the subgraph from')
   .option('-n, --subgraph-name <NAME>', 'Subgraph name to remove')
-  .action(cmd => {
+  .action(async cmd => {
     if (cmd.subgraphName === undefined || cmd.node === undefined) {
       console.error('Cannot remove the subgraph')
       console.error('--')
@@ -387,14 +387,17 @@ app
 
     let logger = new Logger(0, { verbosity: getVerbosity(app) })
 
+    // Default to port 8020 for the admin endpoint
     let requestUrl = new URL(cmd.node)
     if (!requestUrl.port) {
       requestUrl.port = '8020'
     }
 
+    // Create remove request client
     let client = jayson.Client.http(requestUrl)
-    if (cmd.apiKey !== undefined) {
-      client.options.headers = { Authorization: 'Bearer ' + cmd.apiKey }
+    let accessToken = await getAccessToken(cmd, cmd.node, logger)
+    if (accessToken !== undefined) {
+      client.options.headers = { Authorization: `Bearer ${accessToken}` }
     }
 
     logger.status('Removing subgraph from Graph node:', requestUrl)

--- a/graph.js
+++ b/graph.js
@@ -208,22 +208,22 @@ app
  */
 app
   .command('auth [NODE] [ACCESS_TOKEN]')
-  .description('Sets the access token to use when deploying to a Graph node')
-  .action(async (nodeUrl, accessToken) => {
+  .description('Sets the access token to use when deploying to a Graph or IPFS node')
+  .action(async (url, accessToken) => {
     let logger = new Logger(0, { verbosity: getVerbosity(app) })
-    if (accessToken === undefined || nodeUrl === undefined || accessToken.length > 200) {
+    if (accessToken === undefined || url === undefined || accessToken.length > 200) {
       console.error('Cannot set the access token')
       console.error('--')
-      outputAuthConfig(nodeUrl, accessToken)
+      outputAuthConfig(url, accessToken)
       console.error('--')
       console.error('For more information run this command with --help')
       process.exitCode = 1
       return
     }
     try {
-      let node = normalizeNodeUrl(nodeUrl)
+      let node = normalizeUrl(url)
       await keytar.setPassword('graphprotocol-auth', node, accessToken)
-      logger.status('Access token set for Graph node:', node)
+      logger.status('Access token set for Graph or IPFS node:', node)
     } catch (e) {
       if (process.platform === 'win32') {
         logger.error(`Error storing access token in Windows Credential Vault:`, e)
@@ -232,7 +232,7 @@ app
       } else if (process.platform === 'linux') {
         logger.error(
           `Error storing access token with libsecret ` +
-          `(usually gnome-keyring or ksecretservice):`,
+            `(usually gnome-keyring or ksecretservice):`,
           e
         )
       } else {


### PR DESCRIPTION
Whenever users deploy a Graph Node in public, they will want or need to protect Graph Node and their IPFS node behind authentication.

This PR makes `graph auth` able to store access tokens for IPFS as well, like with
```sh
graph auth /ip4/127.0.0.1/tcp/80 some-token
```

It also makes `graph build --ipfs ...` and `graph deploy` lookup the access token for both Graph Node and IPFS from the keychain. Note that when providing the access token with `--access-token`, the same access token is used for IPFS and Graph Node.

This PR also fixes `graph remove` to look up access tokens from the keychain or take it in with `--access-token`.