### PR TITLE
compiler, type-generator: Fix loading subgraphs in --watch mode

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -64,7 +64,7 @@ class Compiler {
 
   async loadSubgraph({ quiet } = { quiet: false }) {
     if (quiet) {
-      return Subgraph.load(this.options.subgraphManifest)
+      return Subgraph.load(this.options.subgraphManifest).result
     } else {
       const manifestPath = this.displayPath(this.options.subgraphManifest)
 

--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -62,7 +62,7 @@ module.exports = class TypeGenerator {
     if (quiet) {
       return this.options.subgraph
         ? this.options.subgraph
-        : Subgraph.load(this.options.subgraphManifest)
+        : Subgraph.load(this.options.subgraphManifest).result
     } else {
       const manifestPath = this.displayPath(this.options.subgraphManifest)
 


### PR DESCRIPTION
Before:
```
$ uniswap-subgraph git:(jannis/dynamic-data-sources) ✗ graph codegen --watch
Failed to load subgraph: subgraph.getIn is not a function
```

After:
```
$ uniswap-subgraph git:(jannis/dynamic-data-sources) ✗ graph codegen --watch
  Skip migration: Bump mapping apiVersion from 0.0.1 to 0.0.2
✔ Apply migrations
✔ Load subgraph from subgraph.yaml
  Load contract ABI from abis/factory.json
✔ Load contract ABIs
  Generate types for contract ABI: Factory (abis/factory.json)
  Write types to generated/Factory/Factory.ts
✔ Generate types for contract ABIs
  Generate types for data source template Factory > Exchange
  Write types templates of data source Factory to generated/Factory/templates.ts
✔ Generate types for data source templates
  Load data source template ABI from abis/exchange.json
✔ Load data source template ABIs
  Generate types for data source template ABI: Factory > Exchange > Exchange (abis/exchange.json)
  Write types to generated/Factory/templates/Exchange/Exchange.ts
✔ Generate types for data source template ABIs
✔ Load GraphQL schema from schema.graphql
  Write types to generated/schema.ts
✔ Generate types for GraphQL schema

Types generated successfully

⠼ Watching subgraph files
```