### PR TITLE
Don't default to port 8020 if no port is set

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -234,10 +234,6 @@ app
     )
 
     let requestUrl = new URL(cmd.node)
-    if (!requestUrl.port) {
-      requestUrl.port = '8020'
-    }
-
     let client = jayson.Client.http(requestUrl)
 
     let logger = new Logger(0, { verbosity: getVerbosity(app) })
@@ -343,11 +339,8 @@ app
     let logger = new Logger(0, { verbosity: getVerbosity(app) })
 
     let requestUrl = new URL(cmd.node)
-    if (!requestUrl.port) {
-      requestUrl.port = '8020'
-    }
-
     let client = jayson.Client.http(requestUrl)
+
     if (cmd.apiKey !== undefined) {
       client.options.headers = { Authorization: 'Bearer ' + cmd.apiKey }
     }


### PR DESCRIPTION
The problem is: port 80 will result in no port being set and we don't
want to default to 8020 in that case. So it's probably best to just
assume no port means port 80 and use that.