### PR TITLE
Make it harder to use unprefixed subgraph names, add advice to graph deploy errors

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -329,6 +329,8 @@ app
 
     let logger = new Logger(0, { verbosity: getVerbosity(app) })
 
+    let hostedService = cmd.node.match(/thegraph.com/)
+
     let compiler = createCompiler(
       app,
       cmd,
@@ -368,6 +370,18 @@ app
           }
           if (jsonRpcError) {
             logger.fatal('Error deploying the subgraph:', jsonRpcError.message)
+            if (hostedService) {
+              logger.info(
+                `
+You may need to created it at https://thegraph.com/explorer/dashboard`
+              )
+            } else {
+              logger.info(
+                `
+Make sure to create the subgraph first by running the following command:
+$ graph create --node ${cmd.node} ${subgraphName}`
+              )
+            }
           }
           if (!requestError && !jsonRpcError) {
             logger.status('Deployed successfully')
@@ -389,7 +403,6 @@ app
               subscriptions = base + subscriptions
             }
 
-            let hostedService = cmd.node.match(/thegraph.com/)
             if (hostedService) {
               logger.status(
                 `Live deployment:   `,

--- a/graph.js
+++ b/graph.js
@@ -376,7 +376,7 @@ app
               if (hostedService) {
                 logger.info(
                   `
-You may need to created it at https://thegraph.com/explorer/dashboard`
+You may need to created it at https://thegraph.com/explorer/dashboard.`
                 )
               } else {
                 logger.info(

--- a/graph.js
+++ b/graph.js
@@ -370,17 +370,21 @@ app
           }
           if (jsonRpcError) {
             logger.fatal('Error deploying the subgraph:', jsonRpcError.message)
-            if (hostedService) {
-              logger.info(
-                `
+
+            // Provide helpful advice when the subgraph has not been created yet
+            if (jsonRpcError.message.match(/subgraph name not found/)) {
+              if (hostedService) {
+                logger.info(
+                  `
 You may need to created it at https://thegraph.com/explorer/dashboard`
-              )
-            } else {
-              logger.info(
-                `
+                )
+              } else {
+                logger.info(
+                  `
 Make sure to create the subgraph first by running the following command:
 $ graph create --node ${cmd.node} ${subgraphName}`
-              )
+                )
+              }
             }
           }
           if (!requestError && !jsonRpcError) {

--- a/graph.js
+++ b/graph.js
@@ -556,7 +556,10 @@ app
     if (!cmd.allowSimpleName && subgraphName == path.basename(subgraphName)) {
       logger.fatal(
         `Subgraph name "${subgraphName}" needs to have the format "<PREFIX>/${subgraphName}".
-You can bypass this with --allow-simple-name.`
+When using the Hosted Service at https://thegraph.com, <PREFIX> is
+going to be the name of your user or organization account.
+
+You can bypass this check with --allow-simple-name.`
       )
       logger.info(`
 Examples:

--- a/graph.js
+++ b/graph.js
@@ -540,6 +540,7 @@ app
 app
   .command('init [SUBGRAPH_NAME] [DIRECTORY]')
   .description('Creates a new subgraph project with basic scaffolding')
+  .option('--allow-simple-name', 'Use a subgraph name without a prefix component', false)
   .action(async (subgraphName, directory, cmd) => {
     if (!directory || directory === '' || !subgraphName || subgraphName === '') {
       console.error('Cannot initialize new subgraph')
@@ -550,6 +551,17 @@ app
     }
 
     let logger = new Logger(0, { verbosity: getVerbosity(app) })
+
+    if (!cmd.allowSimpleName && subgraphName == path.basename(subgraphName)) {
+      logger.fatal(
+        `
+Subgraph name needs to have the format <PREFIX>/${subgraphName}.
+You can bypass this with --allow-simple-name.
+`
+      )
+      process.exitCode = 1
+      return
+    }
 
     if (fs.existsSync(directory)) {
       logger.fatal(`Directory or file "${directory}" already exists`)


### PR DESCRIPTION
Resolves #205 and #206.

## Running `graph init` with an unprefixed vs. prefixed subgraph name

![image](https://user-images.githubusercontent.com/19324/52717492-82ab1100-2fa1-11e9-979c-6cd525f59d7c.png)

## Running `graph deploy` for a non-existent subgraph

![image](https://user-images.githubusercontent.com/19324/52717675-ee8d7980-2fa1-11e9-8716-64a267ee0fb3.png)
