### PR TITLE
Fix withSpinner and example subgraph value bugs

### DIFF
--- a/src/command-helpers/spinner.js
+++ b/src/command-helpers/spinner.js
@@ -28,8 +28,12 @@ const withSpinner = async (text, errorText, warningText, f) => {
   try {
     let result = await f(spinner)
     if (typeof result === 'object') {
-      if (result.warning && Object.keys(result).indexOf('result') >= 0) {
-        spinner.warn(`${warningText}: ${result.warning}`)
+      let hasWarning = Object.keys(result).indexOf('warning') >= 0
+      let hasResult = Object.keys(result).indexOf('result') >= 0
+      if (hasWarning && hasResult) {
+        if (result.warning) {
+          spinner.warn(`${warningText}: ${result.warning}`)
+        }
         spinner.succeed(text)
         return result.result
       } else {

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -35,7 +35,7 @@ const buildCombinedWarning = (filename, warnings) =>
       .split('\n')
       .join('\n    ')}`,
         `Warnings in ${path.relative(process.cwd(), filename)}:`,
-      )
+      ) + '\n'
     : null
 
 module.exports = class Subgraph {
@@ -220,7 +220,7 @@ ${abiEvents
 
   static validateRepository(manifest, { resolveFile }) {
     return manifest.get('repository') !==
-      'https://github.com/rodventures/gravity-subgraph'
+      'https://github.com/graphprotocol/example-subgraph'
       ? immutable.List()
       : immutable.List().push(
           immutable.fromJS({
@@ -282,7 +282,7 @@ Please update it to tell users more about your subgraph.`,
 
     return {
       result: manifest,
-      warning: buildCombinedWarning(filename, warnings) + `\n`,
+      warning: buildCombinedWarning(filename, warnings),
     }
   }
 

--- a/tests/cli/validation/example-values-found/subgraph.yaml
+++ b/tests/cli/validation/example-values-found/subgraph.yaml
@@ -1,5 +1,5 @@
 specVersion: 0.0.1
-repository: https://github.com/rodventures/gravity-subgraph
+repository: https://github.com/graphprotocol/example-subgraph
 description: Gravatar for Ethereum
 schema:
   file: ./schema.graphql


### PR DESCRIPTION
This fixes the following bugs:

1. Validation was still checking for `rodventures/gravity-subgraph` instead of `graphprotocol/example-subgraph`.
2. `withSpinner` wasn't properly returning results when the result was an object with `warning: null`.
3. `Subgraph.load` wasn't returning warnings correctly: it was returning `"null\n`" instead of `null` when there were no warnings.