### PR TITLE
Fix how graph init handles --abi

### DIFF
--- a/tests/cli/init.test.js
+++ b/tests/cli/init.test.js
@@ -7,6 +7,7 @@ describe('Init', () => {
 
   let subgraphDir1 = path.join(baseDir, 'from-example')
   let subgraphDir2 = path.join(baseDir, 'from-contract')
+  let subgraphDir3 = path.join(baseDir, 'from-contract-with-abi')
 
   const removeSubgraphDirs = () => {
     if (fs.existsSync(subgraphDir1)) {
@@ -14,6 +15,9 @@ describe('Init', () => {
     }
     if (fs.existsSync(subgraphDir2)) {
       fs.removeSync(subgraphDir2)
+    }
+    if (fs.existsSync(subgraphDir3)) {
+      fs.removeSync(subgraphDir3)
     }
   }
 
@@ -28,7 +32,7 @@ describe('Init', () => {
       exitCode: 0,
       timeout: 60000,
       cwd: baseDir,
-    }
+    },
   )
 
   cliTest(
@@ -47,6 +51,23 @@ describe('Init', () => {
       exitCode: 0,
       timeout: 60000,
       cwd: baseDir,
-    }
+    },
+  )
+
+  cliTest(
+    'From contract with abi',
+    [
+      'init',
+      '--from-contract',
+      '0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d',
+      '--abi',
+      path.join(baseDir, 'abis', 'Marketplace.json'),
+      '--network',
+      'mainnet',
+      'user/subgraph-from-contract-with-abi',
+      subgraphDir3,
+    ],
+    'init/from-contract-with-abi',
+    { exitCode: 0, timeout: 60000, cwd: baseDir },
   )
 })

--- a/tests/cli/init/abis/Marketplace.json
+++ b/tests/cli/init/abis/Marketplace.json
@@ -1,0 +1,408 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "nonFungibleRegistry",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "acceptedToken",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "ownerCutPercentage",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "destroy",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "publicationFeeInWei",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "auctionByAssetId",
+    "outputs": [
+      {
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "name": "seller",
+        "type": "address"
+      },
+      {
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "name": "expiresAt",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_recipient",
+        "type": "address"
+      }
+    ],
+    "name": "destroyAndSend",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "_acceptedToken",
+        "type": "address"
+      },
+      {
+        "name": "_nonFungibleRegistry",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "name": "assetId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "name": "seller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "priceInWei",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "expiresAt",
+        "type": "uint256"
+      }
+    ],
+    "name": "AuctionCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "name": "assetId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "name": "seller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "totalPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "name": "winner",
+        "type": "address"
+      }
+    ],
+    "name": "AuctionSuccessful",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "name": "assetId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "name": "seller",
+        "type": "address"
+      }
+    ],
+    "name": "AuctionCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "publicationFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "ChangedPublicationFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "ownerCut",
+        "type": "uint256"
+      }
+    ],
+    "name": "ChangedOwnerCut",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "Pause",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "Unpause",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "publicationFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "setPublicationFee",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "ownerCut",
+        "type": "uint8"
+      }
+    ],
+    "name": "setOwnerCut",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "assetId",
+        "type": "uint256"
+      },
+      {
+        "name": "priceInWei",
+        "type": "uint256"
+      },
+      {
+        "name": "expiresAt",
+        "type": "uint256"
+      }
+    ],
+    "name": "createOrder",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "assetId",
+        "type": "uint256"
+      }
+    ],
+    "name": "cancelOrder",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "assetId",
+        "type": "uint256"
+      },
+      {
+        "name": "price",
+        "type": "uint256"
+      }
+    ],
+    "name": "executeOrder",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/tests/cli/init/from-contract-with-abi.stderr
+++ b/tests/cli/init/from-contract-with-abi.stderr
@@ -1,0 +1,12 @@
+- Create subgraph scaffold
+  Generate subgraph from ABI
+- Create subgraph scaffold
+  Write subgraph to directory
+- Create subgraph scaffold
+✔ Create subgraph scaffold
+- Initialize subgraph repository
+✔ Initialize subgraph repository
+- Install dependencies with yarn
+✔ Install dependencies with yarn
+- Generate ABI and schema types with yarn codegen
+✔ Generate ABI and schema types with yarn codegen

--- a/tests/cli/init/from-contract-with-abi.stdout
+++ b/tests/cli/init/from-contract-with-abi.stdout
@@ -1,0 +1,15 @@
+
+Subgraph user/subgraph-from-contract-with-abi created in from-contract-with-abi
+
+Next steps:
+
+  1. Run `graph auth https://api.thegraph.com/deploy/ <access-token>`
+     to authenticate with the hosted service. You can get the access token from
+     https://thegraph.com/explorer/dashboard/.
+
+  2. Type `cd from-contract-with-abi` to enter the subgraph.
+
+  3. Run `yarn deploy` to deploy the subgraph to
+     https://thegraph.com/explorer/subgraph/user/subgraph-from-contract-with-abi.
+
+Make sure to visit the documentation on https://thegraph.com/docs/ for further information.


### PR DESCRIPTION
This bug was reported earlier on Discord. Previously, when `--abi` was provided, neither was the value filled into the form correctly, nor was it loaded if all parameters were provided. This fixes both.

This also adds a test to verify that `graph init` completes successfully when provided with the `--abi` flag.