### PR TITLE
Add `graph create` command to create named subgraphs

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -331,7 +331,7 @@ app
     if (subgraphName === undefined || cmd.node === undefined) {
       console.error('Cannot create the subgraph')
       console.error('--')
-      outputNameAndNodeConfig(cmd, { subgraphNameFromFlag: false, subgraphName })
+      outputNameAndNodeConfig(cmd, { subgraphName })
       console.error('--')
       console.error('For more information run this command with --help')
       process.exitCode = 1
@@ -376,7 +376,7 @@ app
     if (subgraphName === undefined || cmd.node === undefined) {
       console.error('Cannot remove the subgraph')
       console.error('--')
-      outputNameAndNodeConfig(cmd, { subgraphNameFromFlag: false, subgraphName })
+      outputNameAndNodeConfig(cmd, { subgraphName })
       console.error('--')
       console.error('For more information run this command with --help')
       process.exitCode = 1

--- a/graph.js
+++ b/graph.js
@@ -248,7 +248,7 @@ app
 app
   .command('deploy [SUBGRAPH_MANIFEST]')
   .description('Deploys the subgraph to a graph node')
-  .option('-g, --node <URL>[:PORT]', 'Graph node to deploy to')
+  .option('-g, --node <URL>', 'Graph node to deploy to')
   .option('-i, --ipfs <ADDR>', 'IPFS node to use for uploading files')
   .option('-n, --subgraph-name <NAME>', 'Subgraph name')
   .option('--access-token <TOKEN>', 'Graph access token')
@@ -340,7 +340,7 @@ app
 app
   .command('create [SUBGRAPH_NAME]')
   .description('Creates a named subgraph name')
-  .option('-g, --node <URL>[:PORT]', 'Graph node to create the subgraph in')
+  .option('-g, --node <URL>', 'Graph node to create the subgraph in')
   .option('--access-token <TOKEN>', 'Graph access token')
   .action(async (subgraphName, cmd) => {
     if (subgraphName === undefined || cmd.node === undefined) {
@@ -385,7 +385,7 @@ app
 app
   .command('remove [SUBGRAPH_NAME]')
   .description('Removes subgraph from node')
-  .option('-g, --node <URL>[:PORT]', 'Graph node to remove the subgraph from')
+  .option('-g, --node <URL>', 'Graph node to remove the subgraph from')
   .option('--access-token <TOKEN>', 'Graph access token')
   .action(async (subgraphName, cmd) => {
     if (subgraphName === undefined || cmd.node === undefined) {

--- a/graph.js
+++ b/graph.js
@@ -287,14 +287,14 @@ app
             logger.fatal('Error deploying the subgraph:', jsonRpcError.message)
           }
           if (!requestError && !jsonRpcError) {
-            logger.status('Deployed successfully.')
+            logger.status('Deployed successfully')
 
             // Assume that the host is the same.
             // In the future the deployment router should also return the host.
             let base = requestUrl.protocol + '//' + requestUrl.hostname
-            logger.status('Playground:         ', base + res.playground)
-            logger.status('Queries (HTTP):     ', base + res.queries)
-            logger.status('Subscriptions (WS): ', base + res.subscriptions)
+            logger.status('Playground:        ', base + res.playground)
+            logger.status('Queries (HTTP):    ', base + res.queries)
+            logger.status('Subscriptions (WS):', base + res.subscriptions)
           }
         }
       )

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -29,11 +29,7 @@ class Compiler {
   }
 
   displayPath(p) {
-    if (p.indexOf(this.sourceDir) >= 0) {
-      return p.replace(this.sourceDir, '<src>')
-    } else {
-      return path.relative(process.cwd(), p)
-    }
+    return path.relative(process.cwd(), p)
   }
 
   async compile() {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -63,6 +63,7 @@ class Compiler {
   completed(ipfsHashOrPath) {
     this.logger.status('Build completed')
     this.logger.status(chalk.bold(chalk.blue('Subgraph:')), ipfsHashOrPath)
+    this.logger.note('')
   }
 
   loadSubgraph() {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -7,7 +7,6 @@ const yaml = require('js-yaml')
 
 const Logger = require('./logger')
 const Subgraph = require('./subgraph')
-const TypeGenerator = require('./type-generator')
 const Watcher = require('./watcher')
 const ABI = require('./abi')
 
@@ -197,21 +196,12 @@ class Compiler {
         throw e
       }
 
-      let libs = path.join(baseDir, 'node_modules');
+      let libs = path.join(baseDir, 'node_modules')
       let global = path.join(libs, '@graphprotocol', 'graph-ts', 'global', 'global.ts')
       global = path.relative(baseDir, global)
 
       asc.main(
-        [
-          inputFile,
-          global,
-          '--baseDir',
-          baseDir,
-          '--lib',
-          libs,
-          '--outFile',
-          outputFile,
-        ],
+        [inputFile, global, '--baseDir', baseDir, '--lib', libs, '--outFile', outputFile],
         {
           stdout: process.stdout,
           stderr: process.stdout,

--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -17,9 +17,6 @@ module.exports = class TypeGenerator {
       prefix: this.options.logger.prefix,
       verbosity: this.options.logger.verbosity,
     })
-    this.displayPath = this.options.displayPath
-      ? this.options.displayPath
-      : s => path.relative(process.cwd(), s)
     this.sourceDir =
       this.options.sourceDir ||
       (this.options.subgraphManifest && path.dirname(this.options.subgraphManifest))
@@ -27,6 +24,10 @@ module.exports = class TypeGenerator {
     process.on('uncaughtException', function(e) {
       this.logger.error('UNCAUGHT EXCEPTION:', e)
     })
+  }
+
+  displayPath(p) {
+    return path.relative(process.cwd(), p)
   }
 
   generateTypes() {

--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -13,7 +13,7 @@ let Watcher = require('./watcher')
 module.exports = class TypeGenerator {
   constructor(options) {
     this.options = options || {}
-    this.logger = new Logger(3, {
+    this.logger = new Logger(5, {
       prefix: this.options.logger.prefix,
       verbosity: this.options.logger.verbosity,
     })
@@ -184,6 +184,9 @@ module.exports = class TypeGenerator {
 
       // Add the subgraph manifest file
       files.push(this.options.subgraphManifest)
+
+      // Add the GraphQL schema to the watched files
+      files.push(subgraph.getIn(['schema', 'file']))
 
       // Add all file paths specified in manifest
       subgraph.get('dataSources').map(dataSource => {

--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -45,6 +45,10 @@ module.exports = class TypeGenerator {
 
       let schema = this.loadSchema(subgraph)
       this.generateTypesForSchema(schema)
+
+      this.logger.status('Types generated')
+      this.logger.note('')
+
       return true
     } catch (e) {
       this.logger.error('Failed to generate types:', e)
@@ -103,8 +107,6 @@ module.exports = class TypeGenerator {
       return abis.map((abi, name) => this._generateTypesForABI(abi))
     } catch (e) {
       throw Error(`Failed to generate types for contract ABIs: ${e}`)
-    } finally {
-      this.logger.status('Types generated')
     }
   }
 


### PR DESCRIPTION
Resolves #189. Fixes #191. Fixes #181. Resolves #192.

This also changes the `graph remove` and `graph deploy` command. Together, all three commands now have the following signature:

```sh
graph create <SUBGRAPH_NAME> ... # -g/--node, --access-token are supported
graph remove <SUBGRAPH_NAME> ... # -g/--node, --access-token are supported
graph deploy <SUBGRAPH_NAME> ... # -g/--node, --access-token are supported
```