### PR TITLE
Add support for printing warnings and use in subgraph validation

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "trailingComma": "all",
+  "printWidth": 90,
+  "singleQuote": true
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "jest": "^24.3.0",
     "spawn-command": "^0.0.2-1",
-    "strip-ansi": "^5.0.0"
+    "strip-ansi": "^5.1.0"
   },
   "scripts": {
     "test": "jest --verbose"

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -155,7 +155,7 @@ const loadAbiFromEtherscan = async (network, address) =>
   await withSpinner(
     `Fetching ABI from Etherscan`,
     `Failed to fetch ABI from Etherscan`,
-    `Warnings fetching ABI from Etherscan`,
+    `Warnings while fetching ABI from Etherscan`,
     async spinner => {
       let result = await fetch(
         `https://${

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -155,6 +155,7 @@ const loadAbiFromEtherscan = async (network, address) =>
   await withSpinner(
     `Fetching ABI from Etherscan`,
     `Failed to fetch ABI from Etherscan`,
+    `Warnings fetching ABI from Etherscan`,
     async spinner => {
       let result = await fetch(
         `https://${
@@ -332,6 +333,7 @@ const initRepository = async (toolbox, directory) =>
   await withSpinner(
     `Initialize subgraph repository`,
     `Failed to initialize subgraph repository`,
+    `Warnings while initializing subgraph repository`,
     async spinner => {
       // Remove .git dir in --from-example mode; in --from-contract, we're
       // starting from an empty directory
@@ -352,6 +354,7 @@ const installDependencies = async (toolbox, directory, installCommand) =>
   await withSpinner(
     `Install dependencies with ${toolbox.print.colors.muted(installCommand)}`,
     `Failed to install dependencies`,
+    `Warnings while installing dependencies`,
     async spinner => {
       await toolbox.system.run(installCommand, { cwd: directory })
       return true
@@ -361,7 +364,8 @@ const installDependencies = async (toolbox, directory, installCommand) =>
 const runCodegen = async (toolbox, directory, codegenCommand) =>
   await withSpinner(
     `Generate ABI and schema types with ${toolbox.print.colors.muted(codegenCommand)}`,
-    `Failed to generatecode from ABI and GraphQL schema`,
+    `Failed to generate code from ABI and GraphQL schema`,
+    `Warnings while generating code from ABI and GraphQL schema`,
     async spinner => {
       await toolbox.system.run(codegenCommand, { cwd: directory })
       return true
@@ -419,6 +423,7 @@ const initSubgraphFromExample = async (
   let cloned = await withSpinner(
     `Cloning example subgraph`,
     `Failed to clone example subgraph`,
+    `Warnings while cloning example subgraph`,
     async spinner => {
       await system.run(
         `git clone http://github.com/graphprotocol/example-subgraph ${directory}`
@@ -435,6 +440,7 @@ const initSubgraphFromExample = async (
   let prepared = await withSpinner(
     `Update subgraph name and commands in package.json`,
     `Failed to update subgraph name and commands in package.json`,
+    `Warnings while updating subgraph name and commands in package.json`,
     async spinner => {
       try {
         // Load package.json
@@ -518,6 +524,7 @@ const initSubgraphFromContract = async (
   let scaffold = await withSpinner(
     `Create subgraph scaffold`,
     `Failed to create subgraph scaffold`,
+    `Warnings while creating subgraph scaffold`,
     async spinner => {
       let scaffold = await generateScaffold(
         {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -6,7 +6,7 @@ const path = require('path')
 const yaml = require('js-yaml')
 const toolbox = require('gluegun/toolbox')
 
-const { withSpinner, step } = require('./command-helpers/spinner')
+const { step, withSpinner } = require('./command-helpers/spinner')
 const Subgraph = require('./subgraph')
 const Watcher = require('./watcher')
 const ABI = require('./abi')
@@ -62,6 +62,7 @@ class Compiler {
       return await withSpinner(
         `Load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
         `Failed to load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
+        `Loaded subgraph from ${this.displayPath(this.options.subgraphManifest)} with warnings`,
         async spinner => {
           return Subgraph.load(this.options.subgraphManifest)
         }
@@ -155,6 +156,7 @@ class Compiler {
     return await withSpinner(
       `Compile subgraph`,
       `Failed to compile subgraph`,
+      null,
       async spinner => {
         subgraph = subgraph.update('dataSources', dataSources =>
           dataSources.map(dataSource =>
@@ -227,6 +229,7 @@ class Compiler {
       `Failed to write compiled subgraph to ${`${this.displayPath(
         this.options.outputDir
       )}${toolbox.filesystem.separator}`}`,
+      null,
       async spinner => {
         // Copy schema and update its path
         subgraph = subgraph.updateIn(['schema', 'file'], schemaFile =>
@@ -284,6 +287,7 @@ class Compiler {
     return withSpinner(
       `Upload subgraph to IPFS`,
       `Failed to upload subgraph to IPFS`,
+      null,
       async spinner => {
         // Collect all source (path -> hash) updates to apply them later
         let updates = []

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -59,12 +59,12 @@ class Compiler {
     if (quiet) {
       return Subgraph.load(this.options.subgraphManifest)
     } else {
+      const manifestPath = this.displayPath(this.options.subgraphManifest)
+
       return await withSpinner(
-        `Load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
-        `Failed to load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
-        `Warnings loading subgraph from ${this.displayPath(
-          this.options.subgraphManifest,
-        )}`,
+        `Load subgraph from ${manifestPath}`,
+        `Failed to load subgraph from ${manifestPath}`,
+        `Warnings loading subgraph from ${manifestPath}`,
         async spinner => {
           return Subgraph.load(this.options.subgraphManifest)
         },
@@ -158,7 +158,7 @@ class Compiler {
     return await withSpinner(
       `Compile subgraph`,
       `Failed to compile subgraph`,
-      null,
+      `Warnings while compiling subgraph`,
       async spinner => {
         subgraph = subgraph.update('dataSources', dataSources =>
           dataSources.map(dataSource =>
@@ -224,14 +224,14 @@ class Compiler {
   }
 
   async writeSubgraphToOutputDirectory(subgraph) {
+    const displayDir = `${this.displayPath(this.options.outputDir)}/${
+      tolbox.filesystem.separator
+    }`
+
     return await withSpinner(
-      `Write compiled subgraph to ${`${this.displayPath(this.options.outputDir)}${
-        toolbox.filesystem.separator
-      }`}`,
-      `Failed to write compiled subgraph to ${`${this.displayPath(
-        this.options.outputDir,
-      )}${toolbox.filesystem.separator}`}`,
-      null,
+      `Write compiled subgraph to ${displayDir}`,
+      `Failed to write compiled subgraph to ${displayDir}`,
+      `Warnings while writing compiled subgraph to ${displayDir}`,
       async spinner => {
         // Copy schema and update its path
         subgraph = subgraph.updateIn(['schema', 'file'], schemaFile =>
@@ -289,7 +289,7 @@ class Compiler {
     return withSpinner(
       `Upload subgraph to IPFS`,
       `Failed to upload subgraph to IPFS`,
-      null,
+      `Warnings while uploading subgraph to IPFS`,
       async spinner => {
         // Collect all source (path -> hash) updates to apply them later
         let updates = []

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -225,7 +225,7 @@ class Compiler {
 
   async writeSubgraphToOutputDirectory(subgraph) {
     const displayDir = `${this.displayPath(this.options.outputDir)}/${
-      tolbox.filesystem.separator
+      toolbox.filesystem.separator
     }`
 
     return await withSpinner(

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -60,11 +60,9 @@ class Compiler {
       return Subgraph.load(this.options.subgraphManifest)
     } else {
       return await withSpinner(
-        `Load subgraph manifest ${this.displayPath(this.options.subgraphManifest)}`,
-        `Failed to load subgraph manifest ${this.displayPath(
-          this.options.subgraphManifest,
-        )}`,
-        `Warnings loading subgraph manifest ${this.displayPath(
+        `Load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
+        `Failed to load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
+        `Warnings loading subgraph from ${this.displayPath(
           this.options.subgraphManifest,
         )}`,
         async spinner => {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -60,12 +60,16 @@ class Compiler {
       return Subgraph.load(this.options.subgraphManifest)
     } else {
       return await withSpinner(
-        `Load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
-        `Failed to load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
-        `Loaded subgraph from ${this.displayPath(this.options.subgraphManifest)} with warnings`,
+        `Load subgraph manifest ${this.displayPath(this.options.subgraphManifest)}`,
+        `Failed to load subgraph manifest ${this.displayPath(
+          this.options.subgraphManifest,
+        )}`,
+        `Warnings loading subgraph manifest ${this.displayPath(
+          this.options.subgraphManifest,
+        )}`,
         async spinner => {
           return Subgraph.load(this.options.subgraphManifest)
-        }
+        },
       )
     }
   }

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -165,13 +165,13 @@ class Compiler {
         subgraph = subgraph.update('dataSources', dataSources =>
           dataSources.map(dataSource =>
             dataSource.updateIn(['mapping', 'file'], mappingPath =>
-              this._compileDataSourceMapping(dataSource, mappingPath, spinner)
-            )
-          )
+              this._compileDataSourceMapping(dataSource, mappingPath, spinner),
+            ),
+          ),
         )
 
         return subgraph
-      }
+      },
     )
   }
 
@@ -183,13 +183,13 @@ class Compiler {
         this.subgraphDir(this.options.outputDir, dataSource),
         this.options.outputFormat == 'wasm'
           ? `${dataSourceName}.wasm`
-          : `${dataSourceName}.wast`
+          : `${dataSourceName}.wast`,
       )
 
       step(
         spinner,
         'Compile data source:',
-        `${dataSourceName} => ${this.displayPath(outFile)}`
+        `${dataSourceName} => ${this.displayPath(outFile)}`,
       )
 
       let baseDir = this.sourceDir
@@ -217,7 +217,7 @@ class Compiler {
           if (e != null) {
             throw e
           }
-        }
+        },
       )
       return outputFile
     } catch (e) {
@@ -231,7 +231,7 @@ class Compiler {
         toolbox.filesystem.separator
       }`}`,
       `Failed to write compiled subgraph to ${`${this.displayPath(
-        this.options.outputDir
+        this.options.outputDir,
       )}${toolbox.filesystem.separator}`}`,
       null,
       async spinner => {
@@ -243,9 +243,9 @@ class Compiler {
               schemaFile,
               this.sourceDir,
               this.options.outputDir,
-              spinner
-            )
-          )
+              spinner,
+            ),
+          ),
         )
 
         // Copy data source files and update their paths
@@ -263,17 +263,17 @@ class Compiler {
                         JSON.stringify(abiData.data.toJS(), null, 2),
                         this.sourceDir,
                         this.subgraphDir(this.options.outputDir, dataSource),
-                        spinner
-                      )
+                        spinner,
+                      ),
                     )
-                  })
-                )
+                  }),
+                ),
               )
               // The mapping file is already being written to the output
               // directory by the AssemblyScript compiler
               .updateIn(['mapping', 'file'], mappingFile =>
-                path.relative(this.options.outputDir, mappingFile)
-              )
+                path.relative(this.options.outputDir, mappingFile),
+              ),
           )
         })
 
@@ -283,7 +283,7 @@ class Compiler {
         Subgraph.write(subgraph, outputFilename)
 
         return subgraph
-      }
+      },
     )
   }
 
@@ -301,7 +301,7 @@ class Compiler {
           keyPath: ['schema', 'file'],
           value: await this._uploadFileToIPFS(
             subgraph.getIn(['schema', 'file']),
-            spinner
+            spinner,
           ),
         })
 
@@ -321,7 +321,7 @@ class Compiler {
             keyPath: ['dataSources', i, 'mapping', 'file'],
             value: await this._uploadFileToIPFS(
               dataSource.getIn(['mapping', 'file']),
-              spinner
+              spinner,
             ),
           })
         }
@@ -333,7 +333,7 @@ class Compiler {
 
         // Upload the subgraph itself
         return await this._uploadSubgraphDefinitionToIPFS(subgraph, spinner)
-      }
+      },
     )
   }
 

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -221,30 +221,24 @@ ${abiEvents
   }
 
   static validateRepository(manifest, { resolveFile }) {
-    let warnings = immutable.List()
-    if (manifest.get('repository') === 'https://github.com/rodventures/gravity-subgraph') {
-      return warnings.push(immutable.fromJS({
+    return manifest.get('repository') !== 'https://github.com/rodventures/gravity-subgraph'
+      ? immutable.List()
+      : immutable.List().push(immutable.fromJS({
           path: ['repository'],
           message: `\
   The subgraph manifest is still referencing the example repository at https://github.com/rodventures/gravity-subgraph.
-  Please replace it with your repository location or leave blank if you prefer to keep it private.`,
+    Please replace it with your repository location or leave blank if you prefer to keep it private.`,
         }))
-    } else {
-      return warnings
-    }
   }
 
   static validateDescription(manifest, { resolveFile }) {
-    let warnings = immutable.List()
-    if (manifest.get('description') === 'Gravatar for Ethereum') {
-      return warnings.push(immutable.fromJS({
+    return manifest.get('description') !== 'Gravatar for Ethereum'
+    ? immutable.List()
+    : immutable.List().push(immutable.fromJS({
           path: ['description'],
           message: `\
   Example subgraph description remains. Please update to provide a short description of what your subgraph is.`,
         }))
-    } else {
-      return immutable.List()
-    }
   }
 
   static load(filename) {

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -34,7 +34,7 @@ const buildCombinedWarning = (filename, warnings) =>
       .get('message')
       .split('\n')
       .join('\n    ')}`,
-        `Warning in ${path.relative(process.cwd(), filename)}:`,
+        `Warnings in ${path.relative(process.cwd(), filename)}:`,
       )
     : null
 

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -33,7 +33,7 @@ const buildCombinedWarning = (filename, warnings) =>
     ${w
       .get('message')
       .split('\n')
-      .join('\n  ')}`,
+      .join('\n    ')}`,
         `Warning in ${path.relative(process.cwd(), filename)}:`,
       )
     : null
@@ -226,8 +226,8 @@ ${abiEvents
           immutable.fromJS({
             path: ['repository'],
             message: `\
-  The subgraph manifest is still referencing the example repository at https://github.com/rodventures/gravity-subgraph.
-    Please replace it with your repository location or leave blank if you prefer to keep it private.`,
+The repository is still set to https://github.com/graphprotocol/example-subgraph.
+Please replace it with a link to your subgraph source code.`,
           }),
         )
   }
@@ -239,7 +239,8 @@ ${abiEvents
           immutable.fromJS({
             path: ['description'],
             message: `\
-  Example subgraph description remains. Please update to provide a short description of what your subgraph is.`,
+The description is still the one from the example subgraph.
+Please update it to tell users more about your subgraph.`,
           }),
         )
   }
@@ -271,8 +272,8 @@ ${abiEvents
 
     // Perform warning validations
     let warnings = immutable.List.of(
-      ...Subgraph.validateDescription(manifest, { resolveFile }),
       ...Subgraph.validateRepository(manifest, { resolveFile }),
+      ...Subgraph.validateDescription(manifest, { resolveFile }),
     )
 
     if (errors.size > 0) {

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -23,22 +23,20 @@ const throwCombinedError = (filename, errors) => {
   )
 }
 
-const buildCombinedWarning = (filename, warnings) => {
-  return (warnings.size > 0)
-    ?
-      warnings.reduce(
+const buildCombinedWarning = (filename, warnings) =>
+  warnings.size > 0
+    ? warnings.reduce(
         (msg, w) =>
           `${msg}
   
     Path: ${w.get('path').size === 0 ? '/' : w.get('path').join(' > ')}
     ${w
-            .get('message')
-            .split('\n')
-            .join('\n  ')}`,
-        `Warning in ${path.relative(process.cwd(), filename)}:`
+      .get('message')
+      .split('\n')
+      .join('\n  ')}`,
+        `Warning in ${path.relative(process.cwd(), filename)}:`,
       )
     : null
-}
 
 module.exports = class Subgraph {
   static validate(data, { resolveFile }) {
@@ -275,10 +273,11 @@ ${abiEvents
     if (errors.size > 0) {
       throwCombinedError(filename, errors)
     }
-    return immutable.Map({
+
+    return {
       result: manifest,
-      warning: buildCombinedWarning(filename, warnings)
-    })
+      warning: buildCombinedWarning(filename, warnings) + `\n`,
+    }
   }
 
   static write(subgraph, filename) {

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -18,8 +18,8 @@ const throwCombinedError = (filename, errors) => {
     .get('message')
     .split('\n')
     .join('\n  ')}`,
-      `Error in ${path.relative(process.cwd(), filename)}:`
-    )
+      `Error in ${path.relative(process.cwd(), filename)}:`,
+    ),
   )
 }
 
@@ -42,7 +42,7 @@ module.exports = class Subgraph {
   static validate(data, { resolveFile }) {
     // Parse the default subgraph schema
     let schema = graphql.parse(
-      fs.readFileSync(path.join(__dirname, '..', 'manifest-schema.graphql'), 'utf-8')
+      fs.readFileSync(path.join(__dirname, '..', 'manifest-schema.graphql'), 'utf-8'),
     )
 
     // Obtain the root `SubgraphManifest` type from the schema
@@ -71,11 +71,11 @@ module.exports = class Subgraph {
       error
         .get('message')
         .split('\n')
-        .join('\n    ')
+        .join('\n    '),
     )
     .map(msg => `- ${msg}`)
     .join('\n  ')}`,
-        `Error in ${path.relative(process.cwd(), filename)}:`
+        `Error in ${path.relative(process.cwd(), filename)}:`,
       )
 
       throw new Error(msg)
@@ -105,7 +105,7 @@ ${abiNames
                 .sort()
                 .map(name => `- ${name}`)
                 .join('\n')}`,
-            })
+            }),
           )
         }
       }, immutable.List())
@@ -132,11 +132,11 @@ ${abiNames
                     'file',
                   ],
                   message: e.message,
-                })
+                }),
               )
             }
           }, errors),
-        immutable.List()
+        immutable.List(),
       )
 
     return immutable.List.of(...abiReferenceErrors, ...abiFileErrors)
@@ -161,7 +161,7 @@ ${abiNames
               message: `\
 Contract address is invalid: ${address}
 Must be 40 hexadecimal characters, with an optional '0x' prefix.`,
-            })
+            }),
           )
         }
       }, immutable.List())
@@ -206,9 +206,9 @@ ${abiEvents
                         .sort()
                         .map(event => `- ${event}`)
                         .join('\n')}`,
-                    })
+                    }),
                   ),
-            errors
+            errors,
           )
         } catch (e) {
           // Ignore errors silently; we can't really say anything about
@@ -219,24 +219,29 @@ ${abiEvents
   }
 
   static validateRepository(manifest, { resolveFile }) {
-    return manifest.get('repository') !== 'https://github.com/rodventures/gravity-subgraph'
+    return manifest.get('repository') !==
+      'https://github.com/rodventures/gravity-subgraph'
       ? immutable.List()
-      : immutable.List().push(immutable.fromJS({
-          path: ['repository'],
-          message: `\
+      : immutable.List().push(
+          immutable.fromJS({
+            path: ['repository'],
+            message: `\
   The subgraph manifest is still referencing the example repository at https://github.com/rodventures/gravity-subgraph.
     Please replace it with your repository location or leave blank if you prefer to keep it private.`,
-        }))
+          }),
+        )
   }
 
   static validateDescription(manifest, { resolveFile }) {
     return manifest.get('description') !== 'Gravatar for Ethereum'
-    ? immutable.List()
-    : immutable.List().push(immutable.fromJS({
-          path: ['description'],
-          message: `\
+      ? immutable.List()
+      : immutable.List().push(
+          immutable.fromJS({
+            path: ['description'],
+            message: `\
   Example subgraph description remains. Please update to provide a short description of what your subgraph is.`,
-        }))
+          }),
+        )
   }
 
   static load(filename) {
@@ -267,7 +272,7 @@ ${abiEvents
     // Perform warning validations
     let warnings = immutable.List.of(
       ...Subgraph.validateDescription(manifest, { resolveFile }),
-      ...Subgraph.validateRepository(manifest, { resolveFile })
+      ...Subgraph.validateRepository(manifest, { resolveFile }),
     )
 
     if (errors.size > 0) {

--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -51,6 +51,7 @@ module.exports = class TypeGenerator {
       return await withSpinner(
         `Load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
         `Failed to load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
+        `Loaded subgraph from ${this.displayPath(this.options.subgraphManifest)} with warnings`,
         async spinner => {
           try {
             return this.options.subgraph
@@ -68,6 +69,7 @@ module.exports = class TypeGenerator {
     return await withSpinner(
       'Load contract ABIs',
       'Failed to load contract ABIs',
+      null,
       async spinner => {
         try {
           return subgraph
@@ -115,6 +117,7 @@ module.exports = class TypeGenerator {
     return withSpinner(
       `Generate types for contract ABIs`,
       `Failed to generate types for contract ABIs`,
+      null,
       async spinner => {
         return await abis.map(
           async (abi, name) => await this._generateTypesForABI(abi, spinner)
@@ -160,6 +163,7 @@ module.exports = class TypeGenerator {
     return await withSpinner(
       `Load GraphQL schema from ${this.displayPath(absolutePath)}`,
       `Failed to load GraphQL schema from ${this.displayPath(absolutePath)}`,
+      null,
       async spinner => {
         let maybeRelativePath = subgraph.getIn(['schema', 'file'])
         let absolutePath = path.resolve(this.sourceDir, maybeRelativePath)
@@ -172,6 +176,7 @@ module.exports = class TypeGenerator {
     return await withSpinner(
       `Generate types for GraphQL schema`,
       `Failed to generate types for GraphQL schema`,
+      null,
       async spinner => {
         // Generate TypeScript module from schema
         let codeGenerator = schema.codeGenerator()

--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -49,18 +49,18 @@ module.exports = class TypeGenerator {
         : Subgraph.load(this.options.subgraphManifest)
     } else {
       return await withSpinner(
-        `Load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
-        `Failed to load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
-        `Loaded subgraph from ${this.displayPath(this.options.subgraphManifest)} with warnings`,
+        `Load subgraph manifest ${this.displayPath(this.options.subgraphManifest)}`,
+        `Failed to load subgraph manifest ${this.displayPath(
+          this.options.subgraphManifest,
+        )}`,
+        `Warnings loading subgraph manifest ${this.displayPath(
+          this.options.subgraphManifest,
+        )}`,
         async spinner => {
-          try {
-            return this.options.subgraph
-              ? this.options.subgraph
-              : Subgraph.load(this.options.subgraphManifest)
-          } catch (e) {
-            throw Error(`Failed to load subgraph: ${e.message}`)
-          }
-        }
+          return this.options.subgraph
+            ? this.options.subgraph
+            : Subgraph.load(this.options.subgraphManifest)
+        },
       )
     }
   }

--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -53,7 +53,7 @@ module.exports = class TypeGenerator {
       return await withSpinner(
         `Load subgraph from ${manifestPath}`,
         `Failed to load subgraph from ${manifestPath}`,
-        `Warnings loading subgraph from ${manifestPath}`,
+        `Warnings while loading subgraph from ${manifestPath}`,
         async spinner => {
           return this.options.subgraph
             ? this.options.subgraph

--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -85,17 +85,17 @@ module.exports = class TypeGenerator {
                           dataSource,
                           abi.get('name'),
                           abi.get('file'),
-                          spinner
-                        )
+                          spinner,
+                        ),
                       ),
-                    abis
+                    abis,
                   ),
-              immutable.List()
+              immutable.List(),
             )
         } catch (e) {
           throw Error(`Failed to load contract ABIs: ${e.message}`)
         }
-      }
+      },
     )
   }
 
@@ -120,9 +120,9 @@ module.exports = class TypeGenerator {
       null,
       async spinner => {
         return await abis.map(
-          async (abi, name) => await this._generateTypesForABI(abi, spinner)
+          async (abi, name) => await this._generateTypesForABI(abi, spinner),
         )
-      }
+      },
     )
   }
 
@@ -131,23 +131,23 @@ module.exports = class TypeGenerator {
       step(
         spinner,
         `Generate types for contract ABI:`,
-        `${abi.abi.name} (${this.displayPath(abi.abi.file)})`
+        `${abi.abi.name} (${this.displayPath(abi.abi.file)})`,
       )
 
       let codeGenerator = abi.abi.codeGenerator()
       let code = prettier.format(
         [...codeGenerator.generateModuleImports(), ...codeGenerator.generateTypes()].join(
-          '\n'
+          '\n',
         ),
         {
           parser: 'typescript',
-        }
+        },
       )
 
       let outputFile = path.join(
         this.options.outputDir,
         abi.dataSource.get('name'),
-        `${abi.abi.name}.ts`
+        `${abi.abi.name}.ts`,
       )
       step(spinner, `Write types to`, this.displayPath(outputFile))
       fs.mkdirsSync(path.dirname(outputFile))
@@ -168,7 +168,7 @@ module.exports = class TypeGenerator {
         let maybeRelativePath = subgraph.getIn(['schema', 'file'])
         let absolutePath = path.resolve(this.sourceDir, maybeRelativePath)
         return Schema.load(absolutePath)
-      }
+      },
     )
   }
 
@@ -187,14 +187,14 @@ module.exports = class TypeGenerator {
           ].join('\n'),
           {
             parser: 'typescript',
-          }
+          },
         )
 
         let outputFile = path.join(this.options.outputDir, 'schema.ts')
         step(spinner, 'Write types to', this.displayPath(outputFile))
         fs.mkdirsSync(path.dirname(outputFile))
         fs.writeFileSync(outputFile, code)
-      }
+      },
     )
   }
 

--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -48,12 +48,12 @@ module.exports = class TypeGenerator {
         ? this.options.subgraph
         : Subgraph.load(this.options.subgraphManifest)
     } else {
+      const manifestPath = this.displayPath(this.options.subgraphManifest)
+
       return await withSpinner(
-        `Load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
-        `Failed to load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
-        `Warnings loading subgraph from ${this.displayPath(
-          this.options.subgraphManifest,
-        )}`,
+        `Load subgraph from ${manifestPath}`,
+        `Failed to load subgraph from ${manifestPath}`,
+        `Warnings loading subgraph from ${manifestPath}`,
         async spinner => {
           return this.options.subgraph
             ? this.options.subgraph
@@ -67,7 +67,7 @@ module.exports = class TypeGenerator {
     return await withSpinner(
       'Load contract ABIs',
       'Failed to load contract ABIs',
-      null,
+      `Warnings while loading contract ABIs`,
       async spinner => {
         try {
           return subgraph
@@ -115,7 +115,7 @@ module.exports = class TypeGenerator {
     return withSpinner(
       `Generate types for contract ABIs`,
       `Failed to generate types for contract ABIs`,
-      null,
+      `Warnings while generating types for contract ABIs`,
       async spinner => {
         return await abis.map(
           async (abi, name) => await this._generateTypesForABI(abi, spinner),
@@ -161,7 +161,7 @@ module.exports = class TypeGenerator {
     return await withSpinner(
       `Load GraphQL schema from ${this.displayPath(absolutePath)}`,
       `Failed to load GraphQL schema from ${this.displayPath(absolutePath)}`,
-      null,
+      `Warnings while loading GraphQL schema from ${this.displayPath(absolutePath)}`,
       async spinner => {
         let maybeRelativePath = subgraph.getIn(['schema', 'file'])
         let absolutePath = path.resolve(this.sourceDir, maybeRelativePath)
@@ -174,7 +174,7 @@ module.exports = class TypeGenerator {
     return await withSpinner(
       `Generate types for GraphQL schema`,
       `Failed to generate types for GraphQL schema`,
-      null,
+      `Warnings while generating types for GraphQL schema`,
       async spinner => {
         // Generate TypeScript module from schema
         let codeGenerator = schema.codeGenerator()

--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -49,11 +49,9 @@ module.exports = class TypeGenerator {
         : Subgraph.load(this.options.subgraphManifest)
     } else {
       return await withSpinner(
-        `Load subgraph manifest ${this.displayPath(this.options.subgraphManifest)}`,
-        `Failed to load subgraph manifest ${this.displayPath(
-          this.options.subgraphManifest,
-        )}`,
-        `Warnings loading subgraph manifest ${this.displayPath(
+        `Load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
+        `Failed to load subgraph from ${this.displayPath(this.options.subgraphManifest)}`,
+        `Warnings loading subgraph from ${this.displayPath(
           this.options.subgraphManifest,
         )}`,
         async spinner => {

--- a/tests/cli/util.js
+++ b/tests/cli/util.js
@@ -1,7 +1,7 @@
+const fs = require('fs')
 const path = require('path')
 const spawn = require('spawn-command')
 const stripAnsi = require('strip-ansi')
-const fs = require('fs')
 
 const cliTest = (title, args, testPath, options) => {
   test(
@@ -40,7 +40,7 @@ const cliTest = (title, args, testPath, options) => {
         expect(stripAnsi(stderr)).toBe(expectedStderr)
       }
     },
-    (options !== undefined && options.timeout) || undefined
+    (options !== undefined && options.timeout) || undefined,
   )
 }
 

--- a/tests/cli/validation.test.js
+++ b/tests/cli/validation.test.js
@@ -34,6 +34,6 @@ describe('Validation', () => {
     'Example values found in manifest',
     ['codegen'],
     'validation/example-values-found',
-    { exitCode: 1 }
+    { exitCode: 0 }
   )
 })

--- a/tests/cli/validation.test.js
+++ b/tests/cli/validation.test.js
@@ -30,4 +30,10 @@ describe('Validation', () => {
   cliTest('Entity field arguments', ['codegen'], 'validation/entity-field-args', {
     exitCode: 1,
   })
+  cliTest(
+    'Example values found in manifest',
+    ['codegen'],
+    'validation/example-values-found',
+    { exitCode: 1 }
+  )
 })

--- a/tests/cli/validation/abi-not-found.stderr
+++ b/tests/cli/validation/abi-not-found.stderr
@@ -1,5 +1,5 @@
 - Load subgraph from subgraph.yaml
-✖ Failed to load subgraph from subgraph.yaml: Failed to load subgraph: Error in subgraph.yaml:
+✖ Failed to load subgraph from subgraph.yaml: Error in subgraph.yaml:
 
   Path: dataSources > 0 > source > abi
   ABI name 'NonExistentAbi' not found in mapping > abis.

--- a/tests/cli/validation/entity-field-args.stderr
+++ b/tests/cli/validation/entity-field-args.stderr
@@ -1,5 +1,5 @@
 - Load subgraph from subgraph.yaml
-✖ Failed to load subgraph from subgraph.yaml: Failed to load subgraph: Error in schema.graphql:
+✖ Failed to load subgraph from subgraph.yaml: Error in schema.graphql:
 
   MyEntity:
   - Field 'foo': Field arguments are not supported.

--- a/tests/cli/validation/event-not-found.stderr
+++ b/tests/cli/validation/event-not-found.stderr
@@ -1,5 +1,5 @@
 - Load subgraph from subgraph.yaml
-✖ Failed to load subgraph from subgraph.yaml: Failed to load subgraph: Error in subgraph.yaml:
+✖ Failed to load subgraph from subgraph.yaml: Error in subgraph.yaml:
 
   Path: dataSources > 0 > eventHandlers > 0
   Event with signature 'ExampleEvent(string,uint256)' not present in ABI 'ExampleContract'.

--- a/tests/cli/validation/example-values-found.stderr
+++ b/tests/cli/validation/example-values-found.stderr
@@ -1,0 +1,9 @@
+- Load subgraph from subgraph.yaml
+✖ Failed to load subgraph from subgraph.yaml: Failed to load subgraph: Error in subgraph.yaml:
+
+  Path: repository
+    The subgraph manifest is still referencing the example repository at https://github.com/rodventures/gravity-subgraph.
+    Please replace it with your repository location or leave blank if you prefer to keep it private.
+
+  Path: description
+    Example subgraph description remains. Please update to provide a short description of what your subgraph is.

--- a/tests/cli/validation/example-values-found.stderr
+++ b/tests/cli/validation/example-values-found.stderr
@@ -1,25 +1,28 @@
 - Load subgraph from subgraph.yaml
-⚠️ Loaded subgraph from subgraph.yaml with warnings: Warning in subgraph.yaml:
-  
-    Path: description
-      Example subgraph description remains. Please update to provide a short description of what your subgraph is.
+⚠ Warnings loading subgraph from subgraph.yaml: Warning in subgraph.yaml:
   
     Path: repository
-      The subgraph manifest is still referencing the example repository at https://github.com/rodventures/gravity-subgraph.
-      Please replace it with your repository location or leave blank if you prefer to keep it private.
+    The repository is still set to https://github.com/graphprotocol/example-subgraph.
+    Please replace it with a link to your subgraph source code.
+  
+    Path: description
+    The description is still the one from the example subgraph.
+    Please update it to tell users more about your subgraph.
+
+✔ Load subgraph from subgraph.yaml
 - Load contract ABIs
-  [90mLoad contract ABI from Abi.json[39m
+  Load contract ABI from Abi.json
 - Load contract ABIs
 ✔ Load contract ABIs
 - Generate types for contract ABIs
-  [90mGenerate types for contract ABI: ExampleContract (Abi.json)[39m
+  Generate types for contract ABI: ExampleContract (Abi.json)
 - Generate types for contract ABIs
-  [90mWrite types to generated/ExampleSubgraph/ExampleContract.ts[39m
+  Write types to generated/ExampleSubgraph/ExampleContract.ts
 - Generate types for contract ABIs
 ✔ Generate types for contract ABIs
 - Load GraphQL schema from schema.graphql
 ✔ Load GraphQL schema from schema.graphql
 - Generate types for GraphQL schema
-  [90mWrite types to generated/schema.ts[39m
+  Write types to generated/schema.ts
 - Generate types for GraphQL schema
 ✔ Generate types for GraphQL schema

--- a/tests/cli/validation/example-values-found.stderr
+++ b/tests/cli/validation/example-values-found.stderr
@@ -1,5 +1,5 @@
 - Load subgraph from subgraph.yaml
-⚠ Warnings loading subgraph from subgraph.yaml: Warnings in subgraph.yaml:
+⚠ Warnings while loading subgraph from subgraph.yaml: Warnings in subgraph.yaml:
   
     Path: repository
     The repository is still set to https://github.com/graphprotocol/example-subgraph.

--- a/tests/cli/validation/example-values-found.stderr
+++ b/tests/cli/validation/example-values-found.stderr
@@ -1,9 +1,25 @@
 - Load subgraph from subgraph.yaml
-✖ Failed to load subgraph from subgraph.yaml: Failed to load subgraph: Error in subgraph.yaml:
-
-  Path: repository
-    The subgraph manifest is still referencing the example repository at https://github.com/rodventures/gravity-subgraph.
-    Please replace it with your repository location or leave blank if you prefer to keep it private.
-
-  Path: description
-    Example subgraph description remains. Please update to provide a short description of what your subgraph is.
+⚠️ Loaded subgraph from subgraph.yaml with warnings: Warning in subgraph.yaml:
+  
+    Path: description
+      Example subgraph description remains. Please update to provide a short description of what your subgraph is.
+  
+    Path: repository
+      The subgraph manifest is still referencing the example repository at https://github.com/rodventures/gravity-subgraph.
+      Please replace it with your repository location or leave blank if you prefer to keep it private.
+- Load contract ABIs
+  [90mLoad contract ABI from Abi.json[39m
+- Load contract ABIs
+✔ Load contract ABIs
+- Generate types for contract ABIs
+  [90mGenerate types for contract ABI: ExampleContract (Abi.json)[39m
+- Generate types for contract ABIs
+  [90mWrite types to generated/ExampleSubgraph/ExampleContract.ts[39m
+- Generate types for contract ABIs
+✔ Generate types for contract ABIs
+- Load GraphQL schema from schema.graphql
+✔ Load GraphQL schema from schema.graphql
+- Generate types for GraphQL schema
+  [90mWrite types to generated/schema.ts[39m
+- Generate types for GraphQL schema
+✔ Generate types for GraphQL schema

--- a/tests/cli/validation/example-values-found.stderr
+++ b/tests/cli/validation/example-values-found.stderr
@@ -1,5 +1,5 @@
 - Load subgraph from subgraph.yaml
-⚠ Warnings loading subgraph from subgraph.yaml: Warning in subgraph.yaml:
+⚠ Warnings loading subgraph from subgraph.yaml: Warnings in subgraph.yaml:
   
     Path: repository
     The repository is still set to https://github.com/graphprotocol/example-subgraph.

--- a/tests/cli/validation/example-values-found/Abi.json
+++ b/tests/cli/validation/example-values-found/Abi.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "event",
+    "name": "ExampleEvent",
+    "inputs": [{ "type": "string" }]
+  }
+]

--- a/tests/cli/validation/example-values-found/schema.graphql
+++ b/tests/cli/validation/example-values-found/schema.graphql
@@ -1,0 +1,3 @@
+type MyEntity @entity {
+  id: ID!
+}

--- a/tests/cli/validation/example-values-found/subgraph.yaml
+++ b/tests/cli/validation/example-values-found/subgraph.yaml
@@ -1,0 +1,24 @@
+specVersion: 0.0.1
+repository: https://github.com/rodventures/gravity-subgraph
+description: Gravatar for Ethereum
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: ExampleSubgraph
+    source:
+      address: '22843e74c59580b3eaf6c233fa67d8b7c561a835'
+      abi: ExampleContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.1
+      language: wasm/assemblyscript
+      file: ./mapping.ts
+      entities:
+        - ExampleEntity
+      abis:
+        - name: ExampleContract
+          file: ./Abi.json
+      eventHandlers:
+        - event: ExampleEvent(string)
+          handler: handleExampleEvent

--- a/tests/cli/validation/invalid-abis.stderr
+++ b/tests/cli/validation/invalid-abis.stderr
@@ -1,5 +1,5 @@
 - Load subgraph from subgraph.yaml
-✖ Failed to load subgraph from subgraph.yaml: Failed to load subgraph: Error in subgraph.yaml:
+✖ Failed to load subgraph from subgraph.yaml: Error in subgraph.yaml:
 
   Path: dataSources > 0 > mapping > abis > 0 > file
   No valid ABI in file: InvalidAbi.json

--- a/tests/cli/validation/invalid-contract-addresses.stderr
+++ b/tests/cli/validation/invalid-contract-addresses.stderr
@@ -1,5 +1,5 @@
 - Load subgraph from subgraph.yaml
-✖ Failed to load subgraph from subgraph.yaml: Failed to load subgraph: Error in subgraph.yaml:
+✖ Failed to load subgraph from subgraph.yaml: Error in subgraph.yaml:
 
   Path: dataSources > 0 > source > address
   Contract address is invalid: 22843e74c59580b3eaf6c233fa67d8b7c561a835a

--- a/tests/cli/validation/invalid-entity-field-types.stderr
+++ b/tests/cli/validation/invalid-entity-field-types.stderr
@@ -1,5 +1,5 @@
 - Load subgraph from subgraph.yaml
-✖ Failed to load subgraph from subgraph.yaml: Failed to load subgraph: Error in schema.graphql:
+✖ Failed to load subgraph from subgraph.yaml: Error in schema.graphql:
 
   MyEntity:
   - Field 'isSet1': Unknown type 'bool'. Did you mean 'Boolean'?

--- a/tests/cli/validation/invalid-manifest.stderr
+++ b/tests/cli/validation/invalid-manifest.stderr
@@ -1,5 +1,5 @@
 - Load subgraph from subgraph.yaml
-✖ Failed to load subgraph from subgraph.yaml: Failed to load subgraph: Error in subgraph.yaml:
+✖ Failed to load subgraph from subgraph.yaml: Error in subgraph.yaml:
 
   Path: specVersion
   No value provided

--- a/tests/cli/validation/missing-entity-id.stderr
+++ b/tests/cli/validation/missing-entity-id.stderr
@@ -1,5 +1,5 @@
 - Load subgraph from subgraph.yaml
-✖ Failed to load subgraph from subgraph.yaml: Failed to load subgraph: Error in schema.graphql:
+✖ Failed to load subgraph from subgraph.yaml: Error in schema.graphql:
 
   MyEntity:
   - Missing field: id: ID!

--- a/yarn.lock
+++ b/yarn.lock
@@ -412,6 +412,11 @@ ansi-regex@^4.0.0:
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
   integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
 
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -4585,6 +4590,13 @@ strip-ansi@^5.0.0:
   integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
   dependencies:
     ansi-regex "^4.0.0"
+
+strip-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz#55aaa54e33b4c0649a7338a43437b1887d153ec4"
+  integrity sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-bom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Resolves #222 and #217 

Extend the `withSpinner()` function wrapper to include support for logging warning messages and continuing the process. In the output  ⚠️ denotes the start of a warning message. 
The new functionality is used in subgraph validation to print warning messages if vestiges of the example subgraph are found in the manifest file.