### PR TITLE
Map types of indexed array/string parameters to bytes32

### DIFF
--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -25,7 +25,7 @@ module.exports = class AbiCodeGenerator {
           'Address',
           'BigInt',
         ],
-        '@graphprotocol/graph-ts'
+        '@graphprotocol/graph-ts',
       ),
     ]
   }
@@ -49,8 +49,8 @@ module.exports = class AbiCodeGenerator {
             `constructor`,
             [tsCodegen.param(`event`, eventClassName)],
             null,
-            `this._event = event`
-          )
+            `this._event = event`,
+          ),
         )
 
         event.get('inputs').forEach((input, index) => {
@@ -73,8 +73,8 @@ module.exports = class AbiCodeGenerator {
               `this._event.parameters[${index}].value`,
               inputType,
             )}
-            `
-            )
+            `,
+            ),
           )
         })
 
@@ -88,15 +88,15 @@ module.exports = class AbiCodeGenerator {
             `get params`,
             [],
             tsCodegen.namedType(paramsClassName),
-            `return new ${paramsClassName}(this)`
-          )
+            `return new ${paramsClassName}(this)`,
+          ),
         )
         return [klass, paramsClass]
       })
       .reduce(
         // flatten the array
         (array, classes) => array.concat(classes),
-        []
+        [],
       )
   }
 
@@ -116,8 +116,8 @@ module.exports = class AbiCodeGenerator {
         tsCodegen.namedType(this.abi.name),
         `
         return new ${this.abi.name}('${this.abi.name}', address);
-        `
-      )
+        `,
+      ),
     )
 
     this.abi.data.forEach(member => {
@@ -136,7 +136,7 @@ module.exports = class AbiCodeGenerator {
               // Create a type dedicated to holding the return values
               returnType = tsCodegen.klass(
                 this.abi.name + '__' + member.get('name') + 'Result',
-                { export: true }
+                { export: true },
               )
 
               // Add a constructor to this type
@@ -148,15 +148,15 @@ module.exports = class AbiCodeGenerator {
                     .map((output, index) =>
                       tsCodegen.param(
                         `value${index}`,
-                        typesCodegen.ascTypeForEthereum(output.get('type'))
-                      )
+                        typesCodegen.ascTypeForEthereum(output.get('type')),
+                      ),
                     ),
                   null,
                   member
                     .get('outputs')
                     .map((output, index) => `this.value${index} = value${index}`)
-                    .join('\n')
-                )
+                    .join('\n'),
+                ),
               )
 
               // Add a `toMap(): TypedMap<string,EthereumValue>` function to the return type
@@ -173,13 +173,13 @@ module.exports = class AbiCodeGenerator {
                       (output, index) =>
                         `map.set('value${index}', ${typesCodegen.ethereumValueFromAsc(
                           `this.value${index}`,
-                          output.get('type')
-                        )})`
+                          output.get('type'),
+                        )})`,
                     )
                     .join(';')}
                   return map;
-                  `
-                )
+                  `,
+                ),
               )
 
               // Add value0, value1 etc. members to the type
@@ -188,8 +188,8 @@ module.exports = class AbiCodeGenerator {
                 .map((output, index) =>
                   tsCodegen.klassMember(
                     `value${index}`,
-                    typesCodegen.ascTypeForEthereum(output.get('type'))
-                  )
+                    typesCodegen.ascTypeForEthereum(output.get('type')),
+                  ),
                 )
                 .forEach(member => returnType.addMember(member))
 
@@ -203,8 +203,8 @@ module.exports = class AbiCodeGenerator {
                   member
                     .get('outputs')
                     .get(0)
-                    .get('type')
-                )
+                    .get('type'),
+                ),
               )
             }
 
@@ -218,8 +218,8 @@ module.exports = class AbiCodeGenerator {
                   .map((input, index) =>
                     tsCodegen.param(
                       paramName(input.get('name'), index),
-                      typesCodegen.ascTypeForEthereum(input.get('type'))
-                    )
+                      typesCodegen.ascTypeForEthereum(input.get('type')),
+                    ),
                   ),
                 returnType,
                 `
@@ -232,8 +232,8 @@ module.exports = class AbiCodeGenerator {
                           .map((input, index) =>
                             typesCodegen.ethereumValueFromAsc(
                               paramName(input.get('name'), index),
-                              input.get('type')
-                            )
+                              input.get('type'),
+                            ),
                           )
                           .map(coercion => coercion.toString())
                           .join(', ')
@@ -247,7 +247,7 @@ module.exports = class AbiCodeGenerator {
                         member
                           .get('outputs')
                           .get(0)
-                          .get('type')
+                          .get('type'),
                       )
                     : `new ${returnType.name}(
                   ${member
@@ -255,14 +255,14 @@ module.exports = class AbiCodeGenerator {
                     .map((output, index) =>
                       typesCodegen.ethereumValueToAsc(
                         `result[${index}]`,
-                        output.get('type')
-                      )
+                        output.get('type'),
+                      ),
                     )
                     .join(', ')}
                 )`
                 };
-                `
-              )
+                `,
+              ),
             )
           }
       }

--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -276,6 +276,9 @@ module.exports = class AbiCodeGenerator {
     if (
       inputType === 'string' ||
       inputType === 'bytes' ||
+      // the following matches arrays of the forms `uint256[]` and `uint256[12356789]`;
+      // the value type name doesn't matter here, just that the type name ends with
+      // brackets and, optionally, a number inside the brackets
       inputType.match(/\[[0-9]*\]$/g)
     ) {
       return 'bytes32'

--- a/src/codegen/types/index.js
+++ b/src/codegen/types/index.js
@@ -8,7 +8,7 @@ const conversionsForTypeSystems = (fromTypeSystem, toTypeSystem) => {
   let conversions = TYPE_CONVERSIONS.getIn([fromTypeSystem, toTypeSystem])
   if (conversions === undefined) {
     throw new Error(
-      `Conversions from '${fromTypeSystem}' to '${toTypeSystem}' are not supported`
+      `Conversions from '${fromTypeSystem}' to '${toTypeSystem}' are not supported`,
     )
   }
   return conversions
@@ -35,13 +35,13 @@ const findConversionFromType = (fromTypeSystem, toTypeSystem, fromType) => {
     conversion =>
       typeof conversion.get(0) === 'string'
         ? conversion.get(0) === fromType
-        : fromType.match(conversion.get(0))
+        : fromType.match(conversion.get(0)),
   )
 
   if (conversion === undefined) {
     throw new Error(
       `Conversion from '${fromTypeSystem}' to '${toTypeSystem}' for ` +
-        `source type '${fromType}' is not supported`
+        `source type '${fromType}' is not supported`,
     )
   }
 
@@ -55,13 +55,13 @@ const findConversionToType = (fromTypeSystem, toTypeSystem, toType) => {
     conversion =>
       typeof conversion.get(1) === 'string'
         ? conversion.get(1) === toType
-        : toType.match(conversion.get(1))
+        : toType.match(conversion.get(1)),
   )
 
   if (conversion === undefined) {
     throw new Error(
       `Conversion from '${fromTypeSystem}' to '${toTypeSystem}' for ` +
-        `target type '${toType}' is not supported`
+        `target type '${toType}' is not supported`,
     )
   }
 
@@ -81,12 +81,12 @@ const ethereumTypeForAsc = ascType =>
 
 const ethereumValueToAsc = (code, ethereumType) =>
   findConversionFromType('EthereumValue', 'AssemblyScript', ethereumType).get('convert')(
-    code
+    code,
   )
 
 const ethereumValueFromAsc = (code, ethereumType) =>
   findConversionToType('AssemblyScript', 'EthereumValue', ethereumType).get('convert')(
-    code
+    code,
   )
 
 const ascTypeForValue = valueType =>


### PR DESCRIPTION
This is the Graph CLI part of solving https://github.com/graphprotocol/graph-node/issues/731 / https://github.com/paritytech/ethabi/issues/146.

To deal with indexed parameters properly, we need to treat them as `bytes32` and generate code accordingly.