### PR TITLE
Reject entity fields with arguments as part of validation

### DIFF
--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -151,8 +151,10 @@ const validateInnerFieldType = (defs, def, field) => {
     ...BUILTIN_SCALAR_TYPES,
     ...defs
       .filter(
-        def => def.kind === 'ObjectTypeDefinition' || def.kind === 'EnumTypeDefinition' ||
-                def.kind  === 'InterfaceTypeDefinition'
+        def =>
+          def.kind === 'ObjectTypeDefinition' ||
+          def.kind === 'EnumTypeDefinition' ||
+          def.kind === 'InterfaceTypeDefinition'
       )
       .map(def => def.name.value)
   )
@@ -179,9 +181,25 @@ const validateEntityFieldType = (defs, def, field) =>
     ...validateInnerFieldType(defs, def, field)
   )
 
+const validateEntityFieldArguments = (defs, def, field) =>
+  field.arguments.length > 0
+    ? immutable.fromJS([
+        {
+          loc: field.loc,
+          entity: def.name.value,
+          message: `\
+Field '${field.name.value}': \
+Field arguments are not supported.`,
+        },
+      ])
+    : List()
+
 const validateEntityFields = (defs, def) =>
   def.fields.reduce(
-    (errors, field) => errors.concat(validateEntityFieldType(defs, def, field)),
+    (errors, field) =>
+      errors
+        .concat(validateEntityFieldType(defs, def, field))
+        .concat(validateEntityFieldArguments(defs, def, field)),
     List()
   )
 

--- a/tests/cli/validation.test.js
+++ b/tests/cli/validation.test.js
@@ -10,4 +10,5 @@ describe('Validation', () => {
     exitCode: 1,
   })
   cliTest('Invalid contract addresses', 'validation/invalid-contract-addresses')
+  cliTest('Entity field arguments', 'validation/entity-field-args', { exitCode: 1 })
 })

--- a/tests/cli/validation/entity-field-args.stderr
+++ b/tests/cli/validation/entity-field-args.stderr
@@ -1,0 +1,5 @@
+- Load subgraph from subgraph.yaml
+✖ Failed to load subgraph from subgraph.yaml: Failed to load subgraph: Error in schema.graphql:
+
+  MyEntity:
+  - Field 'foo': Field arguments are not supported.

--- a/tests/cli/validation/entity-field-args/Abi.json
+++ b/tests/cli/validation/entity-field-args/Abi.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "event",
+    "name": "ExampleEvent",
+    "inputs": [{ "type": "string" }]
+  }
+]

--- a/tests/cli/validation/entity-field-args/schema.graphql
+++ b/tests/cli/validation/entity-field-args/schema.graphql
@@ -1,0 +1,4 @@
+type MyEntity @entity {
+  id: ID!
+  foo(bar: Int!): Int!
+}

--- a/tests/cli/validation/entity-field-args/subgraph.yaml
+++ b/tests/cli/validation/entity-field-args/subgraph.yaml
@@ -1,0 +1,22 @@
+specVersion: 0.0.1
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: ExampleSubgraph
+    source:
+      address: '22843e74c59580b3eaf6c233fa67d8b7c561a835'
+      abi: ExampleContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.1
+      language: wasm/assemblyscript
+      file: ./mapping.ts
+      entities:
+        - ExampleEntity
+      abis:
+        - name: ExampleContract
+          file: ./Abi.json
+      eventHandlers:
+        - event: ExampleEvent(string)
+          handler: handleExampleEvent


### PR DESCRIPTION
Resolves #220 by adding a new validation step for entity fields. Includes a new CLI test that shows it works.