### PR TITLE
graph init: Disambiguate names, spread tuples over multiple entity fields

### DIFF
--- a/src/abi.js
+++ b/src/abi.js
@@ -5,14 +5,11 @@ const path = require('path')
 const AbiCodeGenerator = require('./codegen/abi')
 
 const buildSignatureParameter = input => {
-  return input.get('type') === 'tuple'
+  return input.type === 'tuple'
     ? '(' +
-        input
-          .get('components')
-          .map(component => buildSignatureParameter(component))
-          .join(',') +
+        input.components.map(component => buildSignatureParameter(component)).join(',') +
         ')'
-    : input.get('type')
+    : input.type
 }
 
 module.exports = class ABI {
@@ -26,14 +23,17 @@ module.exports = class ABI {
     return new AbiCodeGenerator(this)
   }
 
+  static eventSignature(event) {
+    return `${event.name}(${(event.inputs || [])
+      .map(input => buildSignatureParameter(input))
+      .join(',')})`
+  }
+
   eventSignatures() {
-    return this.data.filter(entry => entry.get('type') === 'event').map(
-      event =>
-        `${event.get('name')}(${event
-          .get('inputs', immutable.List())
-          .map(input => buildSignatureParameter(input))
-          .join(',')})`,
-    )
+    return this.data
+      .filter(entry => entry.get('type') === 'event')
+      .map(event => event.toJS())
+      .map(ABI.eventSignature)
   }
 
   callFunctions() {

--- a/src/abi.js
+++ b/src/abi.js
@@ -67,20 +67,24 @@ module.exports = class ABI {
     )
   }
 
+  static normalized(json) {
+    if (Array.isArray(json)) {
+      return json
+    } else if (json.abi !== undefined) {
+      return json.abi
+    } else if (
+      json.compilerOutput !== undefined &&
+      json.compilerOutput.abi !== undefined
+    ) {
+      return json.compilerOutput.abi
+    } else {
+      return undefined
+    }
+  }
+
   static load(name, file) {
     let data = JSON.parse(fs.readFileSync(file))
-
-    let abi = null
-    if (Array.isArray(data)) {
-      abi = data
-    } else if (data.abi !== undefined) {
-      abi = data.abi
-    } else if (
-      data.compilerOutput !== undefined &&
-      data.compilerOutput.abi !== undefined
-    ) {
-      abi = data.compilerOutput.abi
-    }
+    let abi = ABI.normalized(data)
 
     if (abi === null || abi === undefined) {
       throw Error(`No valid ABI in file: ${path.relative(process.cwd(), file)}`)

--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -2,6 +2,7 @@ const immutable = require('immutable')
 
 const tsCodegen = require('./typescript')
 const typesCodegen = require('./types')
+const util = require('./util')
 
 module.exports = class AbiCodeGenerator {
   constructor(abi) {
@@ -41,18 +42,21 @@ module.exports = class AbiCodeGenerator {
   }
 
   _generateCallTypes() {
-    return this.abi
-      .callFunctions()
+    let callFunctions = util.disambiguateNames({
+      values: this.abi.callFunctions(),
+      getName: fn =>
+        fn.get('name') || (fn.get('type') === 'constructor' ? 'constructor' : 'default'),
+      setName: (fn, name) => fn.set('_alias', name),
+    })
+
+    return callFunctions
       .map(fn => {
-        let fnName = fn.get(
-          'name',
-          fn.get('type') === 'constructor' ? 'constructor' : 'default',
-        )
-        let fnClassName = `${fnName.charAt(0).toUpperCase()}${fnName.slice(1)}Call`
+        let fnAlias = fn.get('_alias')
+        let fnClassName = `${fnAlias.charAt(0).toUpperCase()}${fnAlias.slice(1)}Call`
         let tupleClasses = []
 
         // First, generate a class with the input getters
-        let inputsClassName = fnClassName + 'Inputs'
+        let inputsClassName = fnClassName + '__Inputs'
         let inputsClass = tsCodegen.klass(inputsClassName, { export: true })
         inputsClass.addMember(tsCodegen.klassMember('_call', fnClassName))
         inputsClass.addMethod(
@@ -65,20 +69,26 @@ module.exports = class AbiCodeGenerator {
         )
 
         // Generate getters and classes for function inputs
-        fn.get('inputs', immutable.List()).forEach((input, index) => {
-          let callInput = this._generateInputOrOutput(
-            input,
-            index,
-            fnClassName,
-            `call`,
-            `inputValues`,
-          )
-          inputsClass.addMethod(callInput.getter)
-          tupleClasses.push(...callInput.classes)
-        })
+        util
+          .disambiguateNames({
+            values: fn.get('inputs', immutable.List()),
+            getName: (input, index) => input.get('name') || `value${index}`,
+            setName: (input, name) => input.set('name', name),
+          })
+          .forEach((input, index) => {
+            let callInput = this._generateInputOrOutput(
+              input,
+              index,
+              fnClassName,
+              `call`,
+              `inputValues`,
+            )
+            inputsClass.addMethod(callInput.getter)
+            tupleClasses.push(...callInput.classes)
+          })
 
         // Second, generate a class with the output getters
-        let outputsClassName = fnClassName + 'Outputs'
+        let outputsClassName = fnClassName + '__Outputs'
         let outputsClass = tsCodegen.klass(outputsClassName, { export: true })
         outputsClass.addMember(tsCodegen.klassMember('_call', fnClassName))
         outputsClass.addMethod(
@@ -91,17 +101,23 @@ module.exports = class AbiCodeGenerator {
         )
 
         // Generate getters and classes for function outputs
-        fn.get('outputs', immutable.List()).forEach((output, index) => {
-          let callInput = this._generateInputOrOutput(
-            output,
-            index,
-            fnClassName,
-            `call`,
-            `outputValues`,
-          )
-          outputsClass.addMethod(callInput.getter)
-          tupleClasses.push(...callInput.classes)
-        })
+        util
+          .disambiguateNames({
+            values: fn.get('outputs', immutable.List()),
+            getName: (output, index) => output.get('name') || `value${index}`,
+            setName: (output, name) => output.set('name', name),
+          })
+          .forEach((output, index) => {
+            let callInput = this._generateInputOrOutput(
+              output,
+              index,
+              fnClassName,
+              `call`,
+              `outputValues`,
+            )
+            outputsClass.addMethod(callInput.getter)
+            tupleClasses.push(...callInput.classes)
+          })
 
         // Then, generate the event class itself
         let klass = tsCodegen.klass(fnClassName, {
@@ -134,20 +150,16 @@ module.exports = class AbiCodeGenerator {
   }
 
   _generateEventTypes() {
-    // Keep a map of how many events were generated so far with the given name.
-    // If there are no name collisions, all entries map to 1.
-    let generatedEvents = new Map()
-    return this.abi.data
-      .filter(member => member.get('type') === 'event')
+    // Enumerate events with duplicate names
+    let events = util.disambiguateNames({
+      values: this.abi.data.filter(member => member.get('type') === 'event'),
+      getName: event => event.get('name'),
+      setName: (event, name) => event.set('_alias', name),
+    })
+
+    return events
       .map(event => {
-        let eventClassName = event.get('name')
-        let currentCount = generatedEvents.get(eventClassName)
-        if (currentCount === undefined) {
-          generatedEvents.set(eventClassName, 1)
-        } else {
-          generatedEvents.set(eventClassName, currentCount + 1)
-          eventClassName += currentCount
-        }
+        let eventClassName = event.get('_alias')
         let tupleClasses = []
 
         // First, generate a class with the param getters
@@ -163,7 +175,14 @@ module.exports = class AbiCodeGenerator {
           ),
         )
 
-        event.get('inputs').forEach((input, index) => {
+        // Enumerate inputs with duplicate names
+        let inputs = util.disambiguateNames({
+          values: event.get('inputs'),
+          getName: (input, index) => input.get('name') || `param${index}`,
+          setName: (input, name) => input.set('name', name),
+        })
+
+        inputs.forEach((input, index) => {
           // Generate getters and classes for event params
           let paramObject = this._generateInputOrOutput(
             input,
@@ -310,138 +329,151 @@ module.exports = class AbiCodeGenerator {
       ),
     )
 
-    this.abi.data.forEach(member => {
-      switch (member.get('type')) {
-        case 'function':
-          if (
-            member.get('stateMutability') === 'view' ||
-            member.get('stateMutability') === 'pure'
-          ) {
-            let methodName = member.get('name')
-            
-            // Generate a type for the result of calling the function
-            let returnType = undefined
-            let simpleReturnType = true
-            if (member.get('outputs').size > 1) {
-              simpleReturnType = false
+    // Get view/pure functions from the contract
+    let functions = this.abi.data.filter(
+      member =>
+        member.get('type') === 'function' &&
+        (member.get('stateMutability') === 'view' ||
+          member.get('stateMutability') === 'pure'),
+    )
 
-              // Create a type dedicated to holding the return values
-              returnType = tsCodegen.klass(
-                this.abi.name + '__' + methodName + 'Result',
-                { export: true },
+    // Disambiguate functions with duplicate names
+    functions = util.disambiguateNames({
+      values: functions,
+      getName: fn => fn.get('name'),
+      setName: (fn, name) => fn.set('_alias', name),
+    })
+
+    functions.forEach(member => {
+      let fnName = member.get('name')
+      let fnAlias = member.get('_alias')
+
+      // Generate a type for the result of calling the function
+      let returnType = undefined
+      let simpleReturnType = true
+      if (member.get('outputs', immutable.List()).size > 1) {
+        simpleReturnType = false
+
+        // Create a type dedicated to holding the return values
+        returnType = tsCodegen.klass(this.abi.name + '__' + fnAlias + 'Result', {
+          export: true,
+        })
+
+        // Add a constructor to this type
+        returnType.addMethod(
+          tsCodegen.method(
+            'constructor',
+            member
+              .get('outputs')
+              .map((output, index) =>
+                tsCodegen.param(
+                  `value${index}`,
+                  typesCodegen.ascTypeForEthereum(output.get('type')),
+                ),
+              ),
+            null,
+            member
+              .get('outputs')
+              .map((output, index) => `this.value${index} = value${index}`)
+              .join('\n'),
+          ),
+        )
+
+        // Add a `toMap(): TypedMap<string,EthereumValue>` function to the return type
+        returnType.addMethod(
+          tsCodegen.method(
+            'toMap',
+            [],
+            tsCodegen.namedType('TypedMap<string,EthereumValue>'),
+            `
+            let map = new TypedMap<string,EthereumValue>();
+            ${member
+              .get('outputs')
+              .map(
+                (output, index) =>
+                  `map.set('value${index}', ${typesCodegen.ethereumValueFromAsc(
+                    `this.value${index}`,
+                    output.get('type'),
+                  )})`,
               )
+              .join(';')}
+            return map;
+            `,
+          ),
+        )
 
-              // Add a constructor to this type
-              returnType.addMethod(
-                tsCodegen.method(
-                  'constructor',
-                  member
-                    .get('outputs')
-                    .map((output, index) =>
-                      tsCodegen.param(
-                        `value${index}`,
-                        typesCodegen.ascTypeForEthereum(output.get('type')),
+        // Add value0, value1 etc. members to the type
+        member
+          .get('outputs')
+          .map((output, index) =>
+            tsCodegen.klassMember(
+              `value${index}`,
+              typesCodegen.ascTypeForEthereum(output.get('type')),
+            ),
+          )
+          .forEach(member => returnType.addMember(member))
+
+        // Add the type to the types we'll create
+        types = types.push(returnType)
+
+        returnType = tsCodegen.namedType(returnType.name)
+      } else {
+        returnType = tsCodegen.namedType(
+          typesCodegen.ascTypeForEthereum(
+            member
+              .get('outputs')
+              .get(0)
+              .get('type'),
+          ),
+        )
+      }
+
+      // Disambiguate inputs with duplicate names
+      let inputs = util.disambiguateNames({
+        values: member.get('inputs', immutable.List()),
+        getName: (input, index) => input.get('name') || `param${index}`,
+        setName: (input, name) => input.set('_alias', name),
+      })
+
+      // Generate and add a method that implements calling the function on
+      // the smart contract
+      klass.addMethod(
+        tsCodegen.method(
+          fnAlias,
+          inputs.map(input =>
+            tsCodegen.param(
+              input.get('_alias'),
+              typesCodegen.ascTypeForEthereum(input.get('type')),
+            ),
+          ),
+          returnType,
+          `
+          let result = super.call(
+            '${fnName}',
+            [${
+              inputs.size > 0
+                ? inputs
+                    .map(input =>
+                      typesCodegen.ethereumValueFromAsc(
+                        input.get('_alias'),
+                        input.get('type'),
                       ),
-                    ),
-                  null,
-                  member
-                    .get('outputs')
-                    .map((output, index) => `this.value${index} = value${index}`)
-                    .join('\n'),
-                ),
-              )
-
-              // Add a `toMap(): TypedMap<string,EthereumValue>` function to the return type
-              returnType.addMethod(
-                tsCodegen.method(
-                  'toMap',
-                  [],
-                  tsCodegen.namedType('TypedMap<string,EthereumValue>'),
-                  `
-                  let map = new TypedMap<string,EthereumValue>();
-                  ${member
-                    .get('outputs')
-                    .map(
-                      (output, index) =>
-                        `map.set('value${index}', ${typesCodegen.ethereumValueFromAsc(
-                          `this.value${index}`,
-                          output.get('type'),
-                        )})`,
                     )
-                    .join(';')}
-                  return map;
-                  `,
-                ),
-              )
-
-              // Add value0, value1 etc. members to the type
-              member
-                .get('outputs')
-                .map((output, index) =>
-                  tsCodegen.klassMember(
-                    `value${index}`,
-                    typesCodegen.ascTypeForEthereum(output.get('type')),
-                  ),
-                )
-                .forEach(member => returnType.addMember(member))
-
-              // Add the type to the types we'll create
-              types = types.push(returnType)
-
-              returnType = tsCodegen.namedType(returnType.name)
-            } else {
-              returnType = tsCodegen.namedType(
-                typesCodegen.ascTypeForEthereum(
+                    .map(coercion => coercion.toString())
+                    .join(', ')
+                : ''
+            }]
+          );
+          return ${
+            simpleReturnType
+              ? typesCodegen.ethereumValueToAsc(
+                  'result[0]',
                   member
                     .get('outputs')
                     .get(0)
                     .get('type'),
-                ),
-              )
-            }
-
-            // Generate and add a method that implements calling the function on
-            // the smart contract
-            klass.addMethod(
-              tsCodegen.method(
-                methodName,
-                member
-                  .get('inputs')
-                  .map((input, index) =>
-                    tsCodegen.param(
-                      paramName(input.get('name'), index),
-                      typesCodegen.ascTypeForEthereum(input.get('type')),
-                    ),
-                  ),
-                returnType,
-                `
-                let result = super.call(
-                  '${member.get('name')}',
-                  [${
-                    member.get('inputs')
-                      ? member
-                          .get('inputs')
-                          .map((input, index) =>
-                            typesCodegen.ethereumValueFromAsc(
-                              paramName(input.get('name'), index),
-                              input.get('type'),
-                            ),
-                          )
-                          .map(coercion => coercion.toString())
-                          .join(', ')
-                      : ''
-                  }]
-                );
-                return ${
-                  simpleReturnType
-                    ? typesCodegen.ethereumValueToAsc(
-                        'result[0]',
-                        member
-                          .get('outputs')
-                          .get(0)
-                          .get('type'),
-                      )
-                    : `new ${returnType.name}(
+                )
+              : `new ${returnType.name}(
                   ${member
                     .get('outputs')
                     .map((output, index) =>
@@ -452,12 +484,10 @@ module.exports = class AbiCodeGenerator {
                     )
                     .join(', ')}
                 )`
-                };
-                `,
-              ),
-            )
-          }
-      }
+          };
+          `,
+        ),
+      )
     })
 
     return [...types, klass]

--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -313,9 +313,6 @@ module.exports = class AbiCodeGenerator {
     let klass = tsCodegen.klass(this.abi.name, { export: true, extends: 'SmartContract' })
     let types = immutable.List()
 
-    const paramName = (name, index) =>
-      name === undefined || name === null || name === '' ? `param${index}` : name
-
     klass.addMethod(
       tsCodegen.staticMethod(
         'bind',

--- a/src/codegen/typescript.js
+++ b/src/codegen/typescript.js
@@ -65,7 +65,6 @@ class Class {
     this.extends = options.extends
     this.methods = []
     this.members = []
-    this.methodNameCount = new Map() // Counts duplicate names.
     this.export = options.export || false
   }
 
@@ -74,14 +73,6 @@ class Class {
   }
 
   addMethod(method) {
-    let currentCount = this.methodNameCount.get(method.name)
-    if (currentCount === undefined) {
-      this.methodNameCount = this.methodNameCount.set(method.name, 1)
-    } else {
-      // Append the count to disambiguate.
-      this.methodNameCount = this.methodNameCount.set(method.name, currentCount + 1)
-      method.name += currentCount
-    }
     this.methods.push(method)
   }
 

--- a/src/codegen/util.js
+++ b/src/codegen/util.js
@@ -14,18 +14,18 @@ const disambiguateNames = ({ values, getName, setName }) => {
 }
 
 const unrollTuple = ({ path, index, value }) =>
-  value.components
-    .map((component, index) => {
-      let name = component.name || `value${index}`
-      return component.type === 'tuple'
+  value.components.reduce((acc, component, index) => {
+    let name = component.name || `value${index}`
+    return acc.concat(
+      component.type === 'tuple'
         ? unrollTuple({
             path: [...path, name],
             index,
             value: component,
           })
-        : [{ path: [...path, name], type: component.type }]
-    })
-    .flat()
+        : [{ path: [...path, name], type: component.type }],
+    )
+  }, [])
 
 module.exports = {
   disambiguateNames,

--- a/src/codegen/util.js
+++ b/src/codegen/util.js
@@ -1,0 +1,33 @@
+const disambiguateNames = ({ values, getName, setName }) => {
+  let collisionCounter = new Map()
+  return values.map((value, index) => {
+    let name = getName(value, index)
+    let counter = collisionCounter[name]
+    if (counter === undefined) {
+      collisionCounter[name] = 1
+      return setName(value, name)
+    } else {
+      collisionCounter[name] += 1
+      return setName(value, `${name}${counter}`)
+    }
+  })
+}
+
+const unrollTuple = ({ path, index, value }) =>
+  value.components
+    .map((component, index) => {
+      let name = component.name || `value${index}`
+      return component.type === 'tuple'
+        ? unrollTuple({
+            path: [...path, name],
+            index,
+            value: component,
+          })
+        : [{ path: [...path, name], type: component.type }]
+    })
+    .flat()
+
+module.exports = {
+  disambiguateNames,
+  unrollTuple,
+}

--- a/src/codegen/util.test.js
+++ b/src/codegen/util.test.js
@@ -1,0 +1,109 @@
+const { disambiguateNames, unrollTuple } = require('./util')
+
+describe('Codegen utilities', () => {
+  test('Name disambiguation', () => {
+    expect(
+      disambiguateNames({
+        values: ['a', 'b', 'c'],
+        getName: x => x,
+        setName: (x, name) => name,
+      }),
+    ).toEqual(['a', 'b', 'c'])
+
+    expect(
+      disambiguateNames({
+        values: ['a', 'a', 'a'],
+        getName: x => x,
+        setName: (x, name) => name,
+      }),
+    ).toEqual(['a', 'a1', 'a2'])
+
+    expect(
+      disambiguateNames({
+        values: [
+          { name: 'ExampleEvent', inputs: [] },
+          { name: 'ExampleEvent', inputs: [{ type: 'uint256' }] },
+          { name: 'ExampleEvent', inputs: [{ type: 'uint96' }] },
+        ],
+        getName: event => event.name,
+        setName: (event, name) => {
+          event.name = name
+          return event
+        },
+      }),
+    ).toEqual([
+      { name: 'ExampleEvent', inputs: [] },
+      { name: 'ExampleEvent1', inputs: [{ type: 'uint256' }] },
+      { name: 'ExampleEvent2', inputs: [{ type: 'uint96' }] },
+    ])
+  })
+
+  test('Tuple unrolling', () => {
+    expect(
+      unrollTuple({
+        value: { type: 'tuple', name: 'value', components: [] },
+        path: ['value'],
+        index: 0,
+      }),
+    ).toEqual([])
+
+    expect(
+      unrollTuple({
+        value: {
+          type: 'tuple',
+          name: 'value',
+          components: [{ name: 'a', type: 'string' }],
+        },
+        path: ['value'],
+        index: 0,
+      }),
+    ).toEqual([{ path: ['value', 'a'], type: 'string' }])
+
+    expect(
+      unrollTuple({
+        value: {
+          type: 'tuple',
+          name: 'value',
+          components: [{ name: 'a', type: 'string' }, { name: 'b', type: 'uint256' }],
+        },
+        path: ['value'],
+        index: 0,
+      }),
+    ).toEqual([
+      { path: ['value', 'a'], type: 'string' },
+      { path: ['value', 'b'], type: 'uint256' },
+    ])
+
+    expect(
+      unrollTuple({
+        value: {
+          type: 'tuple',
+          name: 'value',
+          components: [
+            { name: 'a', type: 'string' },
+            { name: 'b', type: 'uint256' },
+            {
+              name: 'c',
+              type: 'tuple',
+              components: [
+                { type: 'bytes32' },
+                {
+                  name: 'd',
+                  type: 'tuple',
+                  components: [{ name: 'd1', type: 'uint72' }],
+                },
+              ],
+            },
+          ],
+        },
+        path: ['value'],
+        index: 1,
+      }),
+    ).toEqual([
+      { path: ['value', 'a'], type: 'string' },
+      { path: ['value', 'b'], type: 'uint256' },
+      { path: ['value', 'c', 'value0'], type: 'bytes32' },
+      { path: ['value', 'c', 'd', 'd1'], type: 'uint72' },
+    ])
+  })
+})

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -33,7 +33,7 @@ ${chalk.dim('Options for --from-contract:')}
 
 const processInitForm = async (
   toolbox,
-  { abi, address, allowSimpleName, directory, fromExample, network, subgraphName }
+  { abi, address, allowSimpleName, directory, fromExample, network, subgraphName },
 ) => {
   let networkChoices = ['mainnet', 'kovan', 'rinkeby', 'ropsten']
   let addressPattern = /^(0x)?[0-9a-fA-F]{40}$/
@@ -156,11 +156,11 @@ const loadAbiFromEtherscan = async (network, address) =>
       let result = await fetch(
         `https://${
           network === 'mainnet' ? 'api' : `api-${network}`
-        }.etherscan.io/api?module=contract&action=getabi&address=${address}`
+        }.etherscan.io/api?module=contract&action=getabi&address=${address}`,
       )
       let json = await result.json()
       return JSON.parse(json.result)
-    }
+    },
   )
 
 const loadAbiFromFile = async filename => {
@@ -232,7 +232,7 @@ module.exports = {
     let git = await system.which('git')
     if (git === null) {
       print.error(
-        `Git was not found on your system. Please install 'git' so it is in $PATH.`
+        `Git was not found on your system. Please install 'git' so it is in $PATH.`,
       )
       process.exitCode = 1
       return
@@ -243,7 +243,7 @@ module.exports = {
     let npm = await system.which('npm')
     if (!yarn && !npm) {
       print.error(
-        `Neither Yarn nor NPM were found on your system. Please install one of them.`
+        `Neither Yarn nor NPM were found on your system. Please install one of them.`,
       )
       process.exitCode = 1
       return
@@ -261,7 +261,7 @@ module.exports = {
       return await initSubgraphFromExample(
         toolbox,
         { allowSimpleName, directory, subgraphName },
-        { commands }
+        { commands },
       )
     }
 
@@ -288,7 +288,7 @@ module.exports = {
       return await initSubgraphFromContract(
         toolbox,
         { abi, allowSimpleName, directory, address: fromContract, network, subgraphName },
-        { commands }
+        { commands },
       )
     }
 
@@ -318,7 +318,7 @@ module.exports = {
           subgraphName: inputs.subgraphName,
           directory: inputs.directory,
         },
-        { commands }
+        { commands },
       )
     } else {
       await initSubgraphFromContract(
@@ -331,7 +331,7 @@ module.exports = {
           network: inputs.network,
           address: inputs.address,
         },
-        { commands }
+        { commands },
       )
     }
   },
@@ -371,7 +371,7 @@ const initRepository = async (toolbox, directory) =>
         cwd: directory,
       })
       return true
-    }
+    },
   )
 
 const installDependencies = async (toolbox, directory, installCommand) =>
@@ -382,7 +382,7 @@ const installDependencies = async (toolbox, directory, installCommand) =>
     async spinner => {
       await toolbox.system.run(installCommand, { cwd: directory })
       return true
-    }
+    },
   )
 
 const runCodegen = async (toolbox, directory, codegenCommand) =>
@@ -393,7 +393,7 @@ const runCodegen = async (toolbox, directory, codegenCommand) =>
     async spinner => {
       await toolbox.system.run(codegenCommand, { cwd: directory })
       return true
-    }
+    },
   )
 
 const printNextSteps = (toolbox, { subgraphName, directory }, { commands }) => {
@@ -405,12 +405,12 @@ const printNextSteps = (toolbox, { subgraphName, directory }, { commands }) => {
   print.success(
     `
 Subgraph ${print.colors.blue(subgraphName)} created in ${print.colors.blue(relativeDir)}
-`
+`,
   )
   print.info(`Next steps:
 
   1. Run \`${print.colors.muted(
-    'graph auth https://api.thegraph.com/deploy/ <access-token>'
+    'graph auth https://api.thegraph.com/deploy/ <access-token>',
   )}\`
      to authenticate with the hosted service. You can get the access token from
      https://thegraph.com/explorer/dashboard/.
@@ -426,7 +426,7 @@ Make sure to visit the documentation on https://thegraph.com/docs/ for further i
 const initSubgraphFromExample = async (
   toolbox,
   { allowSimpleName, subgraphName, directory },
-  { commands }
+  { commands },
 ) => {
   let { filesystem, print, system } = toolbox
 
@@ -450,10 +450,10 @@ const initSubgraphFromExample = async (
     `Warnings while cloning example subgraph`,
     async spinner => {
       await system.run(
-        `git clone http://github.com/graphprotocol/example-subgraph ${directory}`
+        `git clone http://github.com/graphprotocol/example-subgraph ${directory}`,
       )
       return true
-    }
+    },
   )
   if (!cloned) {
     process.exitCode = 1
@@ -486,7 +486,7 @@ const initSubgraphFromExample = async (
         filesystem.remove(directory)
         return false
       }
-    }
+    },
   )
   if (!prepared) {
     process.exitCode = 1
@@ -520,7 +520,7 @@ const initSubgraphFromExample = async (
 const initSubgraphFromContract = async (
   toolbox,
   { allowSimpleName, subgraphName, directory, abi, network, address },
-  { commands }
+  { commands },
 ) => {
   let { print } = toolbox
 
@@ -557,11 +557,11 @@ const initSubgraphFromContract = async (
           network,
           address,
         },
-        spinner
+        spinner,
       )
       await writeScaffold(scaffold, directory, spinner)
       return true
-    }
+    },
   )
   if (scaffold !== true) {
     process.exitCode = 1

--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -76,7 +76,7 @@ dataSources:
       abi: Contract
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.1
+      apiVersion: 0.0.2
       language: wasm/assemblyscript
       entities:
         ${abiEvents(abi)

--- a/src/scaffold.test.js
+++ b/src/scaffold.test.js
@@ -1,0 +1,145 @@
+const {
+  generateEventFieldAssignments,
+  generateManifest,
+  generateMapping,
+  generateSchema,
+} = require('./scaffold')
+
+const TEST_EVENT = {
+  name: 'ExampleEvent',
+  type: 'event',
+  inputs: [
+    { name: 'a', type: 'uint256' },
+    { name: 'b', type: 'bytes[4]' },
+    { type: 'string' },
+    {
+      name: 'c',
+      type: 'tuple',
+      components: [
+        { name: 'c1', type: 'uint256' },
+        { type: 'bytes32' },
+        { type: 'string' },
+        {
+          name: 'c3',
+          type: 'tuple',
+          components: [
+            { name: 'c31', type: 'uint96' },
+            { type: 'string' },
+            { type: 'bytes32' },
+          ],
+        },
+      ],
+    },
+    { name: 'd', type: 'string', indexed: true },
+  ],
+}
+
+const OVERLOADED_EVENT = {
+  name: 'ExampleEvent',
+  type: 'event',
+  inputs: [{ name: 'a', type: 'bytes32' }],
+}
+
+const TEST_CONTRACT = {
+  name: 'ExampleContract',
+  type: 'contract',
+}
+
+const TEST_ABI = [TEST_EVENT, OVERLOADED_EVENT, TEST_CONTRACT]
+
+describe('Subgraph scaffolding', () => {
+  test('Manifest', () => {
+    expect(
+      generateManifest({
+        abi: TEST_ABI,
+        network: 'kovan',
+        address: '0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d',
+      }),
+    ).toEqual(`\
+specVersion: 0.0.1
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: Contract
+    network: kovan
+    source:
+      address: "0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d"
+      abi: Contract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.2
+      language: wasm/assemblyscript
+      entities:
+        - ExampleEvent
+        - ExampleEvent1
+      abis:
+        - name: Contract
+          file: ./abis/Contract.json
+      eventHandlers:
+        - event: ExampleEvent(uint256,bytes[4],string,tuple,string)
+          handler: handleExampleEvent
+        - event: ExampleEvent(bytes32)
+          handler: handleExampleEvent1
+      file: ./src/mapping.ts
+`)
+  })
+
+  test('Schema', () => {
+    expect(generateSchema({ abi: TEST_ABI })).toEqual(`\
+type ExampleEvent @entity {
+  id: ID!
+  a: BigInt! # uint256
+  b: [Bytes]! # bytes[4]
+  param2: String! # string
+  c_c1: BigInt! # uint256
+  c_value1: Bytes! # bytes32
+  c_value2: String! # string
+  c_c3_c31: BigInt! # uint96
+  c_c3_value1: String! # string
+  c_c3_value2: Bytes! # bytes32
+  d: String! # string
+}
+
+type ExampleEvent1 @entity {
+  id: ID!
+  a: Bytes! # bytes32
+}
+`)
+  })
+
+  test('Mapping', () => {
+    expect(generateMapping({ abi: TEST_ABI })).toEqual(`\
+import {
+  ExampleEvent as ExampleEventEvent,
+  ExampleEvent1 as ExampleEvent1Event
+} from "../generated/Contract/Contract"
+import { ExampleEvent, ExampleEvent1 } from "../generated/schema"
+
+export function handleExampleEvent(event: ExampleEventEvent): void {
+  let entity = new ExampleEvent(
+    event.transaction.hash.toHex() + "-" + event.logIndex.toString()
+  )
+  entity.a = event.params.a
+  entity.b = event.params.b
+  entity.param2 = event.params.param2
+  entity.c_c1 = event.params.c.c1
+  entity.c_value1 = event.params.c.value1
+  entity.c_value2 = event.params.c.value2
+  entity.c_c3_c31 = event.params.c.c3.c31
+  entity.c_c3_value1 = event.params.c.c3.value1
+  entity.c_c3_value2 = event.params.c.c3.value2
+  entity.d = event.params.d
+  entity.save()
+}
+
+export function handleExampleEvent1(event: ExampleEvent1Event): void {
+  let entity = new ExampleEvent1(
+    event.transaction.hash.toHex() + "-" + event.logIndex.toString()
+  )
+  entity.a = event.params.a
+  entity.save()
+}
+`)
+  })
+})

--- a/tests/cli/init.test.js
+++ b/tests/cli/init.test.js
@@ -8,6 +8,8 @@ describe('Init', () => {
   let subgraphDir1 = path.join(baseDir, 'from-example')
   let subgraphDir2 = path.join(baseDir, 'from-contract')
   let subgraphDir3 = path.join(baseDir, 'from-contract-with-abi')
+  let subgraphDir4 = path.join(baseDir, 'from-contract-with-abi-and-structs')
+  let subgraphDir5 = path.join(baseDir, 'from-contract-with-overloaded-elements')
 
   const removeSubgraphDirs = () => {
     if (fs.existsSync(subgraphDir1)) {
@@ -18,6 +20,12 @@ describe('Init', () => {
     }
     if (fs.existsSync(subgraphDir3)) {
       fs.removeSync(subgraphDir3)
+    }
+    if (fs.existsSync(subgraphDir4)) {
+      fs.removeSync(subgraphDir4)
+    }
+    if (fs.existsSync(subgraphDir5)) {
+      fs.removeSync(subgraphDir5)
     }
   }
 
@@ -68,6 +76,40 @@ describe('Init', () => {
       subgraphDir3,
     ],
     'init/from-contract-with-abi',
+    { exitCode: 0, timeout: 60000, cwd: baseDir },
+  )
+
+  cliTest(
+    'From contract with abi and structs',
+    [
+      'init',
+      '--from-contract',
+      '0x1E0447b19BB6EcFdAe1e4AE1694b0C3659614e4e',
+      '--abi',
+      path.join(baseDir, 'abis', 'SoloMargin.json'),
+      '--network',
+      'mainnet',
+      'user/subgraph-from-contract-with-abi-and-structs',
+      subgraphDir4,
+    ],
+    'init/from-contract-with-abi-and-structs',
+    { exitCode: 0, timeout: 60000, cwd: baseDir },
+  )
+
+  cliTest(
+    'From contract with overloaded elements',
+    [
+      'init',
+      '--from-contract',
+      '0x1E0447b19BB6EcFdAe1e4AE1694b0C3659614e4e',
+      '--abi',
+      path.join(baseDir, 'abis', 'OverloadedElements.json'),
+      '--network',
+      'mainnet',
+      'user/subgraph-from-contract-with-overloaded-elements',
+      subgraphDir5,
+    ],
+    'init/from-contract-with-overloaded-elements',
     { exitCode: 0, timeout: 60000, cwd: baseDir },
   )
 })

--- a/tests/cli/init/abis/OverloadedElements.json
+++ b/tests/cli/init/abis/OverloadedElements.json
@@ -1,0 +1,91 @@
+[
+  {
+    "name": "Transfer",
+    "type": "event",
+    "inputs": []
+  },
+  {
+    "name": "Transfer",
+    "type": "event",
+    "inputs": [
+      { "name": "to", "type": "address" }
+    ]
+  },
+  {
+    "name": "Transfer",
+    "type": "event",
+    "inputs": [
+      { "name": "from", "type": "address" },
+      { "name": "to", "type": "address" },
+      { "name": "to", "type": "address" }
+    ]
+  },
+  {
+    "name": "getSomething",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      { "type": "bytes32" }
+    ]
+  },
+  {
+    "name": "getSomething",
+    "type": "function",
+    "stateMutability": "pure",
+    "inputs": [
+      { "name": "owner", "type": "address" },
+      { "name": "owner", "type": "bytes32" }
+    ],
+    "outputs": [
+      { "name": "value", "type": "address" },
+      { "name": "value", "type": "bytes32" }
+    ]
+  },
+  {
+    "name": "getSomething",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      { "name": "value", "type": "bytes32" }
+    ],
+    "outputs": [
+      { "name": "value", "type": "bytes32" },
+      { "type": "address" }
+    ]
+  },
+  {
+    "name": "doSomething",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [],
+    "outputs": [
+      { "type": "bytes32" }
+    ]
+  },
+  {
+    "name": "doSomething",
+    "type": "function",
+    "stateMutability": "payable",
+    "inputs": [
+      { "name": "owner", "type": "address" },
+      { "name": "owner", "type": "bytes32" }
+    ],
+    "outputs": [
+      { "name": "value", "type": "address" },
+      { "name": "value", "type": "bytes32" }
+    ]
+  },
+  {
+    "name": "doSomething",
+    "type": "function",
+    "stateMutability": "payable",
+    "inputs": [
+      { "name": "value", "type": "bytes32" }
+    ],
+    "outputs": [
+      { "name": "value", "type": "bytes32" },
+      { "type": "address" }
+    ]
+  }
+]

--- a/tests/cli/init/abis/SoloMargin.json
+++ b/tests/cli/init/abis/SoloMargin.json
@@ -1,0 +1,2729 @@
+{
+  "contractName": "SoloMargin",
+  "abi": [
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        },
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "spreadPremium",
+          "type": "tuple"
+        }
+      ],
+      "name": "ownerSetSpreadPremium",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "operator",
+          "type": "address"
+        }
+      ],
+      "name": "getIsGlobalOperator",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getMarketTokenAddress",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        },
+        {
+          "name": "interestSetter",
+          "type": "address"
+        }
+      ],
+      "name": "ownerSetInterestSetter",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "components": [
+            {
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "name": "number",
+              "type": "uint256"
+            }
+          ],
+          "name": "account",
+          "type": "tuple"
+        }
+      ],
+      "name": "getAccountValues",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getMarketPriceOracle",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getMarketInterestSetter",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getMarketSpreadPremium",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getNumMarkets",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "name": "recipient",
+          "type": "address"
+        }
+      ],
+      "name": "ownerWithdrawUnsupportedTokens",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "minBorrowedValue",
+          "type": "tuple"
+        }
+      ],
+      "name": "ownerSetMinBorrowedValue",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "spread",
+          "type": "tuple"
+        }
+      ],
+      "name": "ownerSetLiquidationSpread",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "earningsRate",
+          "type": "tuple"
+        }
+      ],
+      "name": "ownerSetEarningsRate",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "name": "operator",
+          "type": "address"
+        }
+      ],
+      "name": "getIsLocalOperator",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "components": [
+            {
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "name": "number",
+              "type": "uint256"
+            }
+          ],
+          "name": "account",
+          "type": "tuple"
+        },
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getAccountPar",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "sign",
+              "type": "bool"
+            },
+            {
+              "name": "value",
+              "type": "uint128"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        },
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "marginPremium",
+          "type": "tuple"
+        }
+      ],
+      "name": "ownerSetMarginPremium",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getMarginRatio",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getMarketCurrentIndex",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "borrow",
+              "type": "uint96"
+            },
+            {
+              "name": "supply",
+              "type": "uint96"
+            },
+            {
+              "name": "lastUpdate",
+              "type": "uint32"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getMarketIsClosing",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getRiskParams",
+      "outputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "name": "value",
+                  "type": "uint256"
+                }
+              ],
+              "name": "marginRatio",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "name": "value",
+                  "type": "uint256"
+                }
+              ],
+              "name": "liquidationSpread",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "name": "value",
+                  "type": "uint256"
+                }
+              ],
+              "name": "earningsRate",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "name": "value",
+                  "type": "uint256"
+                }
+              ],
+              "name": "minBorrowedValue",
+              "type": "tuple"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getMinBorrowedValue",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getMarketPrice",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "isOwner",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        },
+        {
+          "name": "recipient",
+          "type": "address"
+        }
+      ],
+      "name": "ownerWithdrawExcessTokens",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "name": "priceOracle",
+          "type": "address"
+        },
+        {
+          "name": "interestSetter",
+          "type": "address"
+        },
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "marginPremium",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "spreadPremium",
+          "type": "tuple"
+        }
+      ],
+      "name": "ownerAddMarket",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getMarketWithInfo",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "token",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "name": "borrow",
+                  "type": "uint128"
+                },
+                {
+                  "name": "supply",
+                  "type": "uint128"
+                }
+              ],
+              "name": "totalPar",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "name": "borrow",
+                  "type": "uint96"
+                },
+                {
+                  "name": "supply",
+                  "type": "uint96"
+                },
+                {
+                  "name": "lastUpdate",
+                  "type": "uint32"
+                }
+              ],
+              "name": "index",
+              "type": "tuple"
+            },
+            {
+              "name": "priceOracle",
+              "type": "address"
+            },
+            {
+              "name": "interestSetter",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "name": "value",
+                  "type": "uint256"
+                }
+              ],
+              "name": "marginPremium",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "name": "value",
+                  "type": "uint256"
+                }
+              ],
+              "name": "spreadPremium",
+              "type": "tuple"
+            },
+            {
+              "name": "isClosing",
+              "type": "bool"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "name": "borrow",
+              "type": "uint96"
+            },
+            {
+              "name": "supply",
+              "type": "uint96"
+            },
+            {
+              "name": "lastUpdate",
+              "type": "uint32"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "ratio",
+          "type": "tuple"
+        }
+      ],
+      "name": "ownerSetMarginRatio",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getLiquidationSpread",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "components": [
+            {
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "name": "number",
+              "type": "uint256"
+            }
+          ],
+          "name": "account",
+          "type": "tuple"
+        },
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getAccountWei",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "sign",
+              "type": "bool"
+            },
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getMarketTotalPar",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "borrow",
+              "type": "uint128"
+            },
+            {
+              "name": "supply",
+              "type": "uint128"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "heldMarketId",
+          "type": "uint256"
+        },
+        {
+          "name": "owedMarketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getLiquidationSpreadForPair",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getNumExcessTokens",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "sign",
+              "type": "bool"
+            },
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getMarketCachedIndex",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "borrow",
+              "type": "uint96"
+            },
+            {
+              "name": "supply",
+              "type": "uint96"
+            },
+            {
+              "name": "lastUpdate",
+              "type": "uint32"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "components": [
+            {
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "name": "number",
+              "type": "uint256"
+            }
+          ],
+          "name": "account",
+          "type": "tuple"
+        }
+      ],
+      "name": "getAccountStatus",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getEarningsRate",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        },
+        {
+          "name": "priceOracle",
+          "type": "address"
+        }
+      ],
+      "name": "ownerSetPriceOracle",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getRiskLimits",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "marginRatioMax",
+              "type": "uint64"
+            },
+            {
+              "name": "liquidationSpreadMax",
+              "type": "uint64"
+            },
+            {
+              "name": "earningsRateMax",
+              "type": "uint64"
+            },
+            {
+              "name": "marginPremiumMax",
+              "type": "uint64"
+            },
+            {
+              "name": "spreadPremiumMax",
+              "type": "uint64"
+            },
+            {
+              "name": "minBorrowedValueMax",
+              "type": "uint128"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getMarket",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "token",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "name": "borrow",
+                  "type": "uint128"
+                },
+                {
+                  "name": "supply",
+                  "type": "uint128"
+                }
+              ],
+              "name": "totalPar",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "name": "borrow",
+                  "type": "uint96"
+                },
+                {
+                  "name": "supply",
+                  "type": "uint96"
+                },
+                {
+                  "name": "lastUpdate",
+                  "type": "uint32"
+                }
+              ],
+              "name": "index",
+              "type": "tuple"
+            },
+            {
+              "name": "priceOracle",
+              "type": "address"
+            },
+            {
+              "name": "interestSetter",
+              "type": "address"
+            },
+            {
+              "components": [
+                {
+                  "name": "value",
+                  "type": "uint256"
+                }
+              ],
+              "name": "marginPremium",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "name": "value",
+                  "type": "uint256"
+                }
+              ],
+              "name": "spreadPremium",
+              "type": "tuple"
+            },
+            {
+              "name": "isClosing",
+              "type": "bool"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        },
+        {
+          "name": "isClosing",
+          "type": "bool"
+        }
+      ],
+      "name": "ownerSetIsClosing",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "operator",
+          "type": "address"
+        },
+        {
+          "name": "approved",
+          "type": "bool"
+        }
+      ],
+      "name": "ownerSetGlobalOperator",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "components": [
+            {
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "name": "number",
+              "type": "uint256"
+            }
+          ],
+          "name": "account",
+          "type": "tuple"
+        }
+      ],
+      "name": "getAdjustedAccountValues",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getMarketMarginPremium",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "marketId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getMarketInterestRate",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "name": "value",
+                  "type": "uint256"
+                }
+              ],
+              "name": "marginRatio",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "name": "value",
+                  "type": "uint256"
+                }
+              ],
+              "name": "liquidationSpread",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "name": "value",
+                  "type": "uint256"
+                }
+              ],
+              "name": "earningsRate",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "name": "value",
+                  "type": "uint256"
+                }
+              ],
+              "name": "minBorrowedValue",
+              "type": "tuple"
+            }
+          ],
+          "name": "riskParams",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "name": "marginRatioMax",
+              "type": "uint64"
+            },
+            {
+              "name": "liquidationSpreadMax",
+              "type": "uint64"
+            },
+            {
+              "name": "earningsRateMax",
+              "type": "uint64"
+            },
+            {
+              "name": "marginPremiumMax",
+              "type": "uint64"
+            },
+            {
+              "name": "spreadPremiumMax",
+              "type": "uint64"
+            },
+            {
+              "name": "minBorrowedValueMax",
+              "type": "uint128"
+            }
+          ],
+          "name": "riskLimits",
+          "type": "tuple"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "operator",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "trusted",
+          "type": "bool"
+        }
+      ],
+      "name": "LogOperatorSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    }
+  ],
+  "metadata": "{\"compiler\":{\"version\":\"0.5.7+commit.6da8b019\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":false,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"spreadPremium\",\"type\":\"tuple\"}],\"name\":\"ownerSetSpreadPremium\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"getIsGlobalOperator\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getMarketTokenAddress\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"},{\"name\":\"interestSetter\",\"type\":\"address\"}],\"name\":\"ownerSetInterestSetter\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"owner\",\"type\":\"address\"},{\"name\":\"number\",\"type\":\"uint256\"}],\"name\":\"account\",\"type\":\"tuple\"}],\"name\":\"getAccountValues\",\"outputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getMarketPriceOracle\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getMarketInterestSetter\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getMarketSpreadPremium\",\"outputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getNumMarkets\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"token\",\"type\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\"}],\"name\":\"ownerWithdrawUnsupportedTokens\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"minBorrowedValue\",\"type\":\"tuple\"}],\"name\":\"ownerSetMinBorrowedValue\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"spread\",\"type\":\"tuple\"}],\"name\":\"ownerSetLiquidationSpread\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"earningsRate\",\"type\":\"tuple\"}],\"name\":\"ownerSetEarningsRate\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"owner\",\"type\":\"address\"},{\"name\":\"operator\",\"type\":\"address\"}],\"name\":\"getIsLocalOperator\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"owner\",\"type\":\"address\"},{\"name\":\"number\",\"type\":\"uint256\"}],\"name\":\"account\",\"type\":\"tuple\"},{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getAccountPar\",\"outputs\":[{\"components\":[{\"name\":\"sign\",\"type\":\"bool\"},{\"name\":\"value\",\"type\":\"uint128\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"marginPremium\",\"type\":\"tuple\"}],\"name\":\"ownerSetMarginPremium\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getMarginRatio\",\"outputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getMarketCurrentIndex\",\"outputs\":[{\"components\":[{\"name\":\"borrow\",\"type\":\"uint96\"},{\"name\":\"supply\",\"type\":\"uint96\"},{\"name\":\"lastUpdate\",\"type\":\"uint32\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getMarketIsClosing\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getRiskParams\",\"outputs\":[{\"components\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"marginRatio\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"liquidationSpread\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"earningsRate\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"minBorrowedValue\",\"type\":\"tuple\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"owner\",\"type\":\"address\"},{\"name\":\"number\",\"type\":\"uint256\"}],\"name\":\"account\",\"type\":\"tuple\"}],\"name\":\"getAccountBalances\",\"outputs\":[{\"name\":\"\",\"type\":\"address[]\"},{\"components\":[{\"name\":\"sign\",\"type\":\"bool\"},{\"name\":\"value\",\"type\":\"uint128\"}],\"name\":\"\",\"type\":\"tuple[]\"},{\"components\":[{\"name\":\"sign\",\"type\":\"bool\"},{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple[]\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getMinBorrowedValue\",\"outputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"components\":[{\"name\":\"operator\",\"type\":\"address\"},{\"name\":\"trusted\",\"type\":\"bool\"}],\"name\":\"args\",\"type\":\"tuple[]\"}],\"name\":\"setOperators\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getMarketPrice\",\"outputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"isOwner\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"},{\"name\":\"recipient\",\"type\":\"address\"}],\"name\":\"ownerWithdrawExcessTokens\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"token\",\"type\":\"address\"},{\"name\":\"priceOracle\",\"type\":\"address\"},{\"name\":\"interestSetter\",\"type\":\"address\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"marginPremium\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"spreadPremium\",\"type\":\"tuple\"}],\"name\":\"ownerAddMarket\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"components\":[{\"name\":\"owner\",\"type\":\"address\"},{\"name\":\"number\",\"type\":\"uint256\"}],\"name\":\"accounts\",\"type\":\"tuple[]\"},{\"components\":[{\"name\":\"actionType\",\"type\":\"uint8\"},{\"name\":\"accountId\",\"type\":\"uint256\"},{\"components\":[{\"name\":\"sign\",\"type\":\"bool\"},{\"name\":\"denomination\",\"type\":\"uint8\"},{\"name\":\"ref\",\"type\":\"uint8\"},{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"amount\",\"type\":\"tuple\"},{\"name\":\"primaryMarketId\",\"type\":\"uint256\"},{\"name\":\"secondaryMarketId\",\"type\":\"uint256\"},{\"name\":\"otherAddress\",\"type\":\"address\"},{\"name\":\"otherAccountId\",\"type\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"actions\",\"type\":\"tuple[]\"}],\"name\":\"operate\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getMarketWithInfo\",\"outputs\":[{\"components\":[{\"name\":\"token\",\"type\":\"address\"},{\"components\":[{\"name\":\"borrow\",\"type\":\"uint128\"},{\"name\":\"supply\",\"type\":\"uint128\"}],\"name\":\"totalPar\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"borrow\",\"type\":\"uint96\"},{\"name\":\"supply\",\"type\":\"uint96\"},{\"name\":\"lastUpdate\",\"type\":\"uint32\"}],\"name\":\"index\",\"type\":\"tuple\"},{\"name\":\"priceOracle\",\"type\":\"address\"},{\"name\":\"interestSetter\",\"type\":\"address\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"marginPremium\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"spreadPremium\",\"type\":\"tuple\"},{\"name\":\"isClosing\",\"type\":\"bool\"}],\"name\":\"\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"borrow\",\"type\":\"uint96\"},{\"name\":\"supply\",\"type\":\"uint96\"},{\"name\":\"lastUpdate\",\"type\":\"uint32\"}],\"name\":\"\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"ratio\",\"type\":\"tuple\"}],\"name\":\"ownerSetMarginRatio\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getLiquidationSpread\",\"outputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"owner\",\"type\":\"address\"},{\"name\":\"number\",\"type\":\"uint256\"}],\"name\":\"account\",\"type\":\"tuple\"},{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getAccountWei\",\"outputs\":[{\"components\":[{\"name\":\"sign\",\"type\":\"bool\"},{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getMarketTotalPar\",\"outputs\":[{\"components\":[{\"name\":\"borrow\",\"type\":\"uint128\"},{\"name\":\"supply\",\"type\":\"uint128\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"heldMarketId\",\"type\":\"uint256\"},{\"name\":\"owedMarketId\",\"type\":\"uint256\"}],\"name\":\"getLiquidationSpreadForPair\",\"outputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getNumExcessTokens\",\"outputs\":[{\"components\":[{\"name\":\"sign\",\"type\":\"bool\"},{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getMarketCachedIndex\",\"outputs\":[{\"components\":[{\"name\":\"borrow\",\"type\":\"uint96\"},{\"name\":\"supply\",\"type\":\"uint96\"},{\"name\":\"lastUpdate\",\"type\":\"uint32\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"owner\",\"type\":\"address\"},{\"name\":\"number\",\"type\":\"uint256\"}],\"name\":\"account\",\"type\":\"tuple\"}],\"name\":\"getAccountStatus\",\"outputs\":[{\"name\":\"\",\"type\":\"uint8\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getEarningsRate\",\"outputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"},{\"name\":\"priceOracle\",\"type\":\"address\"}],\"name\":\"ownerSetPriceOracle\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getRiskLimits\",\"outputs\":[{\"components\":[{\"name\":\"marginRatioMax\",\"type\":\"uint64\"},{\"name\":\"liquidationSpreadMax\",\"type\":\"uint64\"},{\"name\":\"earningsRateMax\",\"type\":\"uint64\"},{\"name\":\"marginPremiumMax\",\"type\":\"uint64\"},{\"name\":\"spreadPremiumMax\",\"type\":\"uint64\"},{\"name\":\"minBorrowedValueMax\",\"type\":\"uint128\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getMarket\",\"outputs\":[{\"components\":[{\"name\":\"token\",\"type\":\"address\"},{\"components\":[{\"name\":\"borrow\",\"type\":\"uint128\"},{\"name\":\"supply\",\"type\":\"uint128\"}],\"name\":\"totalPar\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"borrow\",\"type\":\"uint96\"},{\"name\":\"supply\",\"type\":\"uint96\"},{\"name\":\"lastUpdate\",\"type\":\"uint32\"}],\"name\":\"index\",\"type\":\"tuple\"},{\"name\":\"priceOracle\",\"type\":\"address\"},{\"name\":\"interestSetter\",\"type\":\"address\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"marginPremium\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"spreadPremium\",\"type\":\"tuple\"},{\"name\":\"isClosing\",\"type\":\"bool\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"},{\"name\":\"isClosing\",\"type\":\"bool\"}],\"name\":\"ownerSetIsClosing\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"operator\",\"type\":\"address\"},{\"name\":\"approved\",\"type\":\"bool\"}],\"name\":\"ownerSetGlobalOperator\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"owner\",\"type\":\"address\"},{\"name\":\"number\",\"type\":\"uint256\"}],\"name\":\"account\",\"type\":\"tuple\"}],\"name\":\"getAdjustedAccountValues\",\"outputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getMarketMarginPremium\",\"outputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"marketId\",\"type\":\"uint256\"}],\"name\":\"getMarketInterestRate\",\"outputs\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"marginRatio\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"liquidationSpread\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"earningsRate\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"minBorrowedValue\",\"type\":\"tuple\"}],\"name\":\"riskParams\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"marginRatioMax\",\"type\":\"uint64\"},{\"name\":\"liquidationSpreadMax\",\"type\":\"uint64\"},{\"name\":\"earningsRateMax\",\"type\":\"uint64\"},{\"name\":\"marginPremiumMax\",\"type\":\"uint64\"},{\"name\":\"spreadPremiumMax\",\"type\":\"uint64\"},{\"name\":\"minBorrowedValueMax\",\"type\":\"uint128\"}],\"name\":\"riskLimits\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"operator\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"trusted\",\"type\":\"bool\"}],\"name\":\"LogOperatorSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"}],\"devdoc\":{\"author\":\"dYdX * Main contract that inherits from other contracts\",\"methods\":{\"getAccountBalances((address,uint256))\":{\"params\":{\"account\":\"The account to query\"},\"return\":\"The following values:                  - The ERC20 token address for each market                  - The account's principal value for each market                  - The account's (supplied or borrowed) number of tokens for each market\"},\"getAccountPar((address,uint256),uint256)\":{\"params\":{\"account\":\"The account to query\",\"marketId\":\"The market to query\"},\"return\":\"The principal value\"},\"getAccountStatus((address,uint256))\":{\"params\":{\"account\":\"The account to query\"},\"return\":\"The account's status\"},\"getAccountValues((address,uint256))\":{\"params\":{\"account\":\"The account to query\"},\"return\":\"The following values:                  - The supplied value of the account                  - The borrowed value of the account\"},\"getAccountWei((address,uint256),uint256)\":{\"params\":{\"account\":\"The account to query\",\"marketId\":\"The market to query\"},\"return\":\"The token amount\"},\"getAdjustedAccountValues((address,uint256))\":{\"params\":{\"account\":\"The account to query\"},\"return\":\"The following values:                  - The supplied value of the account (adjusted for marginPremium)                  - The borrowed value of the account (adjusted for marginPremium)\"},\"getEarningsRate()\":{\"return\":\"The global earnings rate\"},\"getIsGlobalOperator(address)\":{\"params\":{\"operator\":\"The address to query\"},\"return\":\"True if operator is a global operator\"},\"getIsLocalOperator(address,address)\":{\"params\":{\"operator\":\"The possible operator\",\"owner\":\"The owner of the accounts\"},\"return\":\"True if operator is approved for owner's accounts\"},\"getLiquidationSpread()\":{\"return\":\"The global liquidation spread\"},\"getLiquidationSpreadForPair(uint256,uint256)\":{\"params\":{\"heldMarketId\":\"The market for which the account has collateral\",\"owedMarketId\":\"The market for which the account has borrowed tokens\"},\"return\":\"The adjusted liquidation spread\"},\"getMarginRatio()\":{\"return\":\"The global margin-ratio\"},\"getMarket(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"A Storage.Market struct with the current state of the market\"},\"getMarketCachedIndex(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"The most recent index\"},\"getMarketCurrentIndex(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"The estimated current index\"},\"getMarketInterestRate(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"The current interest rate\"},\"getMarketInterestSetter(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"The interest-setter address\"},\"getMarketIsClosing(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"True if the market is closing\"},\"getMarketMarginPremium(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"The market's margin premium\"},\"getMarketPrice(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"The price of each atomic unit of the token\"},\"getMarketPriceOracle(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"The price oracle address\"},\"getMarketSpreadPremium(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"The market's spread premium\"},\"getMarketTokenAddress(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"The token address\"},\"getMarketTotalPar(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"The total principal amounts\"},\"getMarketWithInfo(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"A tuple containing the values:                   - A Storage.Market struct with the current state of the market                   - The current estimated interest index                   - The current token price                   - The current market interest rate\"},\"getMinBorrowedValue()\":{\"return\":\"The global minimum borrow value\"},\"getNumExcessTokens(uint256)\":{\"params\":{\"marketId\":\"The market to query\"},\"return\":\"The number of excess tokens\"},\"getNumMarkets()\":{\"return\":\"The number of markets\"},\"getRiskLimits()\":{\"return\":\"All global risk parameter limnits\"},\"getRiskParams()\":{\"return\":\"All global risk parameters\"},\"isOwner()\":{\"return\":\"true if `msg.sender` is the owner of the contract.\"},\"operate((address,uint256)[],(uint8,uint256,(bool,uint8,uint8,uint256),uint256,uint256,address,uint256,bytes)[])\":{\"params\":{\"accounts\":\"A list of all accounts that will be used in this operation. Cannot contain                  duplicates. In each action, the relevant account will be referred-to by its                  index in the list.\",\"actions\":\"An ordered list of all actions that will be taken in this operation. The                  actions will be processed in order.\"}},\"owner()\":{\"return\":\"the address of the owner.\"},\"renounceOwnership()\":{\"details\":\"Allows the current owner to relinquish control of the contract.\"},\"setOperators((address,bool)[])\":{\"params\":{\"args\":\"A list of OperatorArgs which have an address and a boolean. The boolean value              denotes whether to approve (true) or revoke approval (false) for that address.\"}},\"transferOwnership(address)\":{\"details\":\"Allows the current owner to transfer control of the contract to a newOwner.\",\"params\":{\"newOwner\":\"The address to transfer ownership to.\"}}},\"title\":\"SoloMargin\"},\"userdoc\":{\"methods\":{\"getAccountBalances((address,uint256))\":{\"notice\":\"Get an account's summary for each market.\"},\"getAccountPar((address,uint256),uint256)\":{\"notice\":\"Get the principal value for a particular account and market.\"},\"getAccountStatus((address,uint256))\":{\"notice\":\"Get the status of an account (Normal, Liquidating, or Vaporizing).\"},\"getAccountValues((address,uint256))\":{\"notice\":\"Get the total supplied and total borrowed value of an account.\"},\"getAccountWei((address,uint256),uint256)\":{\"notice\":\"Get the token balance for a particular account and market.\"},\"getAdjustedAccountValues((address,uint256))\":{\"notice\":\"Get the total supplied and total borrowed values of an account adjusted by the marginPremium of each market. Supplied values are divided by (1 + marginPremium) for each market and borrowed values are multiplied by (1 + marginPremium) for each market. Comparing these adjusted values gives the margin-ratio of the account which will be compared to the global margin-ratio when determining if the account can be liquidated.\"},\"getEarningsRate()\":{\"notice\":\"Get the global earnings-rate variable that determines what percentage of the interest paid by borrowers gets passed-on to suppliers.\"},\"getIsGlobalOperator(address)\":{\"notice\":\"Return true if a particular address is approved as a global operator. Such an address can act on any account as if it were the operator's own.\"},\"getIsLocalOperator(address,address)\":{\"notice\":\"Return true if a particular address is approved as an operator for an owner's accounts. Approved operators can act on the accounts of the owner as if it were the operator's own.\"},\"getLiquidationSpread()\":{\"notice\":\"Get the global liquidation spread. This is the spread between oracle prices that incentivizes the liquidation of risky positions.\"},\"getLiquidationSpreadForPair(uint256,uint256)\":{\"notice\":\"Get the adjusted liquidation spread for some market pair. This is equal to the global liquidation spread multiplied by (1 + spreadPremium) for each of the two markets.\"},\"getMarginRatio()\":{\"notice\":\"Get the global minimum margin-ratio that every position must maintain to prevent being liquidated.\"},\"getMarket(uint256)\":{\"notice\":\"Get basic information about a particular market.\"},\"getMarketCachedIndex(uint256)\":{\"notice\":\"Get the most recently cached interest index for a market.\"},\"getMarketCurrentIndex(uint256)\":{\"notice\":\"Get the interest index for a market if it were to be updated right now.\"},\"getMarketInterestRate(uint256)\":{\"notice\":\"Get the current borrower interest rate for a market.\"},\"getMarketInterestSetter(uint256)\":{\"notice\":\"Get the interest-setter address for a market.\"},\"getMarketIsClosing(uint256)\":{\"notice\":\"Return true if a particular market is in closing mode. Additional borrows cannot be taken from a market that is closing.\"},\"getMarketMarginPremium(uint256)\":{\"notice\":\"Get the margin premium for a market. A margin premium makes it so that any positions that include the market require a higher collateralization to avoid being liquidated.\"},\"getMarketPrice(uint256)\":{\"notice\":\"Get the price of the token for a market.\"},\"getMarketPriceOracle(uint256)\":{\"notice\":\"Get the price oracle address for a market.\"},\"getMarketSpreadPremium(uint256)\":{\"notice\":\"Get the spread premium for a market. A spread premium makes it so that any liquidations that include the market have a higher spread than the global default.\"},\"getMarketTokenAddress(uint256)\":{\"notice\":\"Get the ERC20 token address for a market.\"},\"getMarketTotalPar(uint256)\":{\"notice\":\"Get the total principal amounts (borrowed and supplied) for a market.\"},\"getMarketWithInfo(uint256)\":{\"notice\":\"Get comprehensive information about a particular market.\"},\"getMinBorrowedValue()\":{\"notice\":\"Get the global minimum-borrow value which is the minimum value of any new borrow on Solo.\"},\"getNumExcessTokens(uint256)\":{\"notice\":\"Get the number of excess tokens for a market. The number of excess tokens is calculated by taking the current number of tokens held in Solo, adding the number of tokens owed to Solo by borrowers, and subtracting the number of tokens owed to suppliers by Solo.\"},\"getNumMarkets()\":{\"notice\":\"Get the total number of markets.\"},\"getRiskLimits()\":{\"notice\":\"Get all risk parameter limits in a single struct. These are the maximum limits at which the risk parameters can be set by the admin of Solo.\"},\"getRiskParams()\":{\"notice\":\"Get all risk parameters in a single struct.\"},\"operate((address,uint256)[],(uint8,uint256,(bool,uint8,uint8,uint256),uint256,uint256,address,uint256,bytes)[])\":{\"notice\":\"The main entry-point to Solo that allows users and contracts to manage accounts. Take one or more actions on one or more accounts. The msg.sender must be the owner or operator of all accounts except for those being liquidated, vaporized, or traded with. One call to operate() is considered a singular \\\"operation\\\". Account collateralization is ensured only after the completion of the entire operation.\"},\"ownerAddMarket(address,address,address,(uint256),(uint256))\":{\"notice\":\"Add a new market to Solo. Must be for a previously-unsupported ERC20 token.\"},\"ownerSetEarningsRate((uint256))\":{\"notice\":\"Set the global earnings-rate variable that determines what percentage of the interest paid by borrowers gets passed-on to suppliers.\"},\"ownerSetGlobalOperator(address,bool)\":{\"notice\":\"Approve (or disapprove) an address that is permissioned to be an operator for all accounts in Solo. Intended only to approve smart-contracts.\"},\"ownerSetInterestSetter(uint256,address)\":{\"notice\":\"Set the interest-setter for a market.\"},\"ownerSetIsClosing(uint256,bool)\":{\"notice\":\"Set (or unset) the status of a market to \\\"closing\\\". The borrowedValue of a market cannot increase while its status is \\\"closing\\\".\"},\"ownerSetLiquidationSpread((uint256))\":{\"notice\":\"Set the global liquidation spread. This is the spread between oracle prices that incentivizes the liquidation of risky positions.\"},\"ownerSetMarginPremium(uint256,(uint256))\":{\"notice\":\"Set a premium on the minimum margin-ratio for a market. This makes it so that any positions that include this market require a higher collateralization to avoid being liquidated.\"},\"ownerSetMarginRatio((uint256))\":{\"notice\":\"Set the global minimum margin-ratio that every position must maintain to prevent being liquidated.\"},\"ownerSetMinBorrowedValue((uint256))\":{\"notice\":\"Set the global minimum-borrow value which is the minimum value of any new borrow on Solo.\"},\"ownerSetPriceOracle(uint256,address)\":{\"notice\":\"Set the price oracle for a market.\"},\"ownerSetSpreadPremium(uint256,(uint256))\":{\"notice\":\"Set a premium on the liquidation spread for a market. This makes it so that any liquidations that include this market have a higher spread than the global default.\"},\"ownerWithdrawExcessTokens(uint256,address)\":{\"notice\":\"Withdraw an ERC20 token for which there is an associated market. Only excess tokens can be withdrawn. The number of excess tokens is calculated by taking the current number of tokens held in Solo, adding the number of tokens owed to Solo by borrowers, and subtracting the number of tokens owed to suppliers by Solo.\"},\"ownerWithdrawUnsupportedTokens(address,address)\":{\"notice\":\"Withdraw an ERC20 token for which there is no associated market.\"},\"renounceOwnership()\":{\"notice\":\"Renouncing to ownership will leave the contract without an owner. It will not be possible to call the functions with the `onlyOwner` modifier anymore.\"},\"setOperators((address,bool)[])\":{\"notice\":\"Approves/disapproves any number of operators. An operator is an external address that has the same permissions to manipulate an account as the owner of the account. Operators are simply addresses and therefore may either be externally-owned Ethereum accounts OR smart contracts.     * Operators are also able to act as AutoTrader contracts on behalf of the account owner if the operator is a smart contract and implements the IAutoTrader interface.\"}}}},\"settings\":{\"compilationTarget\":{\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/SoloMargin.sol\":\"SoloMargin\"},\"evmVersion\":\"byzantium\",\"libraries\":{},\"optimizer\":{\"enabled\":true,\"runs\":10000},\"remappings\":[]},\"sources\":{\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/Admin.sol\":{\"keccak256\":\"0xf0c68f3d62c7f3e6138b8060c5e4de0498e6840ece10dbf5bff7eb965e249242\",\"urls\":[\"bzzr://ca7761cde5dc880b9a52e0c109ab0f2c1e4f503499f88a3015ee8ce73041e2be\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/Getters.sol\":{\"keccak256\":\"0x37cfba49699e037c12bdb52c00a72c1714f7e00334d16dba27b9072b9cb8705f\",\"urls\":[\"bzzr://92838931cb66fe28b11a6301ab841e236ff21595a692d142820021b394e525af\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/Operation.sol\":{\"keccak256\":\"0x851643bbda019072de0ee1acab8ae730b2917edb8efda0800d77be1607a60d9f\",\"urls\":[\"bzzr://c010a5ab40450595c71643ae6a1a0924dd1d12df05b672a7429bdf0801b98bbb\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/Permission.sol\":{\"keccak256\":\"0x979cc19cdbfee86afc8c3fb4992e6adbed14bb91bc0ba3c555ae4b385c5d1800\",\"urls\":[\"bzzr://f00315a9a80620a1c2c7760fda6900eee2786f1f5fe59aeea56900b214c1d630\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/SoloMargin.sol\":{\"keccak256\":\"0xf7d64da95033d6c8740872a34ad8bf324417712df69cfe6aa31b7f4b125f154f\",\"urls\":[\"bzzr://bea6fbd9b9ca5e6bcbfa67bb76db0b28b8f715c1fe4191529fcf428abd16613c\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/State.sol\":{\"keccak256\":\"0x5714e47e67861242ddb9563681aeccf0e6f1c42dec9e27ec29ff248785cdd25a\",\"urls\":[\"bzzr://4862c97a9f382291472c3954fd3dc279b00ae3d37daed8287491e5a9b9b5d584\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/impl/AdminImpl.sol\":{\"keccak256\":\"0x6c37d2a0a51367c837224e8e56f8ccb30d8a51abd96f2280f25a5bd263b11bdf\",\"urls\":[\"bzzr://8d7208c7261de48b49450e12496db21b994d4b2bd8143842be2f9c78d7db1ce2\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/impl/OperationImpl.sol\":{\"keccak256\":\"0x7042bf56dd98e9fef064493bfd79e1710fd0586fab5b98dcbc0ddebafc1fa3c5\",\"urls\":[\"bzzr://cd20b5da43faff4160dcb0298600c8edfaf8647e818a2ca2a34db47f30d57e72\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/interfaces/IAutoTrader.sol\":{\"keccak256\":\"0xa416051ccd2a83cc5a77e86591a4a3fc093ceb5f42ca7b1d7c8e8d35c79ddb5b\",\"urls\":[\"bzzr://9ad6198a2fcb288d5485b3f2e9042815ec644f85c0ab884b0a2667250780cee5\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/interfaces/ICallee.sol\":{\"keccak256\":\"0x3904aba675b36e1e5e98f8e1e20404287da48adefd527fe8f2e21d9d0439b4ac\",\"urls\":[\"bzzr://1097cf3fd9bdce4abf90e2ce0611c45e39c8a33baf7bdb9e1996e7718530c124\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/interfaces/IErc20.sol\":{\"keccak256\":\"0x6a972ae5d9fcb4e3f44589dc77ac3c168061c09a0a9001f29fdc2e361d044946\",\"urls\":[\"bzzr://e467ccb83dd015c9ca4862f3e95b7fd8c17c1cfd0a15a3dc799209967cf537ac\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/interfaces/IExchangeWrapper.sol\":{\"keccak256\":\"0xa4983e5de7559a9e7236e71d3d089a85eea413ac1f03f8365bac3c5eb0ce0ac8\",\"urls\":[\"bzzr://80338d73c68e6c6649def643dc4c6ae4b1cee4c8e117435f6becc30846e85fa2\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/interfaces/IInterestSetter.sol\":{\"keccak256\":\"0xb675679876a8163f224dfc4f6598a168f8248400a49ab836fdd2a7f4d25a1683\",\"urls\":[\"bzzr://1597c0ec5015093d8d0a91af168e5e89c91ba615abc65048ed721195040ec0f8\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/interfaces/IPriceOracle.sol\":{\"keccak256\":\"0x647a7519803283e4152e0617881f0cf2766f8968cd1de9f28d624ee164adf19a\",\"urls\":[\"bzzr://0cb0053f7cfea2c823036aef20a99b63e5037fa9de5d55116a10374a45c7b828\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Account.sol\":{\"keccak256\":\"0x4c27c617b01972ddb8ca160454284ed09f3ec6f7abd667c31ca9f38805738d33\",\"urls\":[\"bzzr://ad0dd4229cea4f8c5b877a653766cf413d733e442cfc448ffd715e786d7b5216\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Actions.sol\":{\"keccak256\":\"0xa3def9f1d58c1a353cd5412df8027674226000fd0b1cf52f3e11d6b4428fe2dc\",\"urls\":[\"bzzr://955e36c7bd9e222b58764b755169056c4225fc0561fdd88bb71ce7f1e2782a41\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Cache.sol\":{\"keccak256\":\"0x5caa444f1798e385674713fef9b8190088f3a31655ae918340ff755e26566c82\",\"urls\":[\"bzzr://23b8e2e44d3db5588ff1311520e24272255f7b8d23c0923e955f51d5a4397beb\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Decimal.sol\":{\"keccak256\":\"0xfddbafc617a77d1db59ddbc596f6aa22931a9a656c0755887648c09bb038ae8c\",\"urls\":[\"bzzr://40396a3a6ded6bb9fe5b5c4b0318f7518ce23c925b104f557310a3775e6e383d\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Events.sol\":{\"keccak256\":\"0x8467cdc3f69a617a6ae9b3c0921abce180ebcfb0bc9deb6f59f96f2e149b9ad5\",\"urls\":[\"bzzr://44973ebae91505e96610b4732d31b98d2bbab2b1b48875e528ba6e26cbd097e4\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Exchange.sol\":{\"keccak256\":\"0xaea9d9746796378d2e191ccf47569c0acc728342ff948817061179724d4f52e8\",\"urls\":[\"bzzr://2b73f2c0c7726ebea3301504334110b5b2a2d3271fe298bef29b8ccccaf0bb6a\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Interest.sol\":{\"keccak256\":\"0x657f152e3853377ea93d101e145c2f2969fb6fbde025cedd10e7ee17c8bd5c4c\",\"urls\":[\"bzzr://ec53ea6522f8a1ae4150e1c8718f6d7d20d1755b93f4ee6268fd67bd979fa0f9\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Math.sol\":{\"keccak256\":\"0x05162cffa6d5479b6555e03af67b75e63d85272a3c3d3d2630a127ffa811ba41\",\"urls\":[\"bzzr://0e784dccf35201ef16030ec531028252d590936d75f0200f368a7e5981046af4\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Monetary.sol\":{\"keccak256\":\"0x6f876a958c45fb1f2cefce1d7ee0ceb610fbe393e0040ad2d5680e0aa5536e54\",\"urls\":[\"bzzr://8b027c6ce5cd901a634dab7de74d617098b706d50b1c2ea0636406e021ea2815\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Require.sol\":{\"keccak256\":\"0xa72741bce6d0d2b306dc4164f0face04fbfd7a75dbee4e7fa9d9117ff9014a8d\",\"urls\":[\"bzzr://1582848efe93cf77b51c08bd73b24a217b4fa4ee54361d8eca113891d5f267ad\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Storage.sol\":{\"keccak256\":\"0x862bb5cf49dd4415b2659d2815021bb97392d3bd11a32ae2803d9f85ecc947b4\",\"urls\":[\"bzzr://3c48763c77cfd222a379a7be791a4341f355e76f35bc4c62e16264fa0f71f23e\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Time.sol\":{\"keccak256\":\"0x6523f89764a33b986f6655b5a0fb5b375103153be606b07a9fa95ceb2b93c2f6\",\"urls\":[\"bzzr://61ff7be71d666649cf1b78c2d9950e0d58322932e7e5f6742adbe511e864cd51\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Token.sol\":{\"keccak256\":\"0x7fff4d94f462515466ed263d686abb7fff9b6d6c95a28662a64a8424f5d95a23\",\"urls\":[\"bzzr://41bc60c90477c5ddab82a7760c652d87cce21dadb00456e028ff37b849bd13f4\"]},\"/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Types.sol\":{\"keccak256\":\"0x35c04c154e9ef818a3e1b59eb748565645864d5f8f2bc696c1f425a8ade9ab00\",\"urls\":[\"bzzr://8b2db9cb583f79fc2b74a70b270667f6a3bc54c3afef6a2d56e0d2ec5b8ca725\"]},\"openzeppelin-solidity/contracts/math/SafeMath.sol\":{\"keccak256\":\"0x965012d27b4262d7a41f5028cbb30c51ebd9ecd4be8fb30380aaa7a3c64fbc8b\",\"urls\":[\"bzzr://41ca38f6b0fa4b77b0feec43e422cfbec48b7eb38a41edf0b85c77e8d9a296b1\"]},\"openzeppelin-solidity/contracts/ownership/Ownable.sol\":{\"keccak256\":\"0x980de387a1a020a498f53d00f89fecebb12c949a17e8f160093c0303ede2b786\",\"urls\":[\"bzzr://08894efa2a557982070beda6a81a032407e70532d24bdafe80d39660c74904d9\"]},\"openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol\":{\"keccak256\":\"0x58e8ca389c46941a0bfc26b91025d3427864bd9070a7762f90d29677cd3f3dd8\",\"urls\":[\"bzzr://5c079549429384de9624a5686a33649e7e637bf0b715773182e77dffc9ea4c38\"]}},\"version\":1}",
+  "bytecode": "0x60806040527f4765747465727300000000000000000000000000000000000000000000000000600d553480156200003557600080fd5b50604051610140806200459b833981018060405262000058919081019062000336565b600b8054600160a060020a031916331790819055604051600160a060020a0391909116906000907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908290a36001600c5581515160055560208083015151600655604080840151516007556060938401515160085582516009805493850151928501519585015167ffffffffffffffff199485166001604060020a0393841617604060020a608060020a03191668010000000000000000948416850217608060020a60c060020a0319167001000000000000000000000000000000009784169790970296909617600160c060020a0316780100000000000000000000000000000000000000000000000096831696909602959095179094556080830151600a805460a09095015194909316941693909317604060020a60c060020a0319166001608060020a03909216909202179055620003b8565b600060208284031215620001c057600080fd5b620001cc602062000376565b90506000620001dc84846200031a565b82525092915050565b600060c08284031215620001f857600080fd5b6200020460c062000376565b9050600062000214848462000328565b8252506020620002278484830162000328565b60208301525060406200023d8482850162000328565b6040830152506060620002538482850162000328565b6060830152506080620002698482850162000328565b60808301525060a06200027f8482850162000305565b60a08301525092915050565b6000608082840312156200029e57600080fd5b620002aa608062000376565b90506000620002ba8484620001ad565b8252506020620002cd84848301620001ad565b6020830152506040620002e384828501620001ad565b6040830152506060620002f984828501620001ad565b60608301525092915050565b60006200031382516200039d565b9392505050565b6000620003138251620003a9565b6000620003138251620003ac565b60008061014083850312156200034b57600080fd5b60006200035985856200028b565b92505060806200036c85828601620001e5565b9150509250929050565b6040518181016001604060020a03811182821017156200039557600080fd5b604052919050565b6001608060020a031690565b90565b6001604060020a031690565b6141d380620003c86000396000f3fe608060405234801561001057600080fd5b5060043610610348576000357c0100000000000000000000000000000000000000000000000000000000900480638928378e116101cf578063d5ecf7c511610116578063eb44fdd3116100bf578063f2fde38b11610099578063f2fde38b14610717578063f94160521461072a578063fd04b6061461073d578063fd47eda61461075057610348565b8063eb44fdd3146106d1578063ef6957d0146106f1578063f2901ae21461070457610348565b8063e5520228116100f0578063e5520228146106a1578063e8e72f75146106a9578063eb1c6e6b146106bc57610348565b8063d5ecf7c51461065b578063deec053d1461066e578063e51bfcb41461068157610348565b8063b548b89211610178578063c190c2ec11610152578063c190c2ec14610608578063cb04a34c14610628578063d24c48bc1461064857610348565b8063b548b892146105ca578063c0bb72b7146105ed578063c14609421461060057610348565b80638f6bc659116101a95780638f6bc65914610591578063982f323c146105a4578063a67a6a45146105b757610348565b80638928378e1461056e5780638da5cb5b146105815780638f32d59b1461058957610348565b8063387a498a116102935780635ac7d17c1161023c578063715018a611610216578063715018a61461054b5780637e9eaf411461055357806385b53fc81461055b57610348565b80635ac7d17c1461050157806369794795146105145780636a8194e71461052957610348565b80634be874141161026d5780634be87414146104c65780634f3c1542146104d957806356ea84b2146104e157610348565b8063387a498a146104805780633a031bf01461049357806347d1b53c146104a657610348565b8063197f0f05116102f55780632a560845116102cf5780632a560845146104475780632e822af31461045a5780633063bce21461046d57610348565b8063197f0f05146103ff5780631a7777bb14610412578063295c39a51461043257610348565b8063121fb72f11610326578063121fb72f146103ab578063124f914c146103be57806313368364146103df57610348565b8063042069d61461034d578063052f72d714610362578063062bd3e91461038b575b600080fd5b61036061035b366004613594565b610763565b005b6103756103703660046132cf565b610817565b6040516103829190613cf4565b60405180910390f35b61039e6103993660046134ea565b610831565b6040516103829190613c6a565b6103606103b9366004613564565b61084d565b6103d16103cc36600461347e565b6108be565b604051610382929190613f4a565b6103f26103ed3660046134ea565b6108e2565b6040516103829190613d02565b6103f261040d3660046134ea565b610919565b6104256104203660046134ea565b610950565b6040516103829190613d2f565b61043a610987565b6040516103829190613f66565b61043a6104553660046132ed565b61098d565b610360610468366004613460565b610a67565b61036061047b366004613460565b610b18565b61036061048e366004613460565b610b87565b6103756104a13660046132ed565b610bf6565b6104b96104b436600461349c565b610c12565b6040516103829190613d93565b6103606104d4366004613594565b610c35565b610425610ca6565b6104f46104ef3660046134ea565b610cc2565b6040516103829190613d3d565b61037561050f3660046134ea565b610cf7565b61051c610d1b565b6040516103829190613daf565b61053c61053736600461347e565b610d77565b60405161038293929190613cbb565b610360610ee5565b610425610f65565b61036061056936600461342b565b610f81565b61042561057c3660046134ea565b611064565b61039e611086565b6103756110a2565b61043a61059f366004613526565b6110c0565b6103606105b2366004613357565b611133565b6103606105c53660046133cc565b6111f0565b6105dd6105d83660046134ea565b611250565b6040516103829493929190613d5a565b6103606105fb366004613460565b6112ac565b61042561131b565b61061b61061636600461349c565b611337565b6040516103829190613f58565b61063b6106363660046134ea565b611377565b6040516103829190613f3c565b6104256106563660046135c4565b611399565b61061b6106693660046134ea565b6113c5565b6104f461067c3660046134ea565b6113e7565b61069461068f36600461347e565b611409565b6040516103829190613d10565b61042561141b565b6103606106b7366004613564565b611437565b6106c46114a8565b6040516103829190613da1565b6106e46106df3660046134ea565b61154a565b6040516103829190613d4b565b6103606106ff366004613545565b611689565b610360610712366004613327565b6116fa565b6103606107253660046132cf565b61176b565b6103d161073836600461347e565b611788565b61042561074b3660046134ea565b6117a3565b61042561075e3660046134ea565b6117da565b61076b6110a2565b61077457600080fd5b600c8054600101908190556040517f8854ab3e00000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________90638854ab3e906107d49060009087908790600401613f14565b60006040518083038186803b1580156107ec57600080fd5b505af4158015610800573d6000803e3d6000fd5b50505050600c54811461081257600080fd5b505050565b6000610829818363ffffffff61180f16565b90505b919050565b600061083c8261183e565b61082960008363ffffffff61187116565b6108556110a2565b61085e57600080fd5b600c8054600101908190556040517faa92e34800000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________9063aa92e348906107d49060009087908790600401613eec565b6108c6612d4f565b6108ce612d4f565b6108d983600061189d565b91509150915091565b60006108ed8261183e565b5060009081526001602052604090206003015473ffffffffffffffffffffffffffffffffffffffff1690565b60006109248261183e565b5060009081526001602052604090206004015473ffffffffffffffffffffffffffffffffffffffff1690565b610958612d4f565b6109618261183e565b506000908152600160209081526040918290208251918201909252600690910154815290565b60005490565b60006109976110a2565b6109a057600080fd5b600c8054600101908190556040517fdd32998a00000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________9063dd32998a90610a009060009088908890600401613dbd565b60206040518083038186803b158015610a1857600080fd5b505af4158015610a2c573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250610a509190810190613508565b9150600c548114610a6057600080fd5b5092915050565b610a6f6110a2565b610a7857600080fd5b600c8054600101908190556040517ff9cacc4c00000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________9063f9cacc4c90610ad6906000908690600401613e9b565b60006040518083038186803b158015610aee57600080fd5b505af4158015610b02573d6000803e3d6000fd5b50505050600c548114610b1457600080fd5b5050565b610b206110a2565b610b2957600080fd5b600c8054600101908190556040517f0f44e6bc00000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________90630f44e6bc90610ad6906000908690600401613e9b565b610b8f6110a2565b610b9857600080fd5b600c8054600101908190556040517f311401d000000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________9063311401d090610ad6906000908690600401613e9b565b6000610c0981848463ffffffff61192916565b90505b92915050565b610c1a612d62565b610c238261183e565b610c096000848463ffffffff61196916565b610c3d6110a2565b610c4657600080fd5b600c8054600101908190556040517f7335079b00000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________90637335079b906107d49060009087908790600401613f14565b610cae612d4f565b506040805160208101909152600554815290565b610cca612d79565b610cd38261183e565b61082982610ce860008263ffffffff6119e516565b6000919063ffffffff611a6916565b6000610d028261183e565b5060009081526001602052604090206007015460ff1690565b610d23612d99565b506040805160a0810182526005546080820190815281528151602081810184526006548252808301919091528251808201845260075481528284015282519081019092526008548252606081019190915290565b6060806060600080600001549050606081604051908082528060200260200182016040528015610db1578160200160208202803883390190505b509050606082604051908082528060200260200182016040528015610df057816020015b610ddd612d62565b815260200190600190039081610dd55790505b509050606083604051908082528060200260200182016040528015610e2f57816020015b610e1c612d62565b815260200190600190039081610e145790505b50905060005b84811015610ed657610e4681610831565b848281518110610e5257fe5b602002602001019073ffffffffffffffffffffffffffffffffffffffff16908173ffffffffffffffffffffffffffffffffffffffff1681525050610e968982610c12565b838281518110610ea257fe5b6020026020010181905250610eb78982611337565b828281518110610ec357fe5b6020908102919091010152600101610e35565b50919790965090945092505050565b610eed6110a2565b610ef657600080fd5b600b5460405160009173ffffffffffffffffffffffffffffffffffffffff16907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908390a3600b80547fffffffffffffffffffffffff0000000000000000000000000000000000000000169055565b610f6d612d4f565b506040805160208101909152600854815290565b60005b8151811015610b14576000828281518110610f9b57fe5b60200260200101516000015190506000838381518110610fb757fe5b60209081029190910181015181015133600081815260038452604080822073ffffffffffffffffffffffffffffffffffffffff8816835290945283902080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff001683151517905591519092507f4d7f317d2088d039c2a95a09fcbf9cc9191fad5905f883c937cc3d317c4a6327906110529085908590613c78565b60405180910390a25050600101610f84565b61106c612d4f565b6110758261183e565b61082960008363ffffffff611ac116565b600b5473ffffffffffffffffffffffffffffffffffffffff1690565b600b5473ffffffffffffffffffffffffffffffffffffffff16331490565b60006110ca6110a2565b6110d357600080fd5b600c8054600101908190556040517fb25328e000000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________9063b25328e090610a009060009088908890600401613eb6565b61113b6110a2565b61114457600080fd5b600c8054600101908190556040517f48d0648400000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________906348d06484906111aa906000908a908a908a908a908a90600401613e0d565b60006040518083038186803b1580156111c257600080fd5b505af41580156111d6573d6000803e3d6000fd5b50505050600c5481146111e857600080fd5b505050505050565b600c8054600101908190556040517fbd76ecfd00000000000000000000000000000000000000000000000000000000815273__OperationImpl_________________________9063bd76ecfd906107d49060009087908790600401613e67565b611258612dd8565b611260612d79565b611268612d4f565b611270612d4f565b6112798561183e565b6112828561154a565b61128b86610cc2565b61129487611064565b61129d886117da565b93509350935093509193509193565b6112b46110a2565b6112bd57600080fd5b600c8054600101908190556040517f54dd351600000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________906354dd351690610ad6906000908690600401613e9b565b611323612d4f565b506040805160208101909152600654815290565b61133f612d62565b6113488261183e565b610c0961135d6000858563ffffffff61196916565b61137284610ce860008263ffffffff6119e516565b611c0a565b61137f612d62565b6113888261183e565b61082960008363ffffffff611cbb16565b6113a1612d4f565b6113aa8361183e565b6113b38261183e565b610c096000848463ffffffff611d1b16565b6113cd612d62565b6113d68261183e565b61082960008363ffffffff611db116565b6113ef612d79565b6113f88261183e565b61082960008363ffffffff6119e516565b6000610829818363ffffffff611e7716565b611423612d4f565b506040805160208101909152600754815290565b61143f6110a2565b61144857600080fd5b600c8054600101908190556040517f8c5dabd100000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________90638c5dabd1906107d49060009087908790600401613eec565b6114b0612e4b565b506040805160c08101825260095467ffffffffffffffff808216835268010000000000000000808304821660208501527001000000000000000000000000000000008304821694840194909452780100000000000000000000000000000000000000000000000090910481166060830152600a549081166080830152919091046fffffffffffffffffffffffffffffffff1660a082015290565b611552612dd8565b61155b8261183e565b50600090815260016020818152604092839020835161010081018552815473ffffffffffffffffffffffffffffffffffffffff908116825285518087018752948301546fffffffffffffffffffffffffffffffff808216875270010000000000000000000000000000000090910416858501528184019490945284516060808201875260028401546bffffffffffffffffffffffff80821684526c01000000000000000000000000820416838701527801000000000000000000000000000000000000000000000000900463ffffffff168288015282870191909152600383015485169082015260048201549093166080840152835180830185526005820154815260a084015283519182019093526006830154815260c082015260079091015460ff16151560e082015290565b6116916110a2565b61169a57600080fd5b600c8054600101908190556040517f10c87b0600000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________906310c87b06906107d49060009087908790600401613ed1565b6117026110a2565b61170b57600080fd5b600c8054600101908190556040517fe80f802400000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________9063e80f8024906107d49060009087908790600401613de5565b6117736110a2565b61177c57600080fd5b61178581611eb9565b50565b611790612d4f565b611798612d4f565b6108d983600161189d565b6117ab612d4f565b6117b48261183e565b506000908152600160209081526040918290208251918201909252600590910154815290565b6117e2612d4f565b6117eb8261183e565b6108298261180060008263ffffffff6119e516565b6000919063ffffffff611f6716565b73ffffffffffffffffffffffffffffffffffffffff166000908152600491909101602052604090205460ff1690565b61178560008001548210600d547f4d61726b6574204f4f420000000000000000000000000000000000000000000061208e565b6000908152600191909101602052604090205473ffffffffffffffffffffffffffffffffffffffff1690565b6118a5612d4f565b6118ad612d4f565b6000546118b8612e80565b6118c18261213f565b905060005b82811015611908576118e86118e36000898463ffffffff61196916565b612195565b611900576118fe8260008363ffffffff6121af16565b505b6001016118c6565b5061191c600087838863ffffffff61228916565b9350935050509250929050565b73ffffffffffffffffffffffffffffffffffffffff808316600090815260038501602090815260408083209385168352929052205460ff165b9392505050565b611971612d62565b50815173ffffffffffffffffffffffffffffffffffffffff1660009081526002840160209081526040808320828601518452825280832084845282529182902082518084019093525460ff8116151583526fffffffffffffffffffffffffffffffff61010090910416908201529392505050565b6119ed612d79565b506000908152600191909101602090815260409182902082516060810184526002909101546bffffffffffffffffffffffff80821683526c0100000000000000000000000082041692820192909252780100000000000000000000000000000000000000000000000090910463ffffffff169181019190915290565b611a71612d79565b611a79612d4f565b611a8a85858563ffffffff611f6716565b9050611ab88382611aa1888863ffffffff611cbb16565b604080516020810190915260078a015481526123dc565b95945050505050565b611ac9612d4f565b600082815260018401602052604090206003015473ffffffffffffffffffffffffffffffffffffffff16611afb612d4f565b73ffffffffffffffffffffffffffffffffffffffff82166341976e09611b27878763ffffffff61187116565b6040518263ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401611b5f9190613c6a565b60206040518083038186803b158015611b7757600080fd5b505afa158015611b8b573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250611baf91908101906134cc565b8051909150611c029015157f53746f72616765000000000000000000000000000000000000000000000000007f50726963652063616e6e6f74206265207a65726f00000000000000000000000087612546565b949350505050565b611c12612d62565b602083015183516fffffffffffffffffffffffffffffffff9091169015611c7e57604080518082019091526001815260208481015190820190611c739084906bffffffffffffffffffffffff16670de0b6b3a764000063ffffffff6125e416565b815250915050610c0c565b604080518082019091526000815283516020820190611c739084906bffffffffffffffffffffffff16670de0b6b3a764000063ffffffff61260616565b611cc3612d62565b506000818152600180840160209081526040928390208351808501909452909101546fffffffffffffffffffffffffffffffff8082168452700100000000000000000000000000000000909104169082015292915050565b611d23612d4f565b60068085015460008581526001870160209081526040918290208251918201909252920154825290611d5f908290611d5a90612653565b61268a565b9050611d9a81611d5a876001016000878152602001908152602001600020600601604051806020016040529081600082015481525050612653565b604080516020810190915290815295945050505050565b611db9612d62565b611dc1612d79565b611dd1848463ffffffff6119e516565b9050611ddb612d62565b611deb858563ffffffff611cbb16565b90506000611dff868663ffffffff61187116565b9050611e09612d62565b6040518060400160405280600115158152602001611e2784306126a3565b90529050611e33612d62565b611e3b612d62565b611e458587612748565b9092509050611e6a82611e5e858463ffffffff6127f016565b9063ffffffff6127f016565b9998505050505050505050565b805173ffffffffffffffffffffffffffffffffffffffff1660009081526002929092016020908152604080842092820151845291905290206001015460ff1690565b73ffffffffffffffffffffffffffffffffffffffff8116611ed957600080fd5b600b5460405173ffffffffffffffffffffffffffffffffffffffff8084169216907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a3600b80547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff92909216919091179055565b611f6f612d4f565b611f77612d62565b611f87858563ffffffff611cbb16565b9050611f91612d62565b611f99612d62565b611fa38386612748565b91509150611faf612d4f565b600087815260018901602052604090206004015473ffffffffffffffffffffffffffffffffffffffff1663e8177dcf611fee8a8a63ffffffff61187116565b846020015186602001516040518463ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040161203293929190613c93565b60206040518083038186803b15801561204a57600080fd5b505afa15801561205e573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525061208291908101906134cc565b98975050505050505050565b826108125761209c8261280a565b7f3a200000000000000000000000000000000000000000000000000000000000006120c68361280a565b6040516020016120d893929190613be4565b604080517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0818403018152908290527f08c379a000000000000000000000000000000000000000000000000000000000825261213691600401613d1e565b60405180910390fd5b612147612e80565b60405180602001604052808360405190808252806020026020018201604052801561218c57816020015b612179612e93565b8152602001906001900390816121715790505b50905292915050565b602001516fffffffffffffffffffffffffffffffff161590565b60006121c1848363ffffffff61290516565b156121ce57506000611962565b6121de838363ffffffff611ac116565b84518051849081106121ec57fe5b602090810291909101810151604090810192909252600084815260018601909152206007015460ff161561227f5760018460000151838151811061222c57fe5b6020908102919091010151901515905261224c838363ffffffff611cbb16565b51845180518490811061225b57fe5b6020908102919091018101516fffffffffffffffffffffffffffffffff9092169101525b5060019392505050565b612291612d4f565b612299612d4f565b6122a1612d4f565b6122a9612d4f565b60006122b487612933565b905060005b818110156123cd576122d1888263ffffffff61290516565b6122da576123c5565b6122e2612d62565b6122f38b8b8463ffffffff61293816565b90506122fe816129a7565b1561230957506123c5565b600061233061231e8b8563ffffffff6129af16565b5160208401519063ffffffff6129d916565b905061233a612d4f565b612342612a00565b9050891561237a57600084815260018e0160209081526040918290208251918201909252600590910154815261237790612653565b90505b8251156123a35761239c61238e8383612a22565b88519063ffffffff612a3b16565b87526123c1565b6123be6123b0838361268a565b87519063ffffffff612a3b16565b86525b5050505b6001016122b9565b50919890975095505050505050565b6123e4612d79565b6123ec612d62565b6123f4612d62565b6123fe8588612748565b91509150600061240c612a4d565b905060006124446124368a6040015163ffffffff168463ffffffff16612a5d90919063ffffffff16565b89519063ffffffff6129d916565b90506000612451856129a7565b1561245e57506000612490565b612468828861268a565b90508460200151846020015110156124905761248d81856020015187602001516125e4565b90505b8181111561249a57fe5b60408051606081019091528a5181906124e3906124de906bffffffffffffffffffffffff166124d28188670de0b6b3a76400006125e4565b9063ffffffff612a3b16565b612a72565b6bffffffffffffffffffffffff908116825260208d81015192019161251a916124de91166124d28187670de0b6b3a76400006125e4565b6bffffffffffffffffffffffff1681526020018463ffffffff1681525095505050505050949350505050565b836125de576125548361280a565b7f3a2000000000000000000000000000000000000000000000000000000000000061257e8461280a565b7f203c0000000000000000000000000000000000000000000000000000000000006125a885612ad0565b6040516120d89594939291907f3e0000000000000000000000000000000000000000000000000000000000000090602001613c0c565b50505050565b6000611c02826125fa868663ffffffff6129d916565b9063ffffffff612bfe16565b6000831580612613575082155b1561262a57612623600083612bfe565b9050611962565b611c0260016124d2846125fa836126478a8a63ffffffff6129d916565b9063ffffffff612a5d16565b61265b612d4f565b60408051602081019091528251819061268290670de0b6b3a764000063ffffffff612a3b16565b905292915050565b6000610c09838360000151670de0b6b3a76400006125e4565b6040517f70a0823100000000000000000000000000000000000000000000000000000000815260009073ffffffffffffffffffffffffffffffffffffffff8416906370a08231906126f8908590600401613c6a565b60206040518083038186803b15801561271057600080fd5b505afa158015612724573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250610c099190810190613508565b612750612d62565b612758612d62565b612760612d62565b5060408051808201909152600181526020858101516fffffffffffffffffffffffffffffffff1690820152612793612d62565b50604080518082019091526000815285516fffffffffffffffffffffffffffffffff1660208201526127c3612d62565b6127cd8387611c0a565b90506127d7612d62565b6127e18388611c0a565b91989197509095505050505050565b6127f8612d62565b610c098361280584612c20565b612c47565b6060808260405160200161281e9190613bcf565b604080517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0818403018152919052905060205b80156128ee5781517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9091019082908290811061288a57fe5b6020910101517f010000000000000000000000000000000000000000000000000000000000000090819004027fff0000000000000000000000000000000000000000000000000000000000000016156128e9576001018152905061082c565b612851565b505060408051600081526020810190915292915050565b60008260000151828151811061291757fe5b6020026020010151604001516000015160001415905092915050565b515190565b612940612d62565b612948612d62565b61295985858563ffffffff61196916565b905061296481612195565b1561297957612971612cd9565b915050611962565b612981612d79565b612991868563ffffffff6119e516565b905061299d8282611c0a565b9695505050505050565b602001511590565b6129b7612d4f565b82518051839081106129c557fe5b602002602001015160400151905092915050565b6000826129e857506000610c0c565b828202828482816129f557fe5b0414610c0957600080fd5b612a08612d4f565b506040805160208101909152670de0b6b3a7640000815290565b6000610c0983670de0b6b3a764000084600001516125e4565b600082820183811015610c0957600080fd5b6000612a5842612cf9565b905090565b600082821115612a6c57600080fd5b50900390565b6000816108296bffffffffffffffffffffffff821682147f4d617468000000000000000000000000000000000000000000000000000000007f556e73616665206361737420746f2075696e743936000000000000000000000061208e565b606081612b11575060408051808201909152600181527f3000000000000000000000000000000000000000000000000000000000000000602082015261082c565b8160005b8115612b2957600101600a82049150612b15565b6060816040519080825280601f01601f191660200182016040528015612b56576020820181803883390190505b508593509050815b8015612bf5577fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01600a84066030017f010000000000000000000000000000000000000000000000000000000000000002828281518110612bbb57fe5b60200101907effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1916908160001a905350600a84049350612b5e565b50949350505050565b6000808211612c0c57600080fd5b6000828481612c1757fe5b04949350505050565b612c28612d62565b5060408051808201909152815115815260208083015190820152919050565b612c4f612d62565b612c57612d62565b8251845115159015151415612c8a5783511515815260208085015190840151612c809190612a3b565b6020820152610c09565b8260200151846020015110612cb35783511515815260208085015190840151612c809190612a5d565b82511515815260208084015190850151612ccd9190612a5d565b60208201529392505050565b612ce1612d62565b50604080518082019091526000808252602082015290565b60008161082963ffffffff821682147f4d617468000000000000000000000000000000000000000000000000000000007f556e73616665206361737420746f2075696e743332000000000000000000000061208e565b6040518060200160405280600081525090565b604080518082019091526000808252602082015290565b604080516060810182526000808252602082018190529181019190915290565b6040518060800160405280612dac612d4f565b8152602001612db9612d4f565b8152602001612dc6612d4f565b8152602001612dd3612d4f565b905290565b604051806101600160405280600073ffffffffffffffffffffffffffffffffffffffff168152602001612e09612d62565b8152602001612e16612d79565b81526000602082018190526040820152606001612e31612d4f565b8152602001612e3e612d4f565b8152600060209091015290565b6040805160c081018252600080825260208201819052918101829052606081018290526080810182905260a081019190915290565b6040518060200160405280606081525090565b6040805160608101825260008082526020820152908101612dd3612d4f565b6000610c098235614015565b600082601f830112612ecf57600080fd5b8135612ee2612edd82613f9b565b613f74565b81815260209384019390925082018360005b83811015612f205781358601612f0a888261308d565b8452506020928301929190910190600101612ef4565b5050505092915050565b600082601f830112612f3b57600080fd5b8135612f49612edd82613f9b565b91508181835260208401935060208101905083856040840282011115612f6e57600080fd5b60005b83811015612f205781612f84888261320b565b84525060209092019160409190910190600101612f71565b600082601f830112612fad57600080fd5b8135612fbb612edd82613f9b565b91508181835260208401935060208101905083856040840282011115612fe057600080fd5b60005b83811015612f205781612ff68882613252565b84525060209092019160409190910190600101612fe3565b6000610c098235614020565b600082601f83011261302b57600080fd5b8135613039612edd82613fbc565b9150808252602083016020830185838301111561305557600080fd5b613060838284614139565b50505092915050565b6000610c0982356140ef565b6000610c0982356140fa565b6000610c098235614109565b600061016082840312156130a057600080fd5b6130ab610100613f74565b905060006130b98484613075565b82525060206130ca848483016132b7565b60208301525060406130de84828501613169565b60408301525060c06130f2848285016132b7565b60608301525060e0613106848285016132b7565b60808301525061010061311b84828501612eb2565b60a083015250610120613130848285016132b7565b60c08301525061014082013567ffffffffffffffff81111561315157600080fd5b61315d8482850161301a565b60e08301525092915050565b60006080828403121561317b57600080fd5b6131856080613f74565b90506000613193848461300e565b82525060206131a484848301613081565b60208301525060406131b884828501613081565b60408301525060606131cc848285016132b7565b60608301525092915050565b6000602082840312156131ea57600080fd5b6131f46020613f74565b9050600061320284846132b7565b82525092915050565b60006040828403121561321d57600080fd5b6132276040613f74565b905060006132358484612eb2565b8252506020613246848483016132b7565b60208301525092915050565b60006040828403121561326457600080fd5b61326e6040613f74565b9050600061327c8484612eb2565b82525060206132468484830161300e565b60006020828403121561329f57600080fd5b6132a96020613f74565b9050600061320284846132c3565b6000610c09823561406f565b6000610c09825161406f565b6000602082840312156132e157600080fd5b6000611c028484612eb2565b6000806040838503121561330057600080fd5b600061330c8585612eb2565b925050602061331d85828601612eb2565b9150509250929050565b6000806040838503121561333a57600080fd5b60006133468585612eb2565b925050602061331d8582860161300e565b600080600080600060a0868803121561336f57600080fd5b600061337b8888612eb2565b955050602061338c88828901613069565b945050604061339d88828901613069565b93505060606133ae888289016131d8565b92505060806133bf888289016131d8565b9150509295509295909350565b600080604083850312156133df57600080fd5b823567ffffffffffffffff8111156133f657600080fd5b61340285828601612f2a565b925050602083013567ffffffffffffffff81111561341f57600080fd5b61331d85828601612ebe565b60006020828403121561343d57600080fd5b813567ffffffffffffffff81111561345457600080fd5b611c0284828501612f9c565b60006020828403121561347257600080fd5b6000611c0284846131d8565b60006040828403121561349057600080fd5b6000611c02848461320b565b600080606083850312156134af57600080fd5b60006134bb858561320b565b925050604061331d858286016132b7565b6000602082840312156134de57600080fd5b6000611c02848461328d565b6000602082840312156134fc57600080fd5b6000611c0284846132b7565b60006020828403121561351a57600080fd5b6000611c0284846132c3565b6000806040838503121561353957600080fd5b600061330c85856132b7565b6000806040838503121561355857600080fd5b600061334685856132b7565b6000806040838503121561357757600080fd5b600061358385856132b7565b925050602061331d85828601613069565b600080604083850312156135a757600080fd5b60006135b385856132b7565b925050602061331d858286016131d8565b600080604083850312156135d757600080fd5b60006135e385856132b7565b925050602061331d858286016132b7565b60006136008383613640565b505060200190565b6000610c0983836138ac565b600061362083836139e0565b505060400190565b60006136208383613a9e565b60006136208383613b91565b61364981614015565b82525050565b600061365a82614008565b613664818561400c565b935061366f83614002565b60005b8281101561369a576136858683516135f4565b955061369082614002565b9150600101613672565b5093949350505050565b60006136af82614008565b6136b9818561400c565b9350836020820285016136cb85614002565b60005b848110156137025783830388526136e6838351613608565b92506136f182614002565b6020989098019791506001016136ce565b50909695505050505050565b600061371982614008565b613723818561400c565b935061372e83614002565b60005b8281101561369a57613744868351613614565b955061374f82614002565b9150600101613731565b600061376482614008565b61376e818561400c565b935061377983614002565b60005b8281101561369a5761378f868351613628565b955061379a82614002565b915060010161377c565b60006137af82614008565b6137b9818561400c565b93506137c483614002565b60005b8281101561369a576137da868351613634565b95506137e582614002565b91506001016137c7565b61364981614020565b61364961380482614025565b61406f565b6136496138048261404a565b6136496138048261406f565b600061382c82614008565b613836818561082c565b9350613846818560208601614145565b9290920192915050565b600061385b82614008565b613865818561400c565b9350613875818560208601614145565b61387e81614171565b9093019392505050565b613649816140ef565b61364981614118565b61364981614123565b6136498161412e565b80516000906101608401906138c18582613891565b5060208301516138d46020860182613bab565b5060408301516138e7604086018261394e565b5060608301516138fa60c0860182613bab565b50608083015161390d60e0860182613bab565b5060a0830151613921610100860182613640565b5060c0830151613935610120860182613bab565b5060e0830151848203610140860152611ab88282613850565b8051608083019061395f84826137ef565b506020820151613972602085018261389a565b506040820151613985604085018261389a565b5060608201516125de6060850182613bab565b805160208301906125de8482613bab565b805160608301906139ba8482613bc6565b5060208201516139cd6020850182613bc6565b5060408201516125de6040850182613bb4565b805160408301906139f18482613640565b5060208201516125de6020850182613bab565b8051610160830190613a168482613640565b506020820151613a296020850182613b80565b506040820151613a3c60608501826139a9565b506060820151613a4f60c0850182613888565b506080820151613a6260e0850182613888565b5060a0820151613a76610100850182613998565b5060c0820151613a8a610120850182613998565b5060e08201516125de6101408501826137ef565b80516040830190613aaf84826137ef565b5060208201516125de6020850182613ba2565b805160c0830190613ad38482613bbd565b506020820151613ae66020850182613bbd565b506040820151613af96040850182613bbd565b506060820151613b0c6060850182613bbd565b506080820151613b1f6080850182613bbd565b5060a08201516125de60a0850182613ba2565b80516080830190613b438482613998565b506020820151613b566020850182613998565b506040820151613b696040850182613998565b5060608201516125de6060850182613998565b9052565b80516040830190613aaf8482613ba2565b805160408301906139f184826137ef565b6136498161409a565b6136498161406f565b613649816140c8565b613649816140d1565b613649816140de565b6000613bdb8284613815565b50602001919050565b6000613bf08286613821565b9150613bfc8285613809565b600282019150611ab88284613821565b6000613c188289613821565b9150613c248288613809565b600282019150613c348287613821565b9150613c408286613809565b600282019150613c508285613821565b9150613c5c82846137f8565b506001019695505050505050565b60208101610c0c8284613640565b60408101613c868285613640565b61196260208301846137ef565b60608101613ca18286613640565b613cae6020830185613bab565b611c026040830184613bab565b60608082528101613ccc818661364f565b90508181036020830152613ce08185613759565b90508181036040830152611ab881846137a4565b60208101610c0c82846137ef565b60208101610c0c8284613888565b60208101610c0c82846138a3565b60208082528101610c098184613850565b60208101610c0c8284613998565b60608101610c0c82846139a9565b6101608101610c0c8284613a04565b6102008101613d698287613a04565b613d776101608301866139a9565b613d856101c0830185613998565b611ab86101e0830184613998565b60408101610c0c8284613a9e565b60c08101610c0c8284613ac2565b60808101610c0c8284613b32565b60608101613dcb8286613b7c565b613dd86020830185613640565b611c026040830184613640565b60608101613df38286613b7c565b613e006020830185613640565b611c0260408301846137ef565b60c08101613e1b8289613b7c565b613e286020830188613640565b613e356040830187613888565b613e426060830186613888565b613e4f6080830185613998565b613e5c60a0830184613998565b979650505050505050565b60608101613e758286613b7c565b8181036020830152613e87818561370e565b90508181036040830152611ab881846136a4565b60408101613ea98285613b7c565b6119626020830184613998565b60608101613ec48286613b7c565b613dd86020830185613bab565b60608101613edf8286613b7c565b613e006020830185613bab565b60608101613efa8286613b7c565b613f076020830185613bab565b611c026040830184613888565b60608101613f228286613b7c565b613f2f6020830185613bab565b611c026040830184613998565b60408101610c0c8284613b80565b60408101613ea98285613998565b60408101610c0c8284613b91565b60208101610c0c8284613bab565b60405181810167ffffffffffffffff81118282101715613f9357600080fd5b604052919050565b600067ffffffffffffffff821115613fb257600080fd5b5060209081020190565b600067ffffffffffffffff821115613fd357600080fd5b506020601f919091017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0160190565b60200190565b5190565b90815260200190565b6000610829826140af565b151590565b7fff000000000000000000000000000000000000000000000000000000000000001690565b7fffff0000000000000000000000000000000000000000000000000000000000001690565b90565b60006009821061407e57fe5b5090565b60006002821061407e57fe5b60006003821061407e57fe5b6fffffffffffffffffffffffffffffffff1690565b73ffffffffffffffffffffffffffffffffffffffff1690565b63ffffffff1690565b67ffffffffffffffff1690565b6bffffffffffffffffffffffff1690565b600061082982614015565b60006009821061407e57600080fd5b60006002821061407e57600080fd5b600061082982614072565b600061082982614082565b60006108298261408e565b82818337506000910152565b60005b83811015614160578181015183820152602001614148565b838111156125de5750506000910152565b601f017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0169056fea265627a7a72305820dfb00714fa7976d59789d8d385c92ee41a3bdc4cc7768bf82d569e7bfb91f3c46c6578706572696d656e74616cf50037",
+  "deployedBytecode": "0x608060405234801561001057600080fd5b5060043610610348576000357c0100000000000000000000000000000000000000000000000000000000900480638928378e116101cf578063d5ecf7c511610116578063eb44fdd3116100bf578063f2fde38b11610099578063f2fde38b14610717578063f94160521461072a578063fd04b6061461073d578063fd47eda61461075057610348565b8063eb44fdd3146106d1578063ef6957d0146106f1578063f2901ae21461070457610348565b8063e5520228116100f0578063e5520228146106a1578063e8e72f75146106a9578063eb1c6e6b146106bc57610348565b8063d5ecf7c51461065b578063deec053d1461066e578063e51bfcb41461068157610348565b8063b548b89211610178578063c190c2ec11610152578063c190c2ec14610608578063cb04a34c14610628578063d24c48bc1461064857610348565b8063b548b892146105ca578063c0bb72b7146105ed578063c14609421461060057610348565b80638f6bc659116101a95780638f6bc65914610591578063982f323c146105a4578063a67a6a45146105b757610348565b80638928378e1461056e5780638da5cb5b146105815780638f32d59b1461058957610348565b8063387a498a116102935780635ac7d17c1161023c578063715018a611610216578063715018a61461054b5780637e9eaf411461055357806385b53fc81461055b57610348565b80635ac7d17c1461050157806369794795146105145780636a8194e71461052957610348565b80634be874141161026d5780634be87414146104c65780634f3c1542146104d957806356ea84b2146104e157610348565b8063387a498a146104805780633a031bf01461049357806347d1b53c146104a657610348565b8063197f0f05116102f55780632a560845116102cf5780632a560845146104475780632e822af31461045a5780633063bce21461046d57610348565b8063197f0f05146103ff5780631a7777bb14610412578063295c39a51461043257610348565b8063121fb72f11610326578063121fb72f146103ab578063124f914c146103be57806313368364146103df57610348565b8063042069d61461034d578063052f72d714610362578063062bd3e91461038b575b600080fd5b61036061035b366004613594565b610763565b005b6103756103703660046132cf565b610817565b6040516103829190613cf4565b60405180910390f35b61039e6103993660046134ea565b610831565b6040516103829190613c6a565b6103606103b9366004613564565b61084d565b6103d16103cc36600461347e565b6108be565b604051610382929190613f4a565b6103f26103ed3660046134ea565b6108e2565b6040516103829190613d02565b6103f261040d3660046134ea565b610919565b6104256104203660046134ea565b610950565b6040516103829190613d2f565b61043a610987565b6040516103829190613f66565b61043a6104553660046132ed565b61098d565b610360610468366004613460565b610a67565b61036061047b366004613460565b610b18565b61036061048e366004613460565b610b87565b6103756104a13660046132ed565b610bf6565b6104b96104b436600461349c565b610c12565b6040516103829190613d93565b6103606104d4366004613594565b610c35565b610425610ca6565b6104f46104ef3660046134ea565b610cc2565b6040516103829190613d3d565b61037561050f3660046134ea565b610cf7565b61051c610d1b565b6040516103829190613daf565b61053c61053736600461347e565b610d77565b60405161038293929190613cbb565b610360610ee5565b610425610f65565b61036061056936600461342b565b610f81565b61042561057c3660046134ea565b611064565b61039e611086565b6103756110a2565b61043a61059f366004613526565b6110c0565b6103606105b2366004613357565b611133565b6103606105c53660046133cc565b6111f0565b6105dd6105d83660046134ea565b611250565b6040516103829493929190613d5a565b6103606105fb366004613460565b6112ac565b61042561131b565b61061b61061636600461349c565b611337565b6040516103829190613f58565b61063b6106363660046134ea565b611377565b6040516103829190613f3c565b6104256106563660046135c4565b611399565b61061b6106693660046134ea565b6113c5565b6104f461067c3660046134ea565b6113e7565b61069461068f36600461347e565b611409565b6040516103829190613d10565b61042561141b565b6103606106b7366004613564565b611437565b6106c46114a8565b6040516103829190613da1565b6106e46106df3660046134ea565b61154a565b6040516103829190613d4b565b6103606106ff366004613545565b611689565b610360610712366004613327565b6116fa565b6103606107253660046132cf565b61176b565b6103d161073836600461347e565b611788565b61042561074b3660046134ea565b6117a3565b61042561075e3660046134ea565b6117da565b61076b6110a2565b61077457600080fd5b600c8054600101908190556040517f8854ab3e00000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________90638854ab3e906107d49060009087908790600401613f14565b60006040518083038186803b1580156107ec57600080fd5b505af4158015610800573d6000803e3d6000fd5b50505050600c54811461081257600080fd5b505050565b6000610829818363ffffffff61180f16565b90505b919050565b600061083c8261183e565b61082960008363ffffffff61187116565b6108556110a2565b61085e57600080fd5b600c8054600101908190556040517faa92e34800000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________9063aa92e348906107d49060009087908790600401613eec565b6108c6612d4f565b6108ce612d4f565b6108d983600061189d565b91509150915091565b60006108ed8261183e565b5060009081526001602052604090206003015473ffffffffffffffffffffffffffffffffffffffff1690565b60006109248261183e565b5060009081526001602052604090206004015473ffffffffffffffffffffffffffffffffffffffff1690565b610958612d4f565b6109618261183e565b506000908152600160209081526040918290208251918201909252600690910154815290565b60005490565b60006109976110a2565b6109a057600080fd5b600c8054600101908190556040517fdd32998a00000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________9063dd32998a90610a009060009088908890600401613dbd565b60206040518083038186803b158015610a1857600080fd5b505af4158015610a2c573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250610a509190810190613508565b9150600c548114610a6057600080fd5b5092915050565b610a6f6110a2565b610a7857600080fd5b600c8054600101908190556040517ff9cacc4c00000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________9063f9cacc4c90610ad6906000908690600401613e9b565b60006040518083038186803b158015610aee57600080fd5b505af4158015610b02573d6000803e3d6000fd5b50505050600c548114610b1457600080fd5b5050565b610b206110a2565b610b2957600080fd5b600c8054600101908190556040517f0f44e6bc00000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________90630f44e6bc90610ad6906000908690600401613e9b565b610b8f6110a2565b610b9857600080fd5b600c8054600101908190556040517f311401d000000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________9063311401d090610ad6906000908690600401613e9b565b6000610c0981848463ffffffff61192916565b90505b92915050565b610c1a612d62565b610c238261183e565b610c096000848463ffffffff61196916565b610c3d6110a2565b610c4657600080fd5b600c8054600101908190556040517f7335079b00000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________90637335079b906107d49060009087908790600401613f14565b610cae612d4f565b506040805160208101909152600554815290565b610cca612d79565b610cd38261183e565b61082982610ce860008263ffffffff6119e516565b6000919063ffffffff611a6916565b6000610d028261183e565b5060009081526001602052604090206007015460ff1690565b610d23612d99565b506040805160a0810182526005546080820190815281528151602081810184526006548252808301919091528251808201845260075481528284015282519081019092526008548252606081019190915290565b6060806060600080600001549050606081604051908082528060200260200182016040528015610db1578160200160208202803883390190505b509050606082604051908082528060200260200182016040528015610df057816020015b610ddd612d62565b815260200190600190039081610dd55790505b509050606083604051908082528060200260200182016040528015610e2f57816020015b610e1c612d62565b815260200190600190039081610e145790505b50905060005b84811015610ed657610e4681610831565b848281518110610e5257fe5b602002602001019073ffffffffffffffffffffffffffffffffffffffff16908173ffffffffffffffffffffffffffffffffffffffff1681525050610e968982610c12565b838281518110610ea257fe5b6020026020010181905250610eb78982611337565b828281518110610ec357fe5b6020908102919091010152600101610e35565b50919790965090945092505050565b610eed6110a2565b610ef657600080fd5b600b5460405160009173ffffffffffffffffffffffffffffffffffffffff16907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908390a3600b80547fffffffffffffffffffffffff0000000000000000000000000000000000000000169055565b610f6d612d4f565b506040805160208101909152600854815290565b60005b8151811015610b14576000828281518110610f9b57fe5b60200260200101516000015190506000838381518110610fb757fe5b60209081029190910181015181015133600081815260038452604080822073ffffffffffffffffffffffffffffffffffffffff8816835290945283902080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff001683151517905591519092507f4d7f317d2088d039c2a95a09fcbf9cc9191fad5905f883c937cc3d317c4a6327906110529085908590613c78565b60405180910390a25050600101610f84565b61106c612d4f565b6110758261183e565b61082960008363ffffffff611ac116565b600b5473ffffffffffffffffffffffffffffffffffffffff1690565b600b5473ffffffffffffffffffffffffffffffffffffffff16331490565b60006110ca6110a2565b6110d357600080fd5b600c8054600101908190556040517fb25328e000000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________9063b25328e090610a009060009088908890600401613eb6565b61113b6110a2565b61114457600080fd5b600c8054600101908190556040517f48d0648400000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________906348d06484906111aa906000908a908a908a908a908a90600401613e0d565b60006040518083038186803b1580156111c257600080fd5b505af41580156111d6573d6000803e3d6000fd5b50505050600c5481146111e857600080fd5b505050505050565b600c8054600101908190556040517fbd76ecfd00000000000000000000000000000000000000000000000000000000815273__OperationImpl_________________________9063bd76ecfd906107d49060009087908790600401613e67565b611258612dd8565b611260612d79565b611268612d4f565b611270612d4f565b6112798561183e565b6112828561154a565b61128b86610cc2565b61129487611064565b61129d886117da565b93509350935093509193509193565b6112b46110a2565b6112bd57600080fd5b600c8054600101908190556040517f54dd351600000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________906354dd351690610ad6906000908690600401613e9b565b611323612d4f565b506040805160208101909152600654815290565b61133f612d62565b6113488261183e565b610c0961135d6000858563ffffffff61196916565b61137284610ce860008263ffffffff6119e516565b611c0a565b61137f612d62565b6113888261183e565b61082960008363ffffffff611cbb16565b6113a1612d4f565b6113aa8361183e565b6113b38261183e565b610c096000848463ffffffff611d1b16565b6113cd612d62565b6113d68261183e565b61082960008363ffffffff611db116565b6113ef612d79565b6113f88261183e565b61082960008363ffffffff6119e516565b6000610829818363ffffffff611e7716565b611423612d4f565b506040805160208101909152600754815290565b61143f6110a2565b61144857600080fd5b600c8054600101908190556040517f8c5dabd100000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________90638c5dabd1906107d49060009087908790600401613eec565b6114b0612e4b565b506040805160c08101825260095467ffffffffffffffff808216835268010000000000000000808304821660208501527001000000000000000000000000000000008304821694840194909452780100000000000000000000000000000000000000000000000090910481166060830152600a549081166080830152919091046fffffffffffffffffffffffffffffffff1660a082015290565b611552612dd8565b61155b8261183e565b50600090815260016020818152604092839020835161010081018552815473ffffffffffffffffffffffffffffffffffffffff908116825285518087018752948301546fffffffffffffffffffffffffffffffff808216875270010000000000000000000000000000000090910416858501528184019490945284516060808201875260028401546bffffffffffffffffffffffff80821684526c01000000000000000000000000820416838701527801000000000000000000000000000000000000000000000000900463ffffffff168288015282870191909152600383015485169082015260048201549093166080840152835180830185526005820154815260a084015283519182019093526006830154815260c082015260079091015460ff16151560e082015290565b6116916110a2565b61169a57600080fd5b600c8054600101908190556040517f10c87b0600000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________906310c87b06906107d49060009087908790600401613ed1565b6117026110a2565b61170b57600080fd5b600c8054600101908190556040517fe80f802400000000000000000000000000000000000000000000000000000000815273__AdminImpl_____________________________9063e80f8024906107d49060009087908790600401613de5565b6117736110a2565b61177c57600080fd5b61178581611eb9565b50565b611790612d4f565b611798612d4f565b6108d983600161189d565b6117ab612d4f565b6117b48261183e565b506000908152600160209081526040918290208251918201909252600590910154815290565b6117e2612d4f565b6117eb8261183e565b6108298261180060008263ffffffff6119e516565b6000919063ffffffff611f6716565b73ffffffffffffffffffffffffffffffffffffffff166000908152600491909101602052604090205460ff1690565b61178560008001548210600d547f4d61726b6574204f4f420000000000000000000000000000000000000000000061208e565b6000908152600191909101602052604090205473ffffffffffffffffffffffffffffffffffffffff1690565b6118a5612d4f565b6118ad612d4f565b6000546118b8612e80565b6118c18261213f565b905060005b82811015611908576118e86118e36000898463ffffffff61196916565b612195565b611900576118fe8260008363ffffffff6121af16565b505b6001016118c6565b5061191c600087838863ffffffff61228916565b9350935050509250929050565b73ffffffffffffffffffffffffffffffffffffffff808316600090815260038501602090815260408083209385168352929052205460ff165b9392505050565b611971612d62565b50815173ffffffffffffffffffffffffffffffffffffffff1660009081526002840160209081526040808320828601518452825280832084845282529182902082518084019093525460ff8116151583526fffffffffffffffffffffffffffffffff61010090910416908201529392505050565b6119ed612d79565b506000908152600191909101602090815260409182902082516060810184526002909101546bffffffffffffffffffffffff80821683526c0100000000000000000000000082041692820192909252780100000000000000000000000000000000000000000000000090910463ffffffff169181019190915290565b611a71612d79565b611a79612d4f565b611a8a85858563ffffffff611f6716565b9050611ab88382611aa1888863ffffffff611cbb16565b604080516020810190915260078a015481526123dc565b95945050505050565b611ac9612d4f565b600082815260018401602052604090206003015473ffffffffffffffffffffffffffffffffffffffff16611afb612d4f565b73ffffffffffffffffffffffffffffffffffffffff82166341976e09611b27878763ffffffff61187116565b6040518263ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401611b5f9190613c6a565b60206040518083038186803b158015611b7757600080fd5b505afa158015611b8b573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250611baf91908101906134cc565b8051909150611c029015157f53746f72616765000000000000000000000000000000000000000000000000007f50726963652063616e6e6f74206265207a65726f00000000000000000000000087612546565b949350505050565b611c12612d62565b602083015183516fffffffffffffffffffffffffffffffff9091169015611c7e57604080518082019091526001815260208481015190820190611c739084906bffffffffffffffffffffffff16670de0b6b3a764000063ffffffff6125e416565b815250915050610c0c565b604080518082019091526000815283516020820190611c739084906bffffffffffffffffffffffff16670de0b6b3a764000063ffffffff61260616565b611cc3612d62565b506000818152600180840160209081526040928390208351808501909452909101546fffffffffffffffffffffffffffffffff8082168452700100000000000000000000000000000000909104169082015292915050565b611d23612d4f565b60068085015460008581526001870160209081526040918290208251918201909252920154825290611d5f908290611d5a90612653565b61268a565b9050611d9a81611d5a876001016000878152602001908152602001600020600601604051806020016040529081600082015481525050612653565b604080516020810190915290815295945050505050565b611db9612d62565b611dc1612d79565b611dd1848463ffffffff6119e516565b9050611ddb612d62565b611deb858563ffffffff611cbb16565b90506000611dff868663ffffffff61187116565b9050611e09612d62565b6040518060400160405280600115158152602001611e2784306126a3565b90529050611e33612d62565b611e3b612d62565b611e458587612748565b9092509050611e6a82611e5e858463ffffffff6127f016565b9063ffffffff6127f016565b9998505050505050505050565b805173ffffffffffffffffffffffffffffffffffffffff1660009081526002929092016020908152604080842092820151845291905290206001015460ff1690565b73ffffffffffffffffffffffffffffffffffffffff8116611ed957600080fd5b600b5460405173ffffffffffffffffffffffffffffffffffffffff8084169216907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a3600b80547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff92909216919091179055565b611f6f612d4f565b611f77612d62565b611f87858563ffffffff611cbb16565b9050611f91612d62565b611f99612d62565b611fa38386612748565b91509150611faf612d4f565b600087815260018901602052604090206004015473ffffffffffffffffffffffffffffffffffffffff1663e8177dcf611fee8a8a63ffffffff61187116565b846020015186602001516040518463ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040161203293929190613c93565b60206040518083038186803b15801561204a57600080fd5b505afa15801561205e573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525061208291908101906134cc565b98975050505050505050565b826108125761209c8261280a565b7f3a200000000000000000000000000000000000000000000000000000000000006120c68361280a565b6040516020016120d893929190613be4565b604080517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0818403018152908290527f08c379a000000000000000000000000000000000000000000000000000000000825261213691600401613d1e565b60405180910390fd5b612147612e80565b60405180602001604052808360405190808252806020026020018201604052801561218c57816020015b612179612e93565b8152602001906001900390816121715790505b50905292915050565b602001516fffffffffffffffffffffffffffffffff161590565b60006121c1848363ffffffff61290516565b156121ce57506000611962565b6121de838363ffffffff611ac116565b84518051849081106121ec57fe5b602090810291909101810151604090810192909252600084815260018601909152206007015460ff161561227f5760018460000151838151811061222c57fe5b6020908102919091010151901515905261224c838363ffffffff611cbb16565b51845180518490811061225b57fe5b6020908102919091018101516fffffffffffffffffffffffffffffffff9092169101525b5060019392505050565b612291612d4f565b612299612d4f565b6122a1612d4f565b6122a9612d4f565b60006122b487612933565b905060005b818110156123cd576122d1888263ffffffff61290516565b6122da576123c5565b6122e2612d62565b6122f38b8b8463ffffffff61293816565b90506122fe816129a7565b1561230957506123c5565b600061233061231e8b8563ffffffff6129af16565b5160208401519063ffffffff6129d916565b905061233a612d4f565b612342612a00565b9050891561237a57600084815260018e0160209081526040918290208251918201909252600590910154815261237790612653565b90505b8251156123a35761239c61238e8383612a22565b88519063ffffffff612a3b16565b87526123c1565b6123be6123b0838361268a565b87519063ffffffff612a3b16565b86525b5050505b6001016122b9565b50919890975095505050505050565b6123e4612d79565b6123ec612d62565b6123f4612d62565b6123fe8588612748565b91509150600061240c612a4d565b905060006124446124368a6040015163ffffffff168463ffffffff16612a5d90919063ffffffff16565b89519063ffffffff6129d916565b90506000612451856129a7565b1561245e57506000612490565b612468828861268a565b90508460200151846020015110156124905761248d81856020015187602001516125e4565b90505b8181111561249a57fe5b60408051606081019091528a5181906124e3906124de906bffffffffffffffffffffffff166124d28188670de0b6b3a76400006125e4565b9063ffffffff612a3b16565b612a72565b6bffffffffffffffffffffffff908116825260208d81015192019161251a916124de91166124d28187670de0b6b3a76400006125e4565b6bffffffffffffffffffffffff1681526020018463ffffffff1681525095505050505050949350505050565b836125de576125548361280a565b7f3a2000000000000000000000000000000000000000000000000000000000000061257e8461280a565b7f203c0000000000000000000000000000000000000000000000000000000000006125a885612ad0565b6040516120d89594939291907f3e0000000000000000000000000000000000000000000000000000000000000090602001613c0c565b50505050565b6000611c02826125fa868663ffffffff6129d916565b9063ffffffff612bfe16565b6000831580612613575082155b1561262a57612623600083612bfe565b9050611962565b611c0260016124d2846125fa836126478a8a63ffffffff6129d916565b9063ffffffff612a5d16565b61265b612d4f565b60408051602081019091528251819061268290670de0b6b3a764000063ffffffff612a3b16565b905292915050565b6000610c09838360000151670de0b6b3a76400006125e4565b6040517f70a0823100000000000000000000000000000000000000000000000000000000815260009073ffffffffffffffffffffffffffffffffffffffff8416906370a08231906126f8908590600401613c6a565b60206040518083038186803b15801561271057600080fd5b505afa158015612724573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250610c099190810190613508565b612750612d62565b612758612d62565b612760612d62565b5060408051808201909152600181526020858101516fffffffffffffffffffffffffffffffff1690820152612793612d62565b50604080518082019091526000815285516fffffffffffffffffffffffffffffffff1660208201526127c3612d62565b6127cd8387611c0a565b90506127d7612d62565b6127e18388611c0a565b91989197509095505050505050565b6127f8612d62565b610c098361280584612c20565b612c47565b6060808260405160200161281e9190613bcf565b604080517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0818403018152919052905060205b80156128ee5781517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9091019082908290811061288a57fe5b6020910101517f010000000000000000000000000000000000000000000000000000000000000090819004027fff0000000000000000000000000000000000000000000000000000000000000016156128e9576001018152905061082c565b612851565b505060408051600081526020810190915292915050565b60008260000151828151811061291757fe5b6020026020010151604001516000015160001415905092915050565b515190565b612940612d62565b612948612d62565b61295985858563ffffffff61196916565b905061296481612195565b1561297957612971612cd9565b915050611962565b612981612d79565b612991868563ffffffff6119e516565b905061299d8282611c0a565b9695505050505050565b602001511590565b6129b7612d4f565b82518051839081106129c557fe5b602002602001015160400151905092915050565b6000826129e857506000610c0c565b828202828482816129f557fe5b0414610c0957600080fd5b612a08612d4f565b506040805160208101909152670de0b6b3a7640000815290565b6000610c0983670de0b6b3a764000084600001516125e4565b600082820183811015610c0957600080fd5b6000612a5842612cf9565b905090565b600082821115612a6c57600080fd5b50900390565b6000816108296bffffffffffffffffffffffff821682147f4d617468000000000000000000000000000000000000000000000000000000007f556e73616665206361737420746f2075696e743936000000000000000000000061208e565b606081612b11575060408051808201909152600181527f3000000000000000000000000000000000000000000000000000000000000000602082015261082c565b8160005b8115612b2957600101600a82049150612b15565b6060816040519080825280601f01601f191660200182016040528015612b56576020820181803883390190505b508593509050815b8015612bf5577fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01600a84066030017f010000000000000000000000000000000000000000000000000000000000000002828281518110612bbb57fe5b60200101907effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1916908160001a905350600a84049350612b5e565b50949350505050565b6000808211612c0c57600080fd5b6000828481612c1757fe5b04949350505050565b612c28612d62565b5060408051808201909152815115815260208083015190820152919050565b612c4f612d62565b612c57612d62565b8251845115159015151415612c8a5783511515815260208085015190840151612c809190612a3b565b6020820152610c09565b8260200151846020015110612cb35783511515815260208085015190840151612c809190612a5d565b82511515815260208084015190850151612ccd9190612a5d565b60208201529392505050565b612ce1612d62565b50604080518082019091526000808252602082015290565b60008161082963ffffffff821682147f4d617468000000000000000000000000000000000000000000000000000000007f556e73616665206361737420746f2075696e743332000000000000000000000061208e565b6040518060200160405280600081525090565b604080518082019091526000808252602082015290565b604080516060810182526000808252602082018190529181019190915290565b6040518060800160405280612dac612d4f565b8152602001612db9612d4f565b8152602001612dc6612d4f565b8152602001612dd3612d4f565b905290565b604051806101600160405280600073ffffffffffffffffffffffffffffffffffffffff168152602001612e09612d62565b8152602001612e16612d79565b81526000602082018190526040820152606001612e31612d4f565b8152602001612e3e612d4f565b8152600060209091015290565b6040805160c081018252600080825260208201819052918101829052606081018290526080810182905260a081019190915290565b6040518060200160405280606081525090565b6040805160608101825260008082526020820152908101612dd3612d4f565b6000610c098235614015565b600082601f830112612ecf57600080fd5b8135612ee2612edd82613f9b565b613f74565b81815260209384019390925082018360005b83811015612f205781358601612f0a888261308d565b8452506020928301929190910190600101612ef4565b5050505092915050565b600082601f830112612f3b57600080fd5b8135612f49612edd82613f9b565b91508181835260208401935060208101905083856040840282011115612f6e57600080fd5b60005b83811015612f205781612f84888261320b565b84525060209092019160409190910190600101612f71565b600082601f830112612fad57600080fd5b8135612fbb612edd82613f9b565b91508181835260208401935060208101905083856040840282011115612fe057600080fd5b60005b83811015612f205781612ff68882613252565b84525060209092019160409190910190600101612fe3565b6000610c098235614020565b600082601f83011261302b57600080fd5b8135613039612edd82613fbc565b9150808252602083016020830185838301111561305557600080fd5b613060838284614139565b50505092915050565b6000610c0982356140ef565b6000610c0982356140fa565b6000610c098235614109565b600061016082840312156130a057600080fd5b6130ab610100613f74565b905060006130b98484613075565b82525060206130ca848483016132b7565b60208301525060406130de84828501613169565b60408301525060c06130f2848285016132b7565b60608301525060e0613106848285016132b7565b60808301525061010061311b84828501612eb2565b60a083015250610120613130848285016132b7565b60c08301525061014082013567ffffffffffffffff81111561315157600080fd5b61315d8482850161301a565b60e08301525092915050565b60006080828403121561317b57600080fd5b6131856080613f74565b90506000613193848461300e565b82525060206131a484848301613081565b60208301525060406131b884828501613081565b60408301525060606131cc848285016132b7565b60608301525092915050565b6000602082840312156131ea57600080fd5b6131f46020613f74565b9050600061320284846132b7565b82525092915050565b60006040828403121561321d57600080fd5b6132276040613f74565b905060006132358484612eb2565b8252506020613246848483016132b7565b60208301525092915050565b60006040828403121561326457600080fd5b61326e6040613f74565b9050600061327c8484612eb2565b82525060206132468484830161300e565b60006020828403121561329f57600080fd5b6132a96020613f74565b9050600061320284846132c3565b6000610c09823561406f565b6000610c09825161406f565b6000602082840312156132e157600080fd5b6000611c028484612eb2565b6000806040838503121561330057600080fd5b600061330c8585612eb2565b925050602061331d85828601612eb2565b9150509250929050565b6000806040838503121561333a57600080fd5b60006133468585612eb2565b925050602061331d8582860161300e565b600080600080600060a0868803121561336f57600080fd5b600061337b8888612eb2565b955050602061338c88828901613069565b945050604061339d88828901613069565b93505060606133ae888289016131d8565b92505060806133bf888289016131d8565b9150509295509295909350565b600080604083850312156133df57600080fd5b823567ffffffffffffffff8111156133f657600080fd5b61340285828601612f2a565b925050602083013567ffffffffffffffff81111561341f57600080fd5b61331d85828601612ebe565b60006020828403121561343d57600080fd5b813567ffffffffffffffff81111561345457600080fd5b611c0284828501612f9c565b60006020828403121561347257600080fd5b6000611c0284846131d8565b60006040828403121561349057600080fd5b6000611c02848461320b565b600080606083850312156134af57600080fd5b60006134bb858561320b565b925050604061331d858286016132b7565b6000602082840312156134de57600080fd5b6000611c02848461328d565b6000602082840312156134fc57600080fd5b6000611c0284846132b7565b60006020828403121561351a57600080fd5b6000611c0284846132c3565b6000806040838503121561353957600080fd5b600061330c85856132b7565b6000806040838503121561355857600080fd5b600061334685856132b7565b6000806040838503121561357757600080fd5b600061358385856132b7565b925050602061331d85828601613069565b600080604083850312156135a757600080fd5b60006135b385856132b7565b925050602061331d858286016131d8565b600080604083850312156135d757600080fd5b60006135e385856132b7565b925050602061331d858286016132b7565b60006136008383613640565b505060200190565b6000610c0983836138ac565b600061362083836139e0565b505060400190565b60006136208383613a9e565b60006136208383613b91565b61364981614015565b82525050565b600061365a82614008565b613664818561400c565b935061366f83614002565b60005b8281101561369a576136858683516135f4565b955061369082614002565b9150600101613672565b5093949350505050565b60006136af82614008565b6136b9818561400c565b9350836020820285016136cb85614002565b60005b848110156137025783830388526136e6838351613608565b92506136f182614002565b6020989098019791506001016136ce565b50909695505050505050565b600061371982614008565b613723818561400c565b935061372e83614002565b60005b8281101561369a57613744868351613614565b955061374f82614002565b9150600101613731565b600061376482614008565b61376e818561400c565b935061377983614002565b60005b8281101561369a5761378f868351613628565b955061379a82614002565b915060010161377c565b60006137af82614008565b6137b9818561400c565b93506137c483614002565b60005b8281101561369a576137da868351613634565b95506137e582614002565b91506001016137c7565b61364981614020565b61364961380482614025565b61406f565b6136496138048261404a565b6136496138048261406f565b600061382c82614008565b613836818561082c565b9350613846818560208601614145565b9290920192915050565b600061385b82614008565b613865818561400c565b9350613875818560208601614145565b61387e81614171565b9093019392505050565b613649816140ef565b61364981614118565b61364981614123565b6136498161412e565b80516000906101608401906138c18582613891565b5060208301516138d46020860182613bab565b5060408301516138e7604086018261394e565b5060608301516138fa60c0860182613bab565b50608083015161390d60e0860182613bab565b5060a0830151613921610100860182613640565b5060c0830151613935610120860182613bab565b5060e0830151848203610140860152611ab88282613850565b8051608083019061395f84826137ef565b506020820151613972602085018261389a565b506040820151613985604085018261389a565b5060608201516125de6060850182613bab565b805160208301906125de8482613bab565b805160608301906139ba8482613bc6565b5060208201516139cd6020850182613bc6565b5060408201516125de6040850182613bb4565b805160408301906139f18482613640565b5060208201516125de6020850182613bab565b8051610160830190613a168482613640565b506020820151613a296020850182613b80565b506040820151613a3c60608501826139a9565b506060820151613a4f60c0850182613888565b506080820151613a6260e0850182613888565b5060a0820151613a76610100850182613998565b5060c0820151613a8a610120850182613998565b5060e08201516125de6101408501826137ef565b80516040830190613aaf84826137ef565b5060208201516125de6020850182613ba2565b805160c0830190613ad38482613bbd565b506020820151613ae66020850182613bbd565b506040820151613af96040850182613bbd565b506060820151613b0c6060850182613bbd565b506080820151613b1f6080850182613bbd565b5060a08201516125de60a0850182613ba2565b80516080830190613b438482613998565b506020820151613b566020850182613998565b506040820151613b696040850182613998565b5060608201516125de6060850182613998565b9052565b80516040830190613aaf8482613ba2565b805160408301906139f184826137ef565b6136498161409a565b6136498161406f565b613649816140c8565b613649816140d1565b613649816140de565b6000613bdb8284613815565b50602001919050565b6000613bf08286613821565b9150613bfc8285613809565b600282019150611ab88284613821565b6000613c188289613821565b9150613c248288613809565b600282019150613c348287613821565b9150613c408286613809565b600282019150613c508285613821565b9150613c5c82846137f8565b506001019695505050505050565b60208101610c0c8284613640565b60408101613c868285613640565b61196260208301846137ef565b60608101613ca18286613640565b613cae6020830185613bab565b611c026040830184613bab565b60608082528101613ccc818661364f565b90508181036020830152613ce08185613759565b90508181036040830152611ab881846137a4565b60208101610c0c82846137ef565b60208101610c0c8284613888565b60208101610c0c82846138a3565b60208082528101610c098184613850565b60208101610c0c8284613998565b60608101610c0c82846139a9565b6101608101610c0c8284613a04565b6102008101613d698287613a04565b613d776101608301866139a9565b613d856101c0830185613998565b611ab86101e0830184613998565b60408101610c0c8284613a9e565b60c08101610c0c8284613ac2565b60808101610c0c8284613b32565b60608101613dcb8286613b7c565b613dd86020830185613640565b611c026040830184613640565b60608101613df38286613b7c565b613e006020830185613640565b611c0260408301846137ef565b60c08101613e1b8289613b7c565b613e286020830188613640565b613e356040830187613888565b613e426060830186613888565b613e4f6080830185613998565b613e5c60a0830184613998565b979650505050505050565b60608101613e758286613b7c565b8181036020830152613e87818561370e565b90508181036040830152611ab881846136a4565b60408101613ea98285613b7c565b6119626020830184613998565b60608101613ec48286613b7c565b613dd86020830185613bab565b60608101613edf8286613b7c565b613e006020830185613bab565b60608101613efa8286613b7c565b613f076020830185613bab565b611c026040830184613888565b60608101613f228286613b7c565b613f2f6020830185613bab565b611c026040830184613998565b60408101610c0c8284613b80565b60408101613ea98285613998565b60408101610c0c8284613b91565b60208101610c0c8284613bab565b60405181810167ffffffffffffffff81118282101715613f9357600080fd5b604052919050565b600067ffffffffffffffff821115613fb257600080fd5b5060209081020190565b600067ffffffffffffffff821115613fd357600080fd5b506020601f919091017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0160190565b60200190565b5190565b90815260200190565b6000610829826140af565b151590565b7fff000000000000000000000000000000000000000000000000000000000000001690565b7fffff0000000000000000000000000000000000000000000000000000000000001690565b90565b60006009821061407e57fe5b5090565b60006002821061407e57fe5b60006003821061407e57fe5b6fffffffffffffffffffffffffffffffff1690565b73ffffffffffffffffffffffffffffffffffffffff1690565b63ffffffff1690565b67ffffffffffffffff1690565b6bffffffffffffffffffffffff1690565b600061082982614015565b60006009821061407e57600080fd5b60006002821061407e57600080fd5b600061082982614072565b600061082982614082565b60006108298261408e565b82818337506000910152565b60005b83811015614160578181015183820152602001614148565b838111156125de5750506000910152565b601f017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0169056fea265627a7a72305820dfb00714fa7976d59789d8d385c92ee41a3bdc4cc7768bf82d569e7bfb91f3c46c6578706572696d656e74616cf50037",
+  "sourceMap": "1015:360:17:-;;;1537:24:14;;;1155:218:17;8:9:-1;5:2;;;30:1;27;20:12;5:2;1155:218:17;;;;;;;;;;;;;;;;;;;;;;515:6:60;:19;;-1:-1:-1;;;;;;515:19:60;524:10;515:19;;;;;549:40;;-1:-1:-1;;;;;582:6:60;;;;;515;;549:40;;515:6;;549:40;576:1:61;560:13;:17;1294:31:17;;;:18;:31;;;;;;;;;;;;;;;-1:-1:-1;1294:31:17;;;;;;;;;1335;;:18;:31;;;;;;;;;;;;;;-1:-1:-1;;1335:31:17;;;-1:-1:-1;;;;;1335:31:17;;;;-1:-1:-1;;;;;;;;1335:31:17;;;;;;;;-1:-1:-1;;;;;;;;1335:31:17;;;;;;;;;;;;;-1:-1:-1;;;;;1335:31:17;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;;;;1335:31:17;-1:-1:-1;;;;;1335:31:17;;;;;;;;;1015:360;;31:338:-1;;149:4;137:9;132:3;128:19;124:30;121:2;;;167:1;164;157:12;121:2;185:20;200:4;185:20;;;176:29;-1:-1;256:1;287:60;343:3;323:9;287:60;;;263:85;;-1:-1;274:5;115:254;-1:-1;;115:254;408:1196;;537:4;525:9;520:3;516:19;512:30;509:2;;;555:1;552;545:12;509:2;573:20;588:4;573:20;;;564:29;-1:-1;653:1;684:59;739:3;719:9;684:59;;;660:84;;-1:-1;821:2;854:59;909:3;885:22;;;854:59;;;847:4;840:5;836:16;829:85;765:160;986:2;1019:59;1074:3;1065:6;1054:9;1050:22;1019:59;;;1012:4;1005:5;1001:16;994:85;935:155;1152:2;1185:59;1240:3;1231:6;1220:9;1216:22;1185:59;;;1178:4;1171:5;1167:16;1160:85;1100:156;1318:3;1352:59;1407:3;1398:6;1387:9;1383:22;1352:59;;;1345:4;1338:5;1334:16;1327:85;1266:157;1488:3;1522:60;1578:3;1569:6;1558:9;1554:22;1522:60;;;1515:4;1508:5;1504:16;1497:86;1433:161;503:1101;;;;;1643:927;;1772:4;1760:9;1755:3;1751:19;1747:30;1744:2;;;1790:1;1787;1780:12;1744:2;1808:20;1823:4;1808:20;;;1799:29;-1:-1;1885:1;1916:78;1990:3;1970:9;1916:78;;;1892:103;;-1:-1;2069:2;2102:78;2176:3;2152:22;;;2102:78;;;2095:4;2088:5;2084:16;2077:104;2016:176;2250:2;2283:78;2357:3;2348:6;2337:9;2333:22;2283:78;;;2276:4;2269:5;2265:16;2258:104;2202:171;2435:2;2468:80;2544:3;2535:6;2524:9;2520:22;2468:80;;;2461:4;2454:5;2450:16;2443:106;2383:177;1738:832;;;;;2952:122;;3030:39;3061:6;3055:13;3030:39;;;3021:48;3015:59;-1:-1;;;3015:59;3081:122;;3159:39;3190:6;3184:13;3159:39;;3210:120;;3287:38;3317:6;3311:13;3287:38;;3337:517;;;3527:3;3515:9;3506:7;3502:23;3498:33;3495:2;;;3544:1;3541;3534:12;3495:2;3579:1;3596:93;3681:7;3661:9;3596:93;;;3586:103;;3558:137;3726:3;3745:93;3830:7;3821:6;3810:9;3806:22;3745:93;;;3735:103;;3705:139;3489:365;;;;;;3861:256;3923:2;3917:9;3949:17;;;-1:-1;;;;;4009:34;;4045:22;;;4006:62;4003:2;;;4081:1;4078;4071:12;4003:2;4097;4090:22;3901:216;;-1:-1;3901:216;4124:120;-1:-1;;;;;4193:46;;4176:68;4251:79;4320:5;4303:27;4337:103;-1:-1;;;;;4405:30;;4388:52;;1015:360:17;;;;;;",
+  "deployedSourceMap": "1015:360:17:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;1015:360:17;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5012:292:13;;;;;;;;;:::i;:::-;;16905:174:14;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;4126:210;;;;;;;;;:::i;:::-;;;;;;;;4013:292:13;;;;;;;;;:::i;13515:255:14:-;;;;;;;;;:::i;:::-;;;;;;;;;5809:225;;;;;;;;;:::i;:::-;;;;;;;;6214:234;;;;;;;;;:::i;7295:236::-;;;;;;;;;:::i;:::-;;;;;;;;3835:125;;;:::i;:::-;;;;;;;;2237:317:13;;;;;;;;;:::i;6644:258::-;;;;;;;;;:::i;5878:238::-;;;;;;;;;:::i;6285:240::-;;;;;;;;;:::i;16408:202:14:-;;;;;;;;;:::i;11974:255::-;;;;;;;;;:::i;:::-;;;;;;;;4520:292:13;;;;;;;;;:::i;1795:150:14:-;;;:::i;5378:257::-;;;;;;;;;:::i;:::-;;;;;;;;7795:213;;;;;;;;;:::i;3154:143::-;;;:::i;:::-;;;;;;;;15195:761;;;;;;;;;:::i;:::-;;;;;;;;;;1347:137:60;;;:::i;2869:162:14:-;;;:::i;1886:371:16:-;;;;;;;;;:::i;8198:219:14:-;;;;;;;;;:::i;659:77:60:-;;;:::i;979:90::-;;;:::i;1830:313:13:-;;;;;;;;;:::i;2710:469::-;;;;;;;;;:::i;2053:260:15:-;;;;;;;;;:::i;10561:491:14:-;;;;;;;;;:::i;:::-;;;;;;;;;;;5488:224:13;;;;;;;;;:::i;2164:162:14:-;;;:::i;12457:369::-;;;;;;;;;:::i;:::-;;;;;;;;4540:223;;;;;;;;;:::i;:::-;;;;;;;;9327:346;;;;;;;;;:::i;11460:226::-;;;;;;;;;:::i;4949:223::-;;;;;;;;;:::i;13019:184::-;;;;;;;;;:::i;:::-;;;;;;;;2543:152;;;:::i;3669:277:13:-;;;;;;;;;:::i;3531:143:14:-;;;:::i;:::-;;;;;;;;9889:211;;;;;;;;;:::i;:::-;;;;;;;;3344:261:13;;;;;;;;;:::i;7140:269::-;;;;;;;;;:::i;1655:107:60:-;;;;;;;;;:::i;14527:262:14:-;;;;;;;;;:::i;6760:236::-;;;;;;;;;:::i;8602:294::-;;;;;;;;;:::i;5012:292:13:-;863:9:60;:7;:9::i;:::-;855:18;;;;;;993:13:61;:18;;1010:1;993:18;;;;;5186:111:13;;;;;:9;;:31;;:111;;993:13:61;;5252:8:13;;5274:13;;5186:111;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;5186:111:13;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;5186:111:13;;;;1102:13:61;;1086:12;:29;1078:38;;;;;;883:1:60;5012:292:13;;:::o;16905:174:14:-;17011:4;17038:34;17011:4;17063:8;17038:34;:24;:34;:::i;:::-;17031:41;;16905:174;;;;:::o;4126:210::-;4234:7;4257:29;4277:8;4257:19;:29::i;:::-;4303:26;:7;4320:8;4303:26;:16;:26;:::i;4013:292:13:-;863:9:60;:7;:9::i;:::-;855:18;;;;;;993:13:61;:18;;1010:1;993:18;;;;;4185:113:13;;;;;:9;;:32;;:113;;993:13:61;;4252:8:13;;4274:14;;4185:113;;;;13515:255:14;13629:21;;:::i;:::-;13652;;:::i;:::-;13696:67;13721:7;13757:5;13696:24;:67::i;:::-;13689:74;;;;13515:255;;;:::o;5809:225::-;5916:12;5944:29;5964:8;5944:19;:29::i;:::-;-1:-1:-1;5990:7:14;:25;;;:15;:25;;;;;:37;;;;;;5809:225::o;6214:234::-;6324:15;6355:29;6375:8;6355:19;:29::i;:::-;-1:-1:-1;6401:7:14;:25;;;:15;:25;;;;;:40;;;;;;6214:234::o;7295:236::-;7404:19;;:::i;:::-;7439:29;7459:8;7439:19;:29::i;:::-;-1:-1:-1;7485:7:14;:25;;;:15;:25;;;;;;;;;7478:46;;;;;;;;7485:39;;;;7478:46;;;;7295:236::o;3835:125::-;3905:7;3935:18;3835:125;:::o;2237:317:13:-;2404:7;863:9:60;:7;:9::i;:::-;855:18;;;;;;993:13:61;:18;;1010:1;993:18;;;;;2434:113:13;;;;;:9;;:40;;:113;;993:13:61;;2509:5:13;;2528:9;;2434:113;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;2434:113:13;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;2434:113:13;;;;;;;101:4:-1;97:9;90:4;84;80:15;76:31;69:5;65:43;126:6;120:4;113:20;0:138;2434:113:13;;;;;;;;;2427:120;;1102:13:61;;1086:12;:29;1078:38;;;;;;883:1:60;2237:317:13;;;;:::o;6644:258::-;863:9:60;:7;:9::i;:::-;855:18;;;;;;993:13:61;:18;;1010:1;993:18;;;;;6800:95:13;;;;;:9;;:34;;:95;;993:13:61;;6869:16:13;;6800:95;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;6800:95:13;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;6800:95:13;;;;1102:13:61;;1086:12;:29;1078:38;;;;;;883:1:60;6644:258:13;:::o;5878:238::-;863:9:60;:7;:9::i;:::-;855:18;;;;;;993:13:61;:18;;1010:1;993:18;;;;;6023:86:13;;;;;:9;;:35;;:86;;993:13:61;;6093:6:13;;6023:86;;;;6285:240;863:9:60;:7;:9::i;:::-;855:18;;;;;;993:13:61;:18;;1010:1;993:18;;;;;6431:87:13;;;;;:9;;:30;;:87;;993:13:61;;6496:12:13;;6431:87;;;;16408:202:14;16536:4;16563:40;16536:4;16587:5;16594:8;16563:40;:23;:40;:::i;:::-;16556:47;;16408:202;;;;;:::o;11974:255::-;12111:16;;:::i;:::-;12143:29;12163:8;12143:19;:29::i;:::-;12189:33;:7;12204;12213:8;12189:33;:14;:33;:::i;4520:292:13:-;863:9:60;:7;:9::i;:::-;855:18;;;;;;993:13:61;:18;;1010:1;993:18;;;;;4694:111:13;;;;;:9;;:31;;:111;;993:13:61;;4760:8:13;;4782:13;;4694:111;;;;1795:150:14;1866:19;;:::i;:::-;-1:-1:-1;1901:37:14;;;;;;;;;1908:18;1901:37;;;1795:150;:::o;5378:257::-;5486:21;;:::i;:::-;5523:29;5543:8;5523:19;:29::i;:::-;5569:59;5591:8;5601:26;:7;5591:8;5601:26;:16;:26;:::i;:::-;5569:7;;:59;;:21;:59;:::i;7795:213::-;7900:4;7920:29;7940:8;7920:19;:29::i;:::-;-1:-1:-1;7966:7:14;:25;;;:15;:25;;;;;:35;;;;;;7795:213::o;3154:143::-;3224:25;;:::i;:::-;-1:-1:-1;3265:25:14;;;;;;;;3272:18;3265:25;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;3265:25:14;;;;;;;;;;;;;;;;;;;;3154:143;:::o;15195:761::-;15324:16;15354:18;15386;15429;15450:7;:18;;;15429:39;;15478:23;15518:10;15504:25;;;;;;;;;;;;;;;;;;;;;;29:2:-1;21:6;17:15;117:4;105:10;97:6;88:34;136:17;;-1:-1;15504:25:14;;15478:51;;15539:23;15581:10;15565:27;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;15539:53;;15602:23;15644:10;15628:27;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;-1:-1:-1;15602:53:14;-1:-1:-1;15671:9:14;15666:200;15690:10;15686:1;:14;15666:200;;;15733:24;15755:1;15733:21;:24::i;:::-;15721:6;15728:1;15721:9;;;;;;;;;;;;;:36;;;;;;;;;;;15781:25;15795:7;15804:1;15781:13;:25::i;:::-;15771:4;15776:1;15771:7;;;;;;;;;;;;;:35;;;;15830:25;15844:7;15853:1;15830:13;:25::i;:::-;15820:4;15825:1;15820:7;;;;;;;;;;;;;;;;;:35;15702:3;;15666:200;;;-1:-1:-1;15897:6:14;;15917:4;;-1:-1:-1;15897:6:14;;-1:-1:-1;15195:761:14;-1:-1:-1;;;15195:761:14:o;1347:137:60:-;863:9;:7;:9::i;:::-;855:18;;;;;;1429:6;;1408:40;;1445:1;;1408:40;1429:6;;1408:40;;1445:1;;1408:40;1458:6;:19;;;;;;1347:137::o;2869:162:14:-;2945:21;;:::i;:::-;-1:-1:-1;2982:42:14;;;;;;;;;2989:35;2982:42;;;2869:162;:::o;1886:371:16:-;1983:9;1978:273;2002:4;:11;1998:1;:15;1978:273;;;2034:16;2053:4;2058:1;2053:7;;;;;;;;;;;;;;:16;;;2034:35;;2083:12;2098:4;2103:1;2098:7;;;;;;;;;;;;;;;;;;;:15;;;2145:10;2127:7;:29;;;:17;:29;;;;;;;:39;;;;;;;;;;:49;;;;;;;;;;2195:45;;2098:15;;-1:-1:-1;2195:45:16;;;;2127:39;;2098:15;;2195:45;;;;;;;;;;-1:-1:-1;;2015:3:16;;1978:273;;8198:219:14;8299:21;;:::i;:::-;8336:29;8356:8;8336:19;:29::i;:::-;8382:28;:7;8401:8;8382:28;:18;:28;:::i;659:77:60:-;723:6;;;;659:77;:::o;979:90::-;1056:6;;;;1042:10;:20;;979:90::o;1830:313:13:-;1995:7;863:9:60;:7;:9::i;:::-;855:18;;;;;;993:13:61;:18;;1010:1;993:18;;;;;2025:111:13;;;;;:9;;:35;;:111;;993:13:61;;2095:8:13;;2117:9;;2025:111;;;;2710:469;863:9:60;:7;:9::i;:::-;855:18;;;;;;993:13:61;:18;;1010:1;993:18;;;;;2991:181:13;;;;;:9;;:24;;:181;;993:13:61;;3050:5:13;;3069:11;;3094:14;;3122:13;;3149;;2991:181;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;2991:181:13;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;2991:181:13;;;;1102:13:61;;1086:12;:29;1078:38;;;;;;883:1:60;2710:469:13;;;;;:::o;2053:260:15:-;993:13:61;:18;;1010:1;993:18;;;;;2211:95:15;;;;;:13;;:21;;:95;;993:13:61;;2267:8:15;;2289:7;;2211:95;;;;10561:491:14;10678:21;;:::i;:::-;10713;;:::i;:::-;10748;;:::i;:::-;10783:20;;:::i;:::-;10828:29;10848:8;10828:19;:29::i;:::-;10888:19;10898:8;10888:9;:19::i;:::-;10921:31;10943:8;10921:21;:31::i;:::-;10966:24;10981:8;10966:14;:24::i;:::-;11004:31;11026:8;11004:21;:31::i;:::-;10867:178;;;;;;;;10561:491;;;;;:::o;5488:224:13:-;863:9:60;:7;:9::i;:::-;855:18;;;;;;993:13:61;:18;;1010:1;993:18;;;;;5626:79:13;;;;;:9;;:29;;:79;;993:13:61;;5690:5:13;;5626:79;;;;2164:162:14;2241:19;;:::i;:::-;-1:-1:-1;2276:43:14;;;;;;;;;2283:36;2276:43;;;2164:162;:::o;12457:369::-;12594:16;;:::i;:::-;12626:29;12646:8;12626:19;:29::i;:::-;12672:147;12703:33;:7;12718;12727:8;12703:33;:14;:33;:::i;:::-;12750:59;12772:8;12782:26;:7;12772:8;12782:26;:16;:26;:::i;12750:59::-;12672:17;:147::i;4540:223::-;4644:21;;:::i;:::-;4681:29;4701:8;4681:19;:29::i;:::-;4727;:7;4747:8;4727:29;:19;:29;:::i;9327:346::-;9475:19;;:::i;:::-;9510:33;9530:12;9510:19;:33::i;:::-;9553;9573:12;9553:19;:33::i;:::-;9603:63;:7;9639:12;9653;9603:63;:35;:63;:::i;11460:226::-;11565:16;;:::i;:::-;11597:29;11617:8;11597:19;:29::i;:::-;11643:36;:7;11670:8;11643:36;:26;:36;:::i;4949:223::-;5056:21;;:::i;:::-;5093:29;5113:8;5093:19;:29::i;:::-;5139:26;:7;5156:8;5139:26;:16;:26;:::i;13019:184::-;13133:14;13170:26;13133:14;13188:7;13170:26;:17;:26;:::i;2543:152::-;2615:19;;:::i;:::-;-1:-1:-1;2650:38:14;;;;;;;;;2657:31;2650:38;;;2543:152;:::o;3669:277:13:-;863:9:60;:7;:9::i;:::-;855:18;;;;;;993:13:61;:18;;1010:1;993:18;;;;;3832:107:13;;;;;:9;;:29;;:107;;993:13:61;;3896:8:13;;3918:11;;3832:107;;;;3531:143:14;3601:25;;:::i;:::-;-1:-1:-1;3642:25:14;;;;;;;;3649:18;3642:25;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;3531:143::o;9889:211::-;9985:21;;:::i;:::-;10022:29;10042:8;10022:19;:29::i;:::-;-1:-1:-1;10068:7:14;:25;;;:15;:25;;;;;;;;;10061:32;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;9889:211::o;3344:261:13:-;863:9:60;:7;:9::i;:::-;855:18;;;;;;993:13:61;:18;;1010:1;993:18;;;;;3495:103:13;;;;;:9;;:27;;:103;;993:13:61;;3557:8:13;;3579:9;;3495:103;;;;7140:269;863:9:60;:7;:9::i;:::-;855:18;;;;;;993:13:61;:18;;1010:1;993:18;;;;;7295:107:13;;;;;:9;;:32;;:107;;993:13:61;;7362:8:13;;7384;;7295:107;;;;1655::60;863:9;:7;:9::i;:::-;855:18;;;;;;1727:28;1746:8;1727:18;:28::i;:::-;1655:107;:::o;14527:262:14:-;14649:21;;:::i;:::-;14672;;:::i;:::-;14716:66;14741:7;14777:4;14716:24;:66::i;6760:236::-;6869:19;;:::i;:::-;6904:29;6924:8;6904:19;:29::i;:::-;-1:-1:-1;6950:7:14;:25;;;:15;:25;;;;;;;;;6943:46;;;;;;;;6950:39;;;;6943:46;;;;6760:236::o;8602:294::-;8710:20;;:::i;:::-;8746:29;8766:8;8746:19;:29::i;:::-;8792:97;8831:8;8853:26;:7;8831:8;8853:26;:16;:26;:::i;:::-;8792:7;;:97;;:25;:97;:::i;11146:207:37:-;11315:31;;11288:4;11315:31;;;:21;;;;;:31;;;;;;;;;11146:207::o;17198:220:14:-;17302:109;17339:7;:18;;;17328:8;:29;17371:4;;17302:109;:12;:109::i;4217:200:37:-;4351:7;4381:23;;;:13;;;;;:23;;;;;:29;;;;4217:200::o;17509:610:14:-;17665:21;;:::i;:::-;17688;;:::i;:::-;17725:18;17746;17801:30;;:::i;:::-;17834:24;17847:10;17834:12;:24::i;:::-;17801:57;-1:-1:-1;17873:9:14;17868:167;17892:10;17888:1;:14;17868:167;;;17928:35;:26;:7;17943;17952:1;17928:26;:14;:26;:::i;:::-;:33;:35::i;:::-;17923:102;;17983:27;:5;17999:7;18008:1;17983:27;:15;:27;:::i;:::-;;17923:102;17904:3;;17868:167;;;-1:-1:-1;18052:60:14;:7;18077;18086:5;18093:18;18052:60;:24;:60;:::i;:::-;18045:67;;;;;;17509:610;;;;;:::o;11359:230:37:-;11550:22;;;;11523:4;11550:22;;;:15;;;:22;;;;;;;;:32;;;;;;;;;;;;11359:230;;;;;;:::o;5908:279::-;6077:16;;:::i;:::-;-1:-1:-1;6131:13:37;;6116:29;;;;;;:14;;;:29;;;;;;;;6146:14;;;;6116:45;;;;;;;:64;;;;;;;;;6109:71;;;;;;;;;;;;;;;;;;;;;;;;;;5908:279;;;;;:::o;4649:214::-;4783:21;;:::i;:::-;-1:-1:-1;4827:23:37;;;;:13;;;;;:23;;;;;;;;;4820:36;;;;;;;4827:29;;;;4820:36;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;4649:214::o;7203:463::-;7379:21;;:::i;:::-;7416:25;;:::i;:::-;7444:40;:5;7468:8;7478:5;7444:40;:23;:40;:::i;:::-;7416:68;-1:-1:-1;7502:157:37;7542:5;7416:68;7579:27;:5;7597:8;7579:27;:17;:27;:::i;:::-;7502:157;;;;;;;;;7620:29;;;7502:157;;;:26;:157::i;:::-;7495:164;7203:463;-1:-1:-1;;;;;7203:463:37:o;8324:492::-;8460:21;;:::i;:::-;8497:19;8532:23;;;:13;;;:23;;;;;:35;;;;;8578:27;;:::i;:::-;8608:15;;;;8624:24;:5;8639:8;8624:24;:14;:24;:::i;:::-;8608:41;;;;;;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;8608:41:37;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;8608:41:37;;;;;;;101:4:-1;97:9;90:4;84;80:15;76:31;69:5;65:43;126:6;120:4;113:20;0:138;8608:41:37;;;;;;;;;8685:11;;8578:71;;-1:-1:-1;8659:128:37;;8685:16;;8715:4;8659:128;8769:8;8659:12;:128::i;:::-;8804:5;8324:492;-1:-1:-1;;;;8324:492:37:o;3844:552:33:-;3975:16;;:::i;:::-;4036:11;;;;4062:10;;4028:20;;;;;4058:332;;;4095:119;;;;;;;;;4129:4;4095:119;;;4180:12;;;;4095:119;;;;4158:41;;:10;;:41;;1197:6;4158:41;:21;:41;:::i;:::-;4095:119;;;4088:126;;;;;4058:332;4252:127;;;;;;;;;-1:-1:-1;4252:127:33;;4345:12;;4252:127;;;;4316:48;;:10;;:48;;1197:6;4316:48;:28;:48;:::i;4423:220:37:-;4560:21;;:::i;:::-;-1:-1:-1;4604:23:37;;;;:13;;;;:23;;;;;;;;;4597:39;;;;;;;;4604:32;;;4597:39;;;;;;;;;;;;;;;;4423:220;;;;:::o;6647:550::-;6834:19;;:::i;:::-;6886:34;;;;:40;6869:14;6981:27;;;6886:34;6981:13;;:27;;;;;;;;;6965:58;;;;;;;;6981:41;;6965:58;;;6886:40;6945:79;;6886:40;;6965:58;;:15;:58::i;:::-;6945:11;:79::i;:::-;6936:88;;7043:79;7055:6;7063:58;7079:5;:13;;:27;7093:12;7079:27;;;;;;;;;;;:41;;7063:58;;;;;;;;;;;;;;;;;:15;:58::i;7043:79::-;7139:51;;;;;;;;;;;;;6647:550;-1:-1:-1;;;;;6647:550:37:o;4869:785::-;5013:16;;:::i;:::-;5045:27;;:::i;:::-;5075:24;:5;5090:8;5075:24;:14;:24;:::i;:::-;5045:54;;5109:30;;:::i;:::-;5142:27;:5;5160:8;5142:27;:17;:27;:::i;:::-;5109:60;-1:-1:-1;5180:13:37;5196:24;:5;5211:8;5196:24;:14;:24;:::i;:::-;5180:40;;5231:27;;:::i;:::-;5261:103;;;;;;;;5291:4;5261:103;;;;;;5316:37;5332:5;5347:4;5316:15;:37::i;:::-;5261:103;;5231:133;-1:-1:-1;5389:26:37;;:::i;:::-;5429;;:::i;:::-;5468:39;5491:8;5501:5;5468:22;:39::i;:::-;5375:132;;-1:-1:-1;5375:132:37;-1:-1:-1;5607:40:37;5375:132;5607:25;:10;5375:132;5607:25;:14;:25;:::i;:::-;:29;:40;:29;:40;:::i;:::-;5600:47;4869:785;-1:-1:-1;;;;;;;;;4869:785:37:o;5660:242::-;5858:13;;5843:29;;5806:14;5843:29;;;:14;;;;;:29;;;;;;;;5873:14;;;;5843:45;;;;;;;:52;;;;;;5660:242::o;1906:183:60:-;1979:22;;;1971:31;;;;;;2038:6;;2017:38;;;;;;;2038:6;;2017:38;;2038:6;;2017:38;2065:6;:17;;;;;;;;;;;;;;;1906:183::o;7672:646:37:-;7852:20;;:::i;:::-;7888:30;;:::i;:::-;7921:27;:5;7939:8;7921:27;:17;:27;:::i;:::-;7888:60;;7972:26;;:::i;:::-;8012;;:::i;:::-;8051:39;8074:8;8084:5;8051:22;:39::i;:::-;7958:132;;;;8101:25;;:::i;:::-;8129:23;;;;:13;;;:23;;;;;:38;;;;;:54;8197:24;8129:5;8143:8;8197:24;:14;:24;:::i;:::-;8235:9;:15;;;8264:9;:15;;;8129:160;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;8129:160:37;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;8129:160:37;;;;;;;101:4:-1;97:9;90:4;84;80:15;76:31;69:5;65:43;126:6;120:4;113:20;0:138;8129:160:37;;;;;;;;;8101:188;7672:646;-1:-1:-1;;;;;;;;7672:646:37:o;1293:408:36:-;1427:4;1422:273;;1541:15;1551:4;1541:9;:15::i;:::-;1582:5;1613:17;1623:6;1613:9;:17::i;:::-;1499:153;;;;;;;;;;;;;;;22:32:-1;26:21;;;22:32;6:49;;1499:153:36;;;;1447:237;;;;;;;;;;;;;;;;;1286:219:29;1383:18;;:::i;:::-;1424:74;;;;;;;;1476:10;1459:28;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;-1:-1:-1;1424:74:29;;1417:81;1286:219;-1:-1:-1;;1286:219:29:o;3594:137:40:-;3712:7;;;:12;;;;3594:137::o;1711:549:29:-;1880:4;1904:25;:5;1920:8;1904:25;:15;:25;:::i;:::-;1900:68;;;-1:-1:-1;1952:5:29;1945:12;;1900:68;2009:26;:5;2026:8;2009:26;:16;:26;:::i;:::-;1977:13;;:23;;1991:8;;1977:23;;;;;;;;;;;;;;;;;:29;;;;:58;;;;2049:23;;;;:13;;;:23;;;;:33;;;;;2045:188;;;2134:4;2098:5;:13;;;2112:8;2098:23;;;;;;;;;;;;;;;;;;:40;;;;;2188:27;:5;2206:8;2188:27;:17;:27;:::i;:::-;:34;2152:13;;:23;;2166:8;;2152:23;;;;;;;;;;;;;;;;;:70;;;;:33;;:70;2045:188;-1:-1:-1;2249:4:29;1711:549;;;;;:::o;8822:1261:37:-;9048:21;;:::i;:::-;9071;;:::i;:::-;9108:33;;:::i;:::-;9151;;:::i;:::-;9195:18;9216:21;:5;:19;:21::i;:::-;9195:42;-1:-1:-1;9252:9:37;9247:786;9271:10;9267:1;:14;9247:786;;;9307:18;:5;9323:1;9307:18;:15;:18;:::i;:::-;9302:66;;9345:8;;9302:66;9382:24;;:::i;:::-;9409;:5;9422:7;9431:1;9409:24;:12;:24;:::i;:::-;9382:51;;9452:16;:7;:14;:16::i;:::-;9448:63;;;9488:8;;;9448:63;9525:18;9546:42;9564:17;:5;9579:1;9564:17;:14;:17;:::i;:::-;:23;9546:13;;;;;:42;:17;:42;:::i;:::-;9525:63;;9602:26;;:::i;:::-;9631:13;:11;:13::i;:::-;9602:42;;9662:18;9658:113;;;9725:16;;;;:13;;;:16;;;;;;;;;9709:47;;;;;;;;9725:30;;;;9709:47;;;;;:15;:47::i;:::-;9700:56;;9658:113;9789:12;;9785:238;;;9841:54;9863:31;9875:10;9887:6;9863:11;:31::i;:::-;9841:17;;;:54;:21;:54;:::i;:::-;9821:74;;9785:238;;;9954:54;9976:31;9988:10;10000:6;9976:11;:31::i;:::-;9954:17;;;:54;:21;:54;:::i;:::-;9934:74;;9785:238;9247:786;;;;9283:3;;9247:786;;;-1:-1:-1;10051:11:37;;10064;;-1:-1:-1;8822:1261:37;-1:-1:-1;;;;;;8822:1261:37:o;2228:1299:33:-;2444:12;;:::i;:::-;2486:26;;:::i;:::-;2526;;:::i;:::-;2565:30;2579:8;2589:5;2565:13;:30::i;:::-;2472:123;;;;2653:18;2674;:16;:18::i;:::-;2653:39;;2702:22;2727:58;2742:42;2767:5;:16;;;2742:42;;2750:11;2742:20;;:24;;:42;;;;:::i;:::-;2727:10;;;:58;:14;:58;:::i;:::-;2702:83;;2843:22;2879:23;2892:9;2879:12;:23::i;:::-;2875:328;;;-1:-1:-1;2935:1:33;2875:328;;;2984:41;2996:14;3012:12;2984:11;:41::i;:::-;2967:58;;3061:9;:15;;;3043:9;:15;;;:33;3039:154;;;3113:65;3129:14;3145:9;:15;;;3162:9;:15;;;3113;:65::i;:::-;3096:82;;3039:154;3237:14;3219;:32;;3212:40;;;;3270:250;;;;;;;;;3354:12;;3270:250;;3298:76;;:69;;;;:51;:69;3328:14;1197:6;3298:15;:51::i;:::-;:55;:69;:55;:69;:::i;:::-;:74;:76::i;:::-;3270:250;;;;;;;3452:12;;;;3270:250;;;3396:76;;:69;;;:51;:69;3426:14;1197:6;3396:15;:51::i;:76::-;3270:250;;;;;;3498:11;3270:250;;;;;3263:257;;;;;;;2228:1299;;;;;;:::o;1707:543:36:-;1867:4;1862:382;;1981:15;1991:4;1981:9;:15::i;:::-;2022:5;2053:17;2063:6;2053:9;:17::i;:::-;2096:6;2128:19;2138:8;2128:9;:19::i;:::-;1939:262;;;;;;;;;2173:6;;1939:262;;;;1862:382;1707:543;;;;:::o;1117:228:34:-;1270:7;1300:38;1326:11;1300:21;:6;1311:9;1300:21;:10;:21;:::i;:::-;:25;:38;:25;:38;:::i;1432:409::-;1592:7;1619:11;;;:29;;-1:-1:-1;1634:14:34;;1619:29;1615:151;;;1727:28;1740:1;1743:11;1727:12;:28::i;:::-;1720:35;;;;1615:151;1782:52;1832:1;1782:45;1815:11;1782:28;1832:1;1782:21;:6;1793:9;1782:21;:10;:21;:::i;:::-;:25;:28;:25;:28;:::i;1290:168:30:-;1383:11;;:::i;:::-;1417:34;;;;;;;;;1431:7;;1417:34;;1431:17;;1013:6;1431:17;:11;:17;:::i;:::-;1417:34;;1410:41;1290:168;-1:-1:-1;;1290:168:30:o;1464:188::-;1577:7;1607:38;1623:6;1631:1;:7;;;1013:6;1607:15;:38::i;1180:185:39:-;1328:30;;;;;1298:7;;1328:23;;;;;;:30;;1352:5;;1328:30;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;1328:30:39;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;1328:30:39;;;;;;;101:4:-1;97:9;90:4;84;80:15;76:31;69:5;65:43;126:6;120:4;113:20;0:138;1328:30:39;;;;;;;;5147:601:33;5291:16;;:::i;:::-;5309;;:::i;:::-;5341:26;;:::i;:::-;-1:-1:-1;5370:81:33;;;;;;;;;5400:4;5370:81;;;5425:15;;;;5370:81;;;;;;5461:26;;:::i;:::-;-1:-1:-1;5490:82:33;;;;;;;;;-1:-1:-1;5490:82:33;;5546:15;;5490:82;;;;;;5582:26;;:::i;:::-;5611;5620:9;5631:5;5611:8;:26::i;:::-;5582:55;;5647:26;;:::i;:::-;5676;5685:9;5696:5;5676:8;:26::i;:::-;5720:9;;;;-1:-1:-1;5147:601:33;;-1:-1:-1;;;;;;5147:601:33:o;4096:169:40:-;4206:10;;:::i;:::-;4239:19;4243:1;4246:11;4255:1;4246:8;:11::i;:::-;4239:3;:19::i;4912:957:36:-;5006:12;5081:19;5120:5;5103:23;;;;;;;;;;;;;22:32:-1;26:21;;;22:32;6:49;;5103:23:36;;;;-1:-1:-1;49:4;5232:571:36;5253:5;;5232:571;;5504:9;;5406:3;;;;;5504:6;;5406:3;;5504:9;;;;;;;;;;;;;;;;;:14;;;5500:293;;5559:1;5555:5;5685:22;;5692:6;-1:-1:-1;5765:13:36;;5500:293;5232:571;;;-1:-1:-1;;5850:12:36;;;5860:1;5850:12;;;;;;;;;5843:19;-1:-1:-1;;4912:957:36:o;2490:206:29:-;2622:4;2649:5;:13;;;2663:8;2649:23;;;;;;;;;;;;;;:29;;;:35;;;2688:1;2649:40;;2642:47;;2490:206;;;;:::o;2317:167::-;2457:13;:20;;2317:167::o;6193:448:37:-;6362:16;;:::i;:::-;6394:20;;:::i;:::-;6417:31;:5;6430:7;6439:8;6417:31;:12;:31;:::i;:::-;6394:54;;6463:12;:3;:10;:12::i;:::-;6459:65;;;6498:15;:13;:15::i;:::-;6491:22;;;;;6459:65;6534:27;;:::i;:::-;6564:24;:5;6579:8;6564:24;:14;:24;:::i;:::-;6534:54;;6605:29;6623:3;6628:5;6605:17;:29::i;:::-;6598:36;6193:448;-1:-1:-1;;;;;;6193:448:37:o;5723:137:40:-;5841:7;;;:12;;5723:137::o;2910:211:29:-;3041:21;;:::i;:::-;3085:13;;:23;;3099:8;;3085:23;;;;;;;;;;;;:29;;;3078:36;;2910:211;;;;:::o;229:421:59:-;287:7;527:6;523:45;;-1:-1:-1;556:1:59;549:8;;523:45;590:5;;;594:1;590;:5;:1;613:5;;;;;:10;605:19;;;;;1160:124:30;1222:11;;:::i;:::-;-1:-1:-1;1256:21:30;;;;;;;;;1013:6;1256:21;;1160:124;:::o;1658:188::-;1771:7;1801:38;1817:6;1013;1831:1;:7;;;1801:15;:38::i;1431:145:59:-;1489:7;1520:5;;;1543:6;;;;1535:15;;;;;909:132:38;979:6;1008:26;1018:15;1008:9;:26::i;:::-;1001:33;;909:132;:::o;1205:145:59:-;1263:7;1295:1;1290;:6;;1282:15;;;;;;-1:-1:-1;1319:5:59;;;1205:145::o;2148:290:34:-;2239:6;2284;2301:107;2327:16;;;;;2357:4;2301:107;:12;:107::i;5875:912:36:-;5969:12;6001:10;5997:51;;-1:-1:-1;6027:10:36;;;;;;;;;;;;;;;;;;;5997:51;6109:5;6097:9;6148:69;6155:6;;6148:69;;6177:8;;6204:2;6199:7;;;;6148:69;;;6258:17;6288:6;6278:17;;;;;;;;;;;;;;;;;;;;;;;;;21:6:-1;;104:10;6278:17:36;87:34:-1;135:17;;-1:-1;6278:17:36;-1:-1:-1;6387:5:36;;-1:-1:-1;6258:37:36;-1:-1:-1;6419:6:36;6402:357;6427:5;;6402:357;;6580:3;;6676:2;6672:1;:6;901:2;6658:21;6647:34;;6637:4;6642:1;6637:7;;;;;;;;;;;:44;;;;;;;;;;-1:-1:-1;6746:2:36;6741:7;;;;6402:357;;;-1:-1:-1;6776:4:36;5875:912;-1:-1:-1;;;;5875:912:36:o;778:296:59:-;836:7;933:1;929;:5;921:14;;;;;;945:9;961:1;957;:5;;;;;;;778:296;-1:-1:-1;;;;778:296:59:o;5201:203:40:-;5294:10;;:::i;:::-;-1:-1:-1;5327:70:40;;;;;;;;;5352:6;;5351:7;5327:70;;;5379:7;;;;5327:70;;;;5201:203;;;:::o;4271:610::-;4381:10;;:::i;:::-;4407:17;;:::i;:::-;4448:6;;4438;;:16;;;;;;4434:418;;;4484:6;;4470:20;;;;4532:7;;;;;4541;;;;4519:30;;4532:7;4519:12;:30::i;:::-;4504:12;;;:45;4434:418;;;4595:1;:7;;;4584:1;:7;;;:18;4580:262;;4636:6;;4622:20;;;;4688:7;;;;;4697;;;;4675:30;;4688:7;4675:12;:30::i;4580:262::-;4758:6;;4744:20;;;;4810:7;;;;;4819;;;;4797:30;;4810:7;4797:12;:30::i;:::-;4782:12;;;:45;:12;4271:610;-1:-1:-1;;;4271:610:40:o;3922:168::-;3988:10;;:::i;:::-;-1:-1:-1;4021:62:40;;;;;;;;;-1:-1:-1;4021:62:40;;;;;;;3922:168;:::o;2444:290:34:-;2535:6;2580;2597:107;2623:16;;;;;2653:4;2597:107;:12;:107::i;1015:360:17:-;;;;;;;;;;;;;;:::o;:::-;;;;;;;;;;-1:-1:-1;1015:360:17;;;;;;;;:::o;:::-;;;;;;;;;-1:-1:-1;1015:360:17;;;;;;;;;;;;;;;;;:::o;:::-;;;;;;;;;;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;:::i;:::-;;;;:::o;:::-;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;;;;:::o;:::-;;;;;;;;;-1:-1:-1;1015:360:17;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;:::-;;;;;;;;;;;;;;:::o;:::-;;;;;;;;;-1:-1:-1;1015:360:17;;;;;;;;;;;;:::i;5:118:-1:-;;72:46;110:6;97:20;72:46;;166:750;;307:3;300:4;292:6;288:17;284:27;274:2;;325:1;322;315:12;274:2;362:6;349:20;384:104;399:88;480:6;399:88;;;384:104;;;516:21;;;560:4;548:17;;;;375:113;;-1:-1;573:14;;548:17;668:1;653:257;678:6;675:1;672:13;653:257;;;761:3;748:17;740:6;736:30;785:61;842:3;830:10;785:61;;;773:74;;-1:-1;870:4;861:14;;;;889;;;;;700:1;693:9;653:257;;;657:14;267:649;;;;;;;;954:761;;1089:3;1082:4;1074:6;1070:17;1066:27;1056:2;;1107:1;1104;1097:12;1056:2;1144:6;1131:20;1166:98;1181:82;1256:6;1181:82;;1166:98;1157:107;;1281:5;1306:6;1299:5;1292:21;1336:4;1328:6;1324:17;1314:27;;1358:4;1353:3;1349:14;1342:21;;1411:6;1458:3;1450:4;1442:6;1438:17;1433:3;1429:27;1426:36;1423:2;;;1475:1;1472;1465:12;1423:2;1500:1;1485:224;1510:6;1507:1;1504:13;1485:224;;;1568:3;1590:55;1641:3;1629:10;1590:55;;;1578:68;;-1:-1;1669:4;1660:14;;;;1697:4;1688:14;;;;;1532:1;1525:9;1485:224;;1763:782;;1905:3;1898:4;1890:6;1886:17;1882:27;1872:2;;1923:1;1920;1913:12;1872:2;1960:6;1947:20;1982:105;1997:89;2079:6;1997:89;;1982:105;1973:114;;2104:5;2129:6;2122:5;2115:21;2159:4;2151:6;2147:17;2137:27;;2181:4;2176:3;2172:14;2165:21;;2234:6;2281:3;2273:4;2265:6;2261:17;2256:3;2252:27;2249:36;2246:2;;;2298:1;2295;2288:12;2246:2;2323:1;2308:231;2333:6;2330:1;2327:13;2308:231;;;2391:3;2413:62;2471:3;2459:10;2413:62;;;2401:75;;-1:-1;2499:4;2490:14;;;;2527:4;2518:14;;;;;2355:1;2348:9;2308:231;;2553:112;;2617:43;2652:6;2639:20;2617:43;;2673:432;;2770:3;2763:4;2755:6;2751:17;2747:27;2737:2;;2788:1;2785;2778:12;2737:2;2825:6;2812:20;2847:60;2862:44;2899:6;2862:44;;2847:60;2838:69;;2927:6;2920:5;2913:21;2963:4;2955:6;2951:17;2996:4;2989:5;2985:16;3031:3;3022:6;3017:3;3013:16;3010:25;3007:2;;;3048:1;3045;3038:12;3007:2;3058:41;3092:6;3087:3;3082;3058:41;;;2730:375;;;;;;;;3113:166;;3204:70;3266:6;3253:20;3204:70;;3453:148;;3535:61;3588:6;3575:20;3535:61;;3608:164;;3698:69;3759:6;3746:20;3698:69;;3976:1523;;4089:5;4077:9;4072:3;4068:19;4064:31;4061:2;;;4108:1;4105;4098:12;4061:2;4126:21;4141:5;4126:21;;;4117:30;-1:-1;4203:1;4234:64;4294:3;4274:9;4234:64;;;4210:89;;-1:-1;4365:2;4398:49;4443:3;4419:22;;;4398:49;;;4391:4;4384:5;4380:16;4373:75;4320:139;4511:2;4544:75;4615:3;4606:6;4595:9;4591:22;4544:75;;;4537:4;4530:5;4526:16;4519:101;4469:162;4692:3;4726:49;4771:3;4762:6;4751:9;4747:22;4726:49;;;4719:4;4712:5;4708:16;4701:75;4641:146;4850:3;4884:49;4929:3;4920:6;4909:9;4905:22;4884:49;;;4877:4;4870:5;4866:16;4859:75;4797:148;5003:3;5037:49;5082:3;5073:6;5062:9;5058:22;5037:49;;;5030:4;5023:5;5019:16;5012:75;4955:143;5158:3;5192:49;5237:3;5228:6;5217:9;5213:22;5192:49;;;5185:4;5178:5;5174:16;5167:75;5108:145;5331:3;5320:9;5316:19;5303:33;5356:18;5348:6;5345:30;5342:2;;;5388:1;5385;5378:12;5342:2;5423:54;5473:3;5464:6;5453:9;5449:22;5423:54;;;5416:4;5409:5;5405:16;5398:80;5263:226;4055:1444;;;;;5537:803;;5652:4;5640:9;5635:3;5631:19;5627:30;5624:2;;;5670:1;5667;5660:12;5624:2;5688:20;5703:4;5688:20;;;5679:29;-1:-1;5758:1;5789:46;5831:3;5811:9;5789:46;;;5765:71;;-1:-1;5905:2;5938:72;6006:3;5982:22;;;5938:72;;;5931:4;5924:5;5920:16;5913:98;5857:165;6071:2;6104:69;6169:3;6160:6;6149:9;6145:22;6104:69;;;6097:4;6090:5;6086:16;6079:95;6032:153;6236:2;6269:49;6314:3;6305:6;6294:9;6290:22;6269:49;;;6262:4;6255:5;6251:16;6244:75;6195:135;5618:722;;;;;6373:320;;6484:4;6472:9;6467:3;6463:19;6459:30;6456:2;;;6502:1;6499;6492:12;6456:2;6520:20;6535:4;6520:20;;;6511:29;-1:-1;6591:1;6622:49;6667:3;6647:9;6622:49;;;6598:74;;-1:-1;6609:5;6450:243;-1:-1;;6450:243;6726:462;;6833:4;6821:9;6816:3;6812:19;6808:30;6805:2;;;6851:1;6848;6841:12;6805:2;6869:20;6884:4;6869:20;;;6860:29;-1:-1;6940:1;6971:49;7016:3;6996:9;6971:49;;;6947:74;;-1:-1;7084:2;7117:49;7162:3;7138:22;;;7117:49;;;7110:4;7103:5;7099:16;7092:75;7042:136;6799:389;;;;;7730:470;;7844:4;7832:9;7827:3;7823:19;7819:30;7816:2;;;7862:1;7859;7852:12;7816:2;7880:20;7895:4;7880:20;;;7871:29;-1:-1;7954:1;7985:49;8030:3;8010:9;7985:49;;;7961:74;;-1:-1;8099:2;8132:46;8174:3;8150:22;;;8132:46;;8235:344;;8359:4;8347:9;8342:3;8338:19;8334:30;8331:2;;;8377:1;8374;8367:12;8331:2;8395:20;8410:4;8395:20;;;8386:29;-1:-1;8466:1;8497:60;8553:3;8533:9;8497:60;;9319:118;;9386:46;9424:6;9411:20;9386:46;;9444:122;;9522:39;9553:6;9547:13;9522:39;;9573:241;;9677:2;9665:9;9656:7;9652:23;9648:32;9645:2;;;9693:1;9690;9683:12;9645:2;9728:1;9745:53;9790:7;9770:9;9745:53;;9821:366;;;9942:2;9930:9;9921:7;9917:23;9913:32;9910:2;;;9958:1;9955;9948:12;9910:2;9993:1;10010:53;10055:7;10035:9;10010:53;;;10000:63;;9972:97;10100:2;10118:53;10163:7;10154:6;10143:9;10139:22;10118:53;;;10108:63;;10079:98;9904:283;;;;;;10194:360;;;10312:2;10300:9;10291:7;10287:23;10283:32;10280:2;;;10328:1;10325;10318:12;10280:2;10363:1;10380:53;10425:7;10405:9;10380:53;;;10370:63;;10342:97;10470:2;10488:50;10530:7;10521:6;10510:9;10506:22;10488:50;;10561:921;;;;;;10822:3;10810:9;10801:7;10797:23;10793:33;10790:2;;;10839:1;10836;10829:12;10790:2;10874:1;10891:53;10936:7;10916:9;10891:53;;;10881:63;;10853:97;10981:2;10999:74;11065:7;11056:6;11045:9;11041:22;10999:74;;;10989:84;;10960:119;11110:2;11128:77;11197:7;11188:6;11177:9;11173:22;11128:77;;;11118:87;;11089:122;11242:2;11260:75;11327:7;11318:6;11307:9;11303:22;11260:75;;;11250:85;;11221:120;11372:3;11391:75;11458:7;11449:6;11438:9;11434:22;11391:75;;;11381:85;;11351:121;10784:698;;;;;;;;;11489:722;;;11702:2;11690:9;11681:7;11677:23;11673:32;11670:2;;;11718:1;11715;11708:12;11670:2;11753:31;;11804:18;11793:30;;11790:2;;;11836:1;11833;11826:12;11790:2;11856:96;11944:7;11935:6;11924:9;11920:22;11856:96;;;11846:106;;11732:226;12017:2;12006:9;12002:18;11989:32;12041:18;12033:6;12030:30;12027:2;;;12073:1;12070;12063:12;12027:2;12093:102;12187:7;12178:6;12167:9;12163:22;12093:102;;12218:427;;12372:2;12360:9;12351:7;12347:23;12343:32;12340:2;;;12388:1;12385;12378:12;12340:2;12423:31;;12474:18;12463:30;;12460:2;;;12506:1;12503;12496:12;12460:2;12526:103;12621:7;12612:6;12601:9;12597:22;12526:103;;12652:285;;12778:2;12766:9;12757:7;12753:23;12749:32;12746:2;;;12794:1;12791;12784:12;12746:2;12829:1;12846:75;12913:7;12893:9;12846:75;;12944:285;;13070:2;13058:9;13049:7;13045:23;13041:32;13038:2;;;13086:1;13083;13076:12;13038:2;13121:1;13138:75;13205:7;13185:9;13138:75;;13236:410;;;13379:2;13367:9;13358:7;13354:23;13350:32;13347:2;;;13395:1;13392;13385:12;13347:2;13430:1;13447:75;13514:7;13494:9;13447:75;;;13437:85;;13409:119;13559:2;13577:53;13622:7;13613:6;13602:9;13598:22;13577:53;;13653:311;;13792:2;13780:9;13771:7;13767:23;13763:32;13760:2;;;13808:1;13805;13798:12;13760:2;13843:1;13860:88;13940:7;13920:9;13860:88;;14581:241;;14685:2;14673:9;14664:7;14660:23;14656:32;14653:2;;;14701:1;14698;14691:12;14653:2;14736:1;14753:53;14798:7;14778:9;14753:53;;14829:263;;14944:2;14932:9;14923:7;14919:23;14915:32;14912:2;;;14960:1;14957;14950:12;14912:2;14995:1;15012:64;15068:7;15048:9;15012:64;;15099:366;;;15220:2;15208:9;15199:7;15195:23;15191:32;15188:2;;;15236:1;15233;15226:12;15188:2;15271:1;15288:53;15333:7;15313:9;15288:53;;15472:360;;;15590:2;15578:9;15569:7;15565:23;15561:32;15558:2;;;15606:1;15603;15596:12;15558:2;15641:1;15658:53;15703:7;15683:9;15658:53;;15839:414;;;15984:2;15972:9;15963:7;15959:23;15955:32;15952:2;;;16000:1;15997;15990:12;15952:2;16035:1;16052:53;16097:7;16077:9;16052:53;;;16042:63;;16014:97;16142:2;16160:77;16229:7;16220:6;16209:9;16205:22;16160:77;;16675:410;;;16818:2;16806:9;16797:7;16793:23;16789:32;16786:2;;;16834:1;16831;16824:12;16786:2;16869:1;16886:53;16931:7;16911:9;16886:53;;;16876:63;;16848:97;16976:2;16994:75;17061:7;17052:6;17041:9;17037:22;16994:75;;17092:366;;;17213:2;17201:9;17192:7;17188:23;17184:32;17181:2;;;17229:1;17226;17219:12;17181:2;17264:1;17281:53;17326:7;17306:9;17281:53;;;17271:63;;17243:97;17371:2;17389:53;17434:7;17425:6;17414:9;17410:22;17389:53;;17466:173;;17553:46;17595:3;17587:6;17553:46;;;-1:-1;;17628:4;17619:14;;17546:93;17648:269;;17805:106;17907:3;17899:6;17805:106;;17926:265;;18057:94;18147:3;18139:6;18057:94;;;-1:-1;;18180:4;18171:14;;18050:141;18200:249;;18323:86;18405:3;18397:6;18323:86;;18458:249;;18581:86;18663:3;18655:6;18581:86;;18715:110;18788:31;18813:5;18788:31;;;18783:3;18776:44;18770:55;;;19250:621;;19395:54;19443:5;19395:54;;;19462:86;19541:6;19536:3;19462:86;;;19455:93;;19568:56;19618:5;19568:56;;;19645:1;19630:219;19655:6;19652:1;19649:13;19630:219;;;19702:63;19761:3;19752:6;19746:13;19702:63;;;19695:70;;19782:60;19835:6;19782:60;;;19772:70;-1:-1;19677:1;19670:9;19630:219;;;-1:-1;19862:3;;19374:497;-1:-1;;;;19374:497;19946:995;;20147:78;20219:5;20147:78;;;20238:118;20349:6;20344:3;20238:118;;;20231:125;;20379:3;20421:4;20413:6;20409:17;20404:3;20400:27;20447:80;20521:5;20447:80;;;20548:1;20533:369;20558:6;20555:1;20552:13;20533:369;;;20620:9;20614:4;20610:20;20605:3;20598:33;20646:120;20761:4;20752:6;20746:13;20646:120;;;20638:128;;20783:84;20860:6;20783:84;;;20890:4;20881:14;;;;;20773:94;-1:-1;20580:1;20573:9;20533:369;;;-1:-1;20915:4;;20126:815;-1:-1;;;;;;20126:815;21004:789;;21193:72;21259:5;21193:72;;;21278:112;21383:6;21378:3;21278:112;;;21271:119;;21410:74;21478:5;21410:74;;;21505:1;21490:281;21515:6;21512:1;21509:13;21490:281;;;21562:107;21665:3;21656:6;21650:13;21562:107;;;21555:114;;21686:78;21757:6;21686:78;;;21676:88;-1:-1;21537:1;21530:9;21490:281;;21850:765;;22031:72;22097:5;22031:72;;;22116:104;22213:6;22208:3;22116:104;;;22109:111;;22240:74;22308:5;22240:74;;;22335:1;22320:273;22345:6;22342:1;22339:13;22320:273;;;22392:99;22487:3;22478:6;22472:13;22392:99;;;22385:106;;22508:78;22579:6;22508:78;;;22498:88;-1:-1;22367:1;22360:9;22320:273;;22672:765;;22853:72;22919:5;22853:72;;;22938:104;23035:6;23030:3;22938:104;;;22931:111;;23062:74;23130:5;23062:74;;;23157:1;23142:273;23167:6;23164:1;23161:13;23142:273;;;23214:99;23309:3;23300:6;23294:13;23214:99;;;23207:106;;23330:78;23401:6;23330:78;;;23320:88;-1:-1;23189:1;23182:9;23142:273;;23445:101;23512:28;23534:5;23512:28;;23913:155;24012:50;24031:30;24055:5;24031:30;;;24012:50;;24075:155;24174:50;24193:30;24217:5;24193:30;;24237:159;24338:52;24358:31;24383:5;24358:31;;24403:356;;24531:38;24563:5;24531:38;;;24581:88;24662:6;24657:3;24581:88;;;24574:95;;24674:52;24719:6;24714:3;24707:4;24700:5;24696:16;24674:52;;;24738:16;;;;;24511:248;-1:-1;;24511:248;24766:331;;24870:34;24898:5;24870:34;;;24916:68;24977:6;24972:3;24916:68;;;24909:75;;24989:52;25034:6;25029:3;25022:4;25015:5;25011:16;24989:52;;;25062:29;25084:6;25062:29;;;25053:39;;;;24850:247;-1:-1;;;24850:247;25104:164;25201:61;25256:5;25201:61;;26168:150;26262:50;26306:5;26262:50;;26325:166;26427:58;26479:5;26427:58;;26665:144;26757:46;26797:5;26757:46;;27231:1663;27454:22;;27231:1663;;27382:5;27373:15;;;27482:82;27377:3;27454:22;27482:82;;;27403:167;27647:4;27640:5;27636:16;27630:23;27659:70;27723:4;27718:3;27714:14;27701:11;27659:70;;;27580:155;27809:4;27802:5;27798:16;27792:23;27821:126;27941:4;27936:3;27932:14;27919:11;27821:126;;;27745:208;28036:4;28029:5;28025:16;28019:23;28048:70;28112:4;28107:3;28103:14;28090:11;28048:70;;;27963:161;28209:4;28202:5;28198:16;28192:23;28221:70;28285:4;28280:3;28276:14;28263:11;28221:70;;;28134:163;28377:4;28370:5;28366:16;28360:23;28389:71;28453:5;28448:3;28444:15;28431:11;28389:71;;;28307:159;28548:4;28541:5;28537:16;28531:23;28560:71;28624:5;28619:3;28615:15;28602:11;28560:71;;;28476:161;28709:4;28702:5;28698:16;28692:23;28762:3;28756:4;28752:14;28744:5;28739:3;28735:15;28728:39;28782:74;28851:4;28838:11;28782:74;;28960:851;29172:22;;29107:4;29098:14;;;29200:63;29102:3;29172:22;29200:63;;;29127:142;29349:4;29342:5;29338:16;29332:23;29361:91;29446:4;29441:3;29437:14;29424:11;29361:91;;;29279:179;29529:4;29522:5;29518:16;29512:23;29541:88;29623:4;29618:3;29614:14;29601:11;29541:88;;;29468:167;29708:4;29701:5;29697:16;29691:23;29720:70;29784:4;29779:3;29775:14;29762:11;29720:70;;29867:313;30070:22;;30004:4;29995:14;;;30098:61;29999:3;30070:22;30098:61;;30980:622;31186:22;;31119:4;31110:14;;;31214:59;31114:3;31186:22;31214:59;;;31139:140;31353:4;31346:5;31342:16;31336:23;31365:60;31419:4;31414:3;31410:14;31397:11;31365:60;;;31289:142;31509:4;31502:5;31498:16;31492:23;31521:60;31575:4;31570:3;31566:14;31553:11;31521:60;;32326:477;32523:22;;32457:4;32448:14;;;32551:69;32452:3;32523:22;32551:69;;;32477:149;32700:4;32693:5;32689:16;32683:23;32712:70;32776:4;32771:3;32767:14;32754:11;32712:70;;32863:1643;33073:22;;33006:5;32997:15;;;33101:61;33001:3;33073:22;33101:61;;;33027:141;33244:4;33237:5;33233:16;33227:23;33256:112;33362:4;33357:3;33353:14;33340:11;33256:112;;;33178:196;33447:4;33440:5;33436:16;33430:23;33459:104;33557:4;33552:3;33548:14;33535:11;33459:104;;;33384:185;33648:4;33641:5;33637:16;33631:23;33660:83;33737:4;33732:3;33728:14;33715:11;33660:83;;;33579:170;33831:4;33824:5;33820:16;33814:23;33843:86;33923:4;33918:3;33914:14;33901:11;33843:86;;;33759:176;34016:4;34009:5;34005:16;33999:23;34028:103;34124:5;34119:3;34115:15;34102:11;34028:103;;;33945:192;34218:4;34211:5;34207:16;34201:23;34230:103;34326:5;34321:3;34317:15;34304:11;34230:103;;;34147:192;34416:4;34409:5;34405:16;34399:23;34428:57;34478:5;34473:3;34469:15;34456:11;34428:57;;34556:459;34758:22;;34693:4;34684:14;;;34786:55;34688:3;34758:22;34786:55;;;34713:134;34920:4;34913:5;34909:16;34903:23;34932:62;34988:4;34983:3;34979:14;34966:11;34932:62;;36326:1152;36552:22;;36477:4;36468:14;;;36580:59;36472:3;36552:22;36580:59;;;36497:148;36733:4;36726:5;36722:16;36716:23;36745:60;36799:4;36794:3;36790:14;36777:11;36745:60;;;36655:156;36894:4;36887:5;36883:16;36877:23;36906:60;36960:4;36955:3;36951:14;36938:11;36906:60;;;36821:151;37056:4;37049:5;37045:16;37039:23;37068:60;37122:4;37117:3;37113:14;37100:11;37068:60;;;36982:152;37218:4;37211:5;37207:16;37201:23;37230:60;37284:4;37279:3;37275:14;37262:11;37230:60;;;37144:152;37383:4;37376:5;37372:16;37366:23;37395:62;37451:4;37446:3;37442:14;37429:11;37395:62;;37546:986;37769:22;;37697:4;37688:14;;;37797:101;37692:3;37769:22;37797:101;;;37717:187;37989:4;37982:5;37978:16;37972:23;38001:102;38097:4;38092:3;38088:14;38075:11;38001:102;;;37914:195;38189:4;38182:5;38178:16;38172:23;38201:102;38297:4;38292:3;38288:14;38275:11;38201:102;;;38119:190;38393:4;38386:5;38382:16;38376:23;38405:106;38505:4;38500:3;38496:14;38483:11;38405:106;;38539:123;38639:18;;38633:29;38722:478;38936:22;;38869:4;38860:14;;;38964:61;38864:3;38936:22;38964:61;;40907:459;41109:22;;41044:4;41035:14;;;41137:55;41039:3;41109:22;41137:55;;41868:110;41941:31;41966:5;41941:31;;41985:110;42058:31;42083:5;42058:31;;42489:107;42560:30;42584:5;42560:30;;42603:107;42674:30;42698:5;42674:30;;42717:107;42788:30;42812:5;42788:30;;42831:244;;42950:75;43021:3;43012:6;42950:75;;;-1:-1;43047:2;43038:12;;42938:137;-1:-1;42938:137;43082:553;;43298:93;43387:3;43378:6;43298:93;;;43291:100;;43402:73;43471:3;43462:6;43402:73;;;43497:1;43492:3;43488:11;43481:18;;43517:93;43606:3;43597:6;43517:93;;43642:978;;43956:93;44045:3;44036:6;43956:93;;;43949:100;;44060:73;44129:3;44120:6;44060:73;;;44155:1;44150:3;44146:11;44139:18;;44175:93;44264:3;44255:6;44175:93;;;44168:100;;44279:73;44348:3;44339:6;44279:73;;;44374:1;44369:3;44365:11;44358:18;;44394:93;44483:3;44474:6;44394:93;;;44387:100;;44498:73;44567:3;44558:6;44498:73;;;-1:-1;44593:1;44584:11;;43937:683;-1:-1;;;;;;43937:683;44627:213;44745:2;44730:18;;44759:71;44734:9;44803:6;44759:71;;44847:312;44987:2;44972:18;;45001:71;44976:9;45045:6;45001:71;;;45083:66;45145:2;45134:9;45130:18;45121:6;45083:66;;45166:435;45340:2;45325:18;;45354:71;45329:9;45398:6;45354:71;;;45436:72;45504:2;45493:9;45489:18;45480:6;45436:72;;;45519;45587:2;45576:9;45572:18;45563:6;45519:72;;45608:1023;46004:2;46018:47;;;45989:18;;46079:108;45989:18;46173:6;46079:108;;;46071:116;;46235:9;46229:4;46225:20;46220:2;46209:9;46205:18;46198:48;46260:144;46399:4;46390:6;46260:144;;;46252:152;;46452:9;46446:4;46442:20;46437:2;46426:9;46422:18;46415:48;46477:144;46616:4;46607:6;46477:144;;46638:201;46750:2;46735:18;;46764:65;46739:9;46802:6;46764:65;;46846:261;46988:2;46973:18;;47002:95;46977:9;47070:6;47002:95;;47376:231;47503:2;47488:18;;47517:80;47492:9;47570:6;47517:80;;47614:301;47752:2;47766:47;;;47737:18;;47827:78;47737:18;47891:6;47827:78;;47922:301;48084:2;48069:18;;48098:115;48073:9;48186:6;48098:115;;48230:305;48394:2;48379:18;;48408:117;48383:9;48498:6;48408:117;;48542:314;48710:3;48695:19;;48725:121;48699:9;48819:6;48725:121;;48863:926;49253:3;49238:19;;49268:121;49242:9;49362:6;49268:121;;;49400:119;49514:3;49503:9;49499:19;49490:6;49400:119;;;49530:121;49646:3;49635:9;49631:19;49622:6;49530:121;;;49662:117;49774:3;49763:9;49759:19;49750:6;49662:117;;49796:301;49958:2;49943:18;;49972:115;49947:9;50060:6;49972:115;;50728:330;50904:3;50889:19;;50919:129;50893:9;51021:6;50919:129;;51065:330;51241:3;51226:19;;51256:129;51230:9;51358:6;51256:129;;51402:509;51605:2;51590:18;;51619:100;51594:9;51692:6;51619:100;;;51730:80;51806:2;51795:9;51791:18;51782:6;51730:80;;;51821;51897:2;51886:9;51882:18;51873:6;51821:80;;51918:497;52115:2;52100:18;;52129:100;52104:9;52202:6;52129:100;;;52240:80;52316:2;52305:9;52301:18;52292:6;52240:80;;;52331:74;52401:2;52390:9;52386:18;52377:6;52331:74;;52422:1135;52842:3;52827:19;;52857:100;52831:9;52930:6;52857:100;;;52968:80;53044:2;53033:9;53029:18;53020:6;52968:80;;;53059:101;53156:2;53145:9;53141:18;53132:6;53059:101;;;53171:104;53271:2;53260:9;53256:18;53247:6;53171:104;;;53286:125;53406:3;53395:9;53391:19;53382:6;53286:125;;;53422;53542:3;53531:9;53527:19;53518:6;53422:125;;;52813:744;;;;;;;;;;53564:973;53951:2;53936:18;;53965:100;53940:9;54038:6;53965:100;;;54113:9;54107:4;54103:20;54098:2;54087:9;54083:18;54076:48;54138:152;54285:4;54276:6;54138:152;;;54130:160;;54338:9;54332:4;54328:20;54323:2;54312:9;54308:18;54301:48;54363:164;54522:4;54513:6;54363:164;;54544:478;54763:2;54748:18;;54777:100;54752:9;54850:6;54777:100;;;54888:124;55008:2;54997:9;54993:18;54984:6;54888:124;;55522:509;55725:2;55710:18;;55739:100;55714:9;55812:6;55739:100;;;55850:80;55926:2;55915:9;55911:18;55902:6;55850:80;;56038:497;56235:2;56220:18;;56249:100;56224:9;56322:6;56249:100;;;56360:80;56436:2;56425:9;56421:18;56412:6;56360:80;;56542:557;56769:2;56754:18;;56783:100;56758:9;56856:6;56783:100;;;56894:80;56970:2;56959:9;56955:18;56946:6;56894:80;;;56985:104;57085:2;57074:9;57070:18;57061:6;56985:104;;57664:597;57911:2;57896:18;;57925:100;57900:9;57998:6;57925:100;;;58036:80;58112:2;58101:9;58097:18;58088:6;58036:80;;;58127:124;58247:2;58236:9;58232:18;58223:6;58127:124;;58268:321;58440:2;58425:18;;58454:125;58429:9;58552:6;58454:125;;58912:516;59154:2;59139:18;;59168:119;59143:9;59260:6;59168:119;;59435:301;59597:2;59582:18;;59611:115;59586:9;59699:6;59611:115;;59743:213;59861:2;59846:18;;59875:71;59850:9;59919:6;59875:71;;59963:256;60025:2;60019:9;60051:17;;;60126:18;60111:34;;60147:22;;;60108:62;60105:2;;;60183:1;60180;60173:12;60105:2;60199;60192:22;60003:216;;-1:-1;60003:216;60226:282;;60409:18;60401:6;60398:30;60395:2;;;60441:1;60438;60431:12;60395:2;-1:-1;60470:4;60458:17;;;60488:15;;60332:176;61088:254;;61227:18;61219:6;61216:30;61213:2;;;61259:1;61256;61249:12;61213:2;-1:-1;61332:4;61303;61280:17;;;;61299:9;61276:33;61322:15;;61150:192;61351:121;61460:4;61448:17;;61429:43;62087:107;62177:12;;62161:33;63760:178;63878:19;;;63927:4;63918:14;;63871:67;65282:105;;65351:31;65376:5;65351:31;;65394:92;65467:13;65460:21;;65443:43;65493:151;65572:66;65561:78;;65544:100;65651:151;65730:66;65719:78;;65702:100;65809:79;65878:5;65861:27;65895:132;;65988:1;65981:5;65978:12;65968:2;;65994:9;65968:2;-1:-1;66017:5;65962:65;66034:140;;66135:1;66128:5;66125:12;66115:2;;66141:9;66325:128;;66414:1;66407:5;66404:12;66394:2;;66420:9;66460:120;66540:34;66529:46;;66512:68;66587:128;66667:42;66656:54;;66639:76;66808:95;66887:10;66876:22;;66859:44;66910:103;66989:18;66978:30;;66961:52;67020:111;67099:26;67088:38;;67071:60;67349:129;;67442:31;67467:5;67442:31;;67618:135;;67711:1;67704:5;67701:12;67691:2;;67727:1;67724;67717:12;67760:143;;67861:1;67854:5;67851:12;67841:2;;67877:1;67874;67867:12;68913:143;;69005:46;69045:5;69005:46;;69063:159;;69163:54;69211:5;69163:54;;69389:135;;69477:42;69513:5;69477:42;;69532:145;69613:6;69608:3;69603;69590:30;-1:-1;69669:1;69651:16;;69644:27;69583:94;69686:268;69751:1;69758:101;69772:6;69769:1;69766:13;69758:101;;;69839:11;;;69833:18;69820:11;;;69813:39;69794:2;69787:10;69758:101;;;69874:6;69871:1;69868:13;69865:2;;;-1:-1;;69939:1;69921:16;;69914:27;69735:219;70203:97;70291:2;70271:14;70287:7;70267:28;;70251:49",
+  "source": "/*\n\n    Copyright 2019 dYdX Trading Inc.\n\n    Licensed under the Apache License, Version 2.0 (the \"License\");\n    you may not use this file except in compliance with the License.\n    You may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\n    Unless required by applicable law or agreed to in writing, software\n    distributed under the License is distributed on an \"AS IS\" BASIS,\n    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n    See the License for the specific language governing permissions and\n    limitations under the License.\n\n*/\n\npragma solidity 0.5.7;\npragma experimental ABIEncoderV2;\n\nimport { Admin } from \"./Admin.sol\";\nimport { Getters } from \"./Getters.sol\";\nimport { Operation } from \"./Operation.sol\";\nimport { Permission } from \"./Permission.sol\";\nimport { State } from \"./State.sol\";\nimport { Storage } from \"./lib/Storage.sol\";\n\n\n/**\n * @title SoloMargin\n * @author dYdX\n *\n * Main contract that inherits from other contracts\n */\ncontract SoloMargin is\n    State,\n    Admin,\n    Getters,\n    Operation,\n    Permission\n{\n    // ============ Constructor ============\n\n    constructor(\n        Storage.RiskParams memory riskParams,\n        Storage.RiskLimits memory riskLimits\n    )\n        public\n    {\n        g_state.riskParams = riskParams;\n        g_state.riskLimits = riskLimits;\n    }\n}\n",
+  "sourcePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/SoloMargin.sol",
+  "ast": {
+    "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/SoloMargin.sol",
+    "exportedSymbols": {
+      "SoloMargin": [
+        5075
+      ]
+    },
+    "id": 5076,
+    "nodeType": "SourceUnit",
+    "nodes": [
+      {
+        "id": 5031,
+        "literals": [
+          "solidity",
+          "0.5",
+          ".7"
+        ],
+        "nodeType": "PragmaDirective",
+        "src": "603:22:17"
+      },
+      {
+        "id": 5032,
+        "literals": [
+          "experimental",
+          "ABIEncoderV2"
+        ],
+        "nodeType": "PragmaDirective",
+        "src": "626:33:17"
+      },
+      {
+        "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/Admin.sol",
+        "file": "./Admin.sol",
+        "id": 5034,
+        "nodeType": "ImportDirective",
+        "scope": 5076,
+        "sourceUnit": 4223,
+        "src": "661:36:17",
+        "symbolAliases": [
+          {
+            "foreign": 5033,
+            "local": null
+          }
+        ],
+        "unitAlias": ""
+      },
+      {
+        "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/Getters.sol",
+        "file": "./Getters.sol",
+        "id": 5036,
+        "nodeType": "ImportDirective",
+        "scope": 5076,
+        "sourceUnit": 4919,
+        "src": "698:40:17",
+        "symbolAliases": [
+          {
+            "foreign": 5035,
+            "local": null
+          }
+        ],
+        "unitAlias": ""
+      },
+      {
+        "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/Operation.sol",
+        "file": "./Operation.sol",
+        "id": 5038,
+        "nodeType": "ImportDirective",
+        "scope": 5076,
+        "sourceUnit": 4957,
+        "src": "739:44:17",
+        "symbolAliases": [
+          {
+            "foreign": 5037,
+            "local": null
+          }
+        ],
+        "unitAlias": ""
+      },
+      {
+        "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/Permission.sol",
+        "file": "./Permission.sol",
+        "id": 5040,
+        "nodeType": "ImportDirective",
+        "scope": 5076,
+        "sourceUnit": 5030,
+        "src": "784:46:17",
+        "symbolAliases": [
+          {
+            "foreign": 5039,
+            "local": null
+          }
+        ],
+        "unitAlias": ""
+      },
+      {
+        "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/State.sol",
+        "file": "./State.sol",
+        "id": 5042,
+        "nodeType": "ImportDirective",
+        "scope": 5076,
+        "sourceUnit": 5084,
+        "src": "831:36:17",
+        "symbolAliases": [
+          {
+            "foreign": 5041,
+            "local": null
+          }
+        ],
+        "unitAlias": ""
+      },
+      {
+        "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Storage.sol",
+        "file": "./lib/Storage.sol",
+        "id": 5044,
+        "nodeType": "ImportDirective",
+        "scope": 5076,
+        "sourceUnit": 12382,
+        "src": "868:44:17",
+        "symbolAliases": [
+          {
+            "foreign": 5043,
+            "local": null
+          }
+        ],
+        "unitAlias": ""
+      },
+      {
+        "baseContracts": [
+          {
+            "arguments": null,
+            "baseName": {
+              "contractScope": null,
+              "id": 5045,
+              "name": "State",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 5083,
+              "src": "1042:5:17",
+              "typeDescriptions": {
+                "typeIdentifier": "t_contract$_State_$5083",
+                "typeString": "contract State"
+              }
+            },
+            "id": 5046,
+            "nodeType": "InheritanceSpecifier",
+            "src": "1042:5:17"
+          },
+          {
+            "arguments": null,
+            "baseName": {
+              "contractScope": null,
+              "id": 5047,
+              "name": "Admin",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 4222,
+              "src": "1053:5:17",
+              "typeDescriptions": {
+                "typeIdentifier": "t_contract$_Admin_$4222",
+                "typeString": "contract Admin"
+              }
+            },
+            "id": 5048,
+            "nodeType": "InheritanceSpecifier",
+            "src": "1053:5:17"
+          },
+          {
+            "arguments": null,
+            "baseName": {
+              "contractScope": null,
+              "id": 5049,
+              "name": "Getters",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 4918,
+              "src": "1064:7:17",
+              "typeDescriptions": {
+                "typeIdentifier": "t_contract$_Getters_$4918",
+                "typeString": "contract Getters"
+              }
+            },
+            "id": 5050,
+            "nodeType": "InheritanceSpecifier",
+            "src": "1064:7:17"
+          },
+          {
+            "arguments": null,
+            "baseName": {
+              "contractScope": null,
+              "id": 5051,
+              "name": "Operation",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 4956,
+              "src": "1077:9:17",
+              "typeDescriptions": {
+                "typeIdentifier": "t_contract$_Operation_$4956",
+                "typeString": "contract Operation"
+              }
+            },
+            "id": 5052,
+            "nodeType": "InheritanceSpecifier",
+            "src": "1077:9:17"
+          },
+          {
+            "arguments": null,
+            "baseName": {
+              "contractScope": null,
+              "id": 5053,
+              "name": "Permission",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 5029,
+              "src": "1092:10:17",
+              "typeDescriptions": {
+                "typeIdentifier": "t_contract$_Permission_$5029",
+                "typeString": "contract Permission"
+              }
+            },
+            "id": 5054,
+            "nodeType": "InheritanceSpecifier",
+            "src": "1092:10:17"
+          }
+        ],
+        "contractDependencies": [
+          4222,
+          4918,
+          4956,
+          5029,
+          5083,
+          18628,
+          18659
+        ],
+        "contractKind": "contract",
+        "documentation": "@title SoloMargin\n@author dYdX\n * Main contract that inherits from other contracts",
+        "fullyImplemented": true,
+        "id": 5075,
+        "linearizedBaseContracts": [
+          5075,
+          5029,
+          4956,
+          4918,
+          4222,
+          18659,
+          18628,
+          5083
+        ],
+        "name": "SoloMargin",
+        "nodeType": "ContractDefinition",
+        "nodes": [
+          {
+            "body": {
+              "id": 5073,
+              "nodeType": "Block",
+              "src": "1284:89:17",
+              "statements": [
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 5065,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "expression": {
+                        "argumentTypes": null,
+                        "id": 5061,
+                        "name": "g_state",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 5082,
+                        "src": "1294:7:17",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_struct$_State_$11085_storage",
+                          "typeString": "struct Storage.State storage ref"
+                        }
+                      },
+                      "id": 5063,
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "memberName": "riskParams",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 11082,
+                      "src": "1294:18:17",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_RiskParams_$11045_storage",
+                        "typeString": "struct Storage.RiskParams storage ref"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "id": 5064,
+                      "name": "riskParams",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 5056,
+                      "src": "1315:10:17",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_RiskParams_$11045_memory_ptr",
+                        "typeString": "struct Storage.RiskParams memory"
+                      }
+                    },
+                    "src": "1294:31:17",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_struct$_RiskParams_$11045_storage",
+                      "typeString": "struct Storage.RiskParams storage ref"
+                    }
+                  },
+                  "id": 5066,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1294:31:17"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 5071,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "expression": {
+                        "argumentTypes": null,
+                        "id": 5067,
+                        "name": "g_state",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 5082,
+                        "src": "1335:7:17",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_struct$_State_$11085_storage",
+                          "typeString": "struct Storage.State storage ref"
+                        }
+                      },
+                      "id": 5069,
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "memberName": "riskLimits",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 11084,
+                      "src": "1335:18:17",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_RiskLimits_$11058_storage",
+                        "typeString": "struct Storage.RiskLimits storage ref"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "id": 5070,
+                      "name": "riskLimits",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 5058,
+                      "src": "1356:10:17",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_RiskLimits_$11058_memory_ptr",
+                        "typeString": "struct Storage.RiskLimits memory"
+                      }
+                    },
+                    "src": "1335:31:17",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_struct$_RiskLimits_$11058_storage",
+                      "typeString": "struct Storage.RiskLimits storage ref"
+                    }
+                  },
+                  "id": 5072,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1335:31:17"
+                }
+              ]
+            },
+            "documentation": null,
+            "id": 5074,
+            "implemented": true,
+            "kind": "constructor",
+            "modifiers": [],
+            "name": "",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 5059,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 5056,
+                  "name": "riskParams",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 5074,
+                  "src": "1176:36:17",
+                  "stateVariable": false,
+                  "storageLocation": "memory",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_struct$_RiskParams_$11045_memory_ptr",
+                    "typeString": "struct Storage.RiskParams"
+                  },
+                  "typeName": {
+                    "contractScope": null,
+                    "id": 5055,
+                    "name": "Storage.RiskParams",
+                    "nodeType": "UserDefinedTypeName",
+                    "referencedDeclaration": 11045,
+                    "src": "1176:18:17",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_struct$_RiskParams_$11045_storage_ptr",
+                      "typeString": "struct Storage.RiskParams"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 5058,
+                  "name": "riskLimits",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 5074,
+                  "src": "1222:36:17",
+                  "stateVariable": false,
+                  "storageLocation": "memory",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_struct$_RiskLimits_$11058_memory_ptr",
+                    "typeString": "struct Storage.RiskLimits"
+                  },
+                  "typeName": {
+                    "contractScope": null,
+                    "id": 5057,
+                    "name": "Storage.RiskLimits",
+                    "nodeType": "UserDefinedTypeName",
+                    "referencedDeclaration": 11058,
+                    "src": "1222:18:17",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_struct$_RiskLimits_$11058_storage_ptr",
+                      "typeString": "struct Storage.RiskLimits"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1166:98:17"
+            },
+            "returnParameters": {
+              "id": 5060,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "1284:0:17"
+            },
+            "scope": 5075,
+            "src": "1155:218:17",
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          }
+        ],
+        "scope": 5076,
+        "src": "1015:360:17"
+      }
+    ],
+    "src": "603:773:17"
+  },
+  "legacyAST": {
+    "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/SoloMargin.sol",
+    "exportedSymbols": {
+      "SoloMargin": [
+        5075
+      ]
+    },
+    "id": 5076,
+    "nodeType": "SourceUnit",
+    "nodes": [
+      {
+        "id": 5031,
+        "literals": [
+          "solidity",
+          "0.5",
+          ".7"
+        ],
+        "nodeType": "PragmaDirective",
+        "src": "603:22:17"
+      },
+      {
+        "id": 5032,
+        "literals": [
+          "experimental",
+          "ABIEncoderV2"
+        ],
+        "nodeType": "PragmaDirective",
+        "src": "626:33:17"
+      },
+      {
+        "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/Admin.sol",
+        "file": "./Admin.sol",
+        "id": 5034,
+        "nodeType": "ImportDirective",
+        "scope": 5076,
+        "sourceUnit": 4223,
+        "src": "661:36:17",
+        "symbolAliases": [
+          {
+            "foreign": 5033,
+            "local": null
+          }
+        ],
+        "unitAlias": ""
+      },
+      {
+        "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/Getters.sol",
+        "file": "./Getters.sol",
+        "id": 5036,
+        "nodeType": "ImportDirective",
+        "scope": 5076,
+        "sourceUnit": 4919,
+        "src": "698:40:17",
+        "symbolAliases": [
+          {
+            "foreign": 5035,
+            "local": null
+          }
+        ],
+        "unitAlias": ""
+      },
+      {
+        "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/Operation.sol",
+        "file": "./Operation.sol",
+        "id": 5038,
+        "nodeType": "ImportDirective",
+        "scope": 5076,
+        "sourceUnit": 4957,
+        "src": "739:44:17",
+        "symbolAliases": [
+          {
+            "foreign": 5037,
+            "local": null
+          }
+        ],
+        "unitAlias": ""
+      },
+      {
+        "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/Permission.sol",
+        "file": "./Permission.sol",
+        "id": 5040,
+        "nodeType": "ImportDirective",
+        "scope": 5076,
+        "sourceUnit": 5030,
+        "src": "784:46:17",
+        "symbolAliases": [
+          {
+            "foreign": 5039,
+            "local": null
+          }
+        ],
+        "unitAlias": ""
+      },
+      {
+        "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/State.sol",
+        "file": "./State.sol",
+        "id": 5042,
+        "nodeType": "ImportDirective",
+        "scope": 5076,
+        "sourceUnit": 5084,
+        "src": "831:36:17",
+        "symbolAliases": [
+          {
+            "foreign": 5041,
+            "local": null
+          }
+        ],
+        "unitAlias": ""
+      },
+      {
+        "absolutePath": "/Users/jannis/Work/oss/dydxprotocol/solo/contracts/protocol/lib/Storage.sol",
+        "file": "./lib/Storage.sol",
+        "id": 5044,
+        "nodeType": "ImportDirective",
+        "scope": 5076,
+        "sourceUnit": 12382,
+        "src": "868:44:17",
+        "symbolAliases": [
+          {
+            "foreign": 5043,
+            "local": null
+          }
+        ],
+        "unitAlias": ""
+      },
+      {
+        "baseContracts": [
+          {
+            "arguments": null,
+            "baseName": {
+              "contractScope": null,
+              "id": 5045,
+              "name": "State",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 5083,
+              "src": "1042:5:17",
+              "typeDescriptions": {
+                "typeIdentifier": "t_contract$_State_$5083",
+                "typeString": "contract State"
+              }
+            },
+            "id": 5046,
+            "nodeType": "InheritanceSpecifier",
+            "src": "1042:5:17"
+          },
+          {
+            "arguments": null,
+            "baseName": {
+              "contractScope": null,
+              "id": 5047,
+              "name": "Admin",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 4222,
+              "src": "1053:5:17",
+              "typeDescriptions": {
+                "typeIdentifier": "t_contract$_Admin_$4222",
+                "typeString": "contract Admin"
+              }
+            },
+            "id": 5048,
+            "nodeType": "InheritanceSpecifier",
+            "src": "1053:5:17"
+          },
+          {
+            "arguments": null,
+            "baseName": {
+              "contractScope": null,
+              "id": 5049,
+              "name": "Getters",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 4918,
+              "src": "1064:7:17",
+              "typeDescriptions": {
+                "typeIdentifier": "t_contract$_Getters_$4918",
+                "typeString": "contract Getters"
+              }
+            },
+            "id": 5050,
+            "nodeType": "InheritanceSpecifier",
+            "src": "1064:7:17"
+          },
+          {
+            "arguments": null,
+            "baseName": {
+              "contractScope": null,
+              "id": 5051,
+              "name": "Operation",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 4956,
+              "src": "1077:9:17",
+              "typeDescriptions": {
+                "typeIdentifier": "t_contract$_Operation_$4956",
+                "typeString": "contract Operation"
+              }
+            },
+            "id": 5052,
+            "nodeType": "InheritanceSpecifier",
+            "src": "1077:9:17"
+          },
+          {
+            "arguments": null,
+            "baseName": {
+              "contractScope": null,
+              "id": 5053,
+              "name": "Permission",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 5029,
+              "src": "1092:10:17",
+              "typeDescriptions": {
+                "typeIdentifier": "t_contract$_Permission_$5029",
+                "typeString": "contract Permission"
+              }
+            },
+            "id": 5054,
+            "nodeType": "InheritanceSpecifier",
+            "src": "1092:10:17"
+          }
+        ],
+        "contractDependencies": [
+          4222,
+          4918,
+          4956,
+          5029,
+          5083,
+          18628,
+          18659
+        ],
+        "contractKind": "contract",
+        "documentation": "@title SoloMargin\n@author dYdX\n * Main contract that inherits from other contracts",
+        "fullyImplemented": true,
+        "id": 5075,
+        "linearizedBaseContracts": [
+          5075,
+          5029,
+          4956,
+          4918,
+          4222,
+          18659,
+          18628,
+          5083
+        ],
+        "name": "SoloMargin",
+        "nodeType": "ContractDefinition",
+        "nodes": [
+          {
+            "body": {
+              "id": 5073,
+              "nodeType": "Block",
+              "src": "1284:89:17",
+              "statements": [
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 5065,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "expression": {
+                        "argumentTypes": null,
+                        "id": 5061,
+                        "name": "g_state",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 5082,
+                        "src": "1294:7:17",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_struct$_State_$11085_storage",
+                          "typeString": "struct Storage.State storage ref"
+                        }
+                      },
+                      "id": 5063,
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "memberName": "riskParams",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 11082,
+                      "src": "1294:18:17",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_RiskParams_$11045_storage",
+                        "typeString": "struct Storage.RiskParams storage ref"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "id": 5064,
+                      "name": "riskParams",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 5056,
+                      "src": "1315:10:17",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_RiskParams_$11045_memory_ptr",
+                        "typeString": "struct Storage.RiskParams memory"
+                      }
+                    },
+                    "src": "1294:31:17",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_struct$_RiskParams_$11045_storage",
+                      "typeString": "struct Storage.RiskParams storage ref"
+                    }
+                  },
+                  "id": 5066,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1294:31:17"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 5071,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "expression": {
+                        "argumentTypes": null,
+                        "id": 5067,
+                        "name": "g_state",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 5082,
+                        "src": "1335:7:17",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_struct$_State_$11085_storage",
+                          "typeString": "struct Storage.State storage ref"
+                        }
+                      },
+                      "id": 5069,
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "memberName": "riskLimits",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 11084,
+                      "src": "1335:18:17",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_RiskLimits_$11058_storage",
+                        "typeString": "struct Storage.RiskLimits storage ref"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "id": 5070,
+                      "name": "riskLimits",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 5058,
+                      "src": "1356:10:17",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_RiskLimits_$11058_memory_ptr",
+                        "typeString": "struct Storage.RiskLimits memory"
+                      }
+                    },
+                    "src": "1335:31:17",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_struct$_RiskLimits_$11058_storage",
+                      "typeString": "struct Storage.RiskLimits storage ref"
+                    }
+                  },
+                  "id": 5072,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1335:31:17"
+                }
+              ]
+            },
+            "documentation": null,
+            "id": 5074,
+            "implemented": true,
+            "kind": "constructor",
+            "modifiers": [],
+            "name": "",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 5059,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 5056,
+                  "name": "riskParams",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 5074,
+                  "src": "1176:36:17",
+                  "stateVariable": false,
+                  "storageLocation": "memory",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_struct$_RiskParams_$11045_memory_ptr",
+                    "typeString": "struct Storage.RiskParams"
+                  },
+                  "typeName": {
+                    "contractScope": null,
+                    "id": 5055,
+                    "name": "Storage.RiskParams",
+                    "nodeType": "UserDefinedTypeName",
+                    "referencedDeclaration": 11045,
+                    "src": "1176:18:17",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_struct$_RiskParams_$11045_storage_ptr",
+                      "typeString": "struct Storage.RiskParams"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 5058,
+                  "name": "riskLimits",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 5074,
+                  "src": "1222:36:17",
+                  "stateVariable": false,
+                  "storageLocation": "memory",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_struct$_RiskLimits_$11058_memory_ptr",
+                    "typeString": "struct Storage.RiskLimits"
+                  },
+                  "typeName": {
+                    "contractScope": null,
+                    "id": 5057,
+                    "name": "Storage.RiskLimits",
+                    "nodeType": "UserDefinedTypeName",
+                    "referencedDeclaration": 11058,
+                    "src": "1222:18:17",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_struct$_RiskLimits_$11058_storage_ptr",
+                      "typeString": "struct Storage.RiskLimits"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1166:98:17"
+            },
+            "returnParameters": {
+              "id": 5060,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "1284:0:17"
+            },
+            "scope": 5075,
+            "src": "1155:218:17",
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          }
+        ],
+        "scope": 5076,
+        "src": "1015:360:17"
+      }
+    ],
+    "src": "603:773:17"
+  },
+  "compiler": {
+    "name": "solc",
+    "version": "0.5.7+commit.6da8b019.Linux.g++"
+  },
+  "networks": {},
+  "schemaVersion": "3.0.9",
+  "updatedAt": "2019-05-07T15:12:35.059Z",
+  "devdoc": {
+    "author": "dYdX * Main contract that inherits from other contracts",
+    "methods": {
+      "getAccountBalances((address,uint256))": {
+        "params": {
+          "account": "The account to query"
+        },
+        "return": "The following values:                  - The ERC20 token address for each market                  - The account's principal value for each market                  - The account's (supplied or borrowed) number of tokens for each market"
+      },
+      "getAccountPar((address,uint256),uint256)": {
+        "params": {
+          "account": "The account to query",
+          "marketId": "The market to query"
+        },
+        "return": "The principal value"
+      },
+      "getAccountStatus((address,uint256))": {
+        "params": {
+          "account": "The account to query"
+        },
+        "return": "The account's status"
+      },
+      "getAccountValues((address,uint256))": {
+        "params": {
+          "account": "The account to query"
+        },
+        "return": "The following values:                  - The supplied value of the account                  - The borrowed value of the account"
+      },
+      "getAccountWei((address,uint256),uint256)": {
+        "params": {
+          "account": "The account to query",
+          "marketId": "The market to query"
+        },
+        "return": "The token amount"
+      },
+      "getAdjustedAccountValues((address,uint256))": {
+        "params": {
+          "account": "The account to query"
+        },
+        "return": "The following values:                  - The supplied value of the account (adjusted for marginPremium)                  - The borrowed value of the account (adjusted for marginPremium)"
+      },
+      "getEarningsRate()": {
+        "return": "The global earnings rate"
+      },
+      "getIsGlobalOperator(address)": {
+        "params": {
+          "operator": "The address to query"
+        },
+        "return": "True if operator is a global operator"
+      },
+      "getIsLocalOperator(address,address)": {
+        "params": {
+          "operator": "The possible operator",
+          "owner": "The owner of the accounts"
+        },
+        "return": "True if operator is approved for owner's accounts"
+      },
+      "getLiquidationSpread()": {
+        "return": "The global liquidation spread"
+      },
+      "getLiquidationSpreadForPair(uint256,uint256)": {
+        "params": {
+          "heldMarketId": "The market for which the account has collateral",
+          "owedMarketId": "The market for which the account has borrowed tokens"
+        },
+        "return": "The adjusted liquidation spread"
+      },
+      "getMarginRatio()": {
+        "return": "The global margin-ratio"
+      },
+      "getMarket(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "A Storage.Market struct with the current state of the market"
+      },
+      "getMarketCachedIndex(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "The most recent index"
+      },
+      "getMarketCurrentIndex(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "The estimated current index"
+      },
+      "getMarketInterestRate(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "The current interest rate"
+      },
+      "getMarketInterestSetter(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "The interest-setter address"
+      },
+      "getMarketIsClosing(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "True if the market is closing"
+      },
+      "getMarketMarginPremium(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "The market's margin premium"
+      },
+      "getMarketPrice(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "The price of each atomic unit of the token"
+      },
+      "getMarketPriceOracle(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "The price oracle address"
+      },
+      "getMarketSpreadPremium(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "The market's spread premium"
+      },
+      "getMarketTokenAddress(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "The token address"
+      },
+      "getMarketTotalPar(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "The total principal amounts"
+      },
+      "getMarketWithInfo(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "A tuple containing the values:                   - A Storage.Market struct with the current state of the market                   - The current estimated interest index                   - The current token price                   - The current market interest rate"
+      },
+      "getMinBorrowedValue()": {
+        "return": "The global minimum borrow value"
+      },
+      "getNumExcessTokens(uint256)": {
+        "params": {
+          "marketId": "The market to query"
+        },
+        "return": "The number of excess tokens"
+      },
+      "getNumMarkets()": {
+        "return": "The number of markets"
+      },
+      "getRiskLimits()": {
+        "return": "All global risk parameter limnits"
+      },
+      "getRiskParams()": {
+        "return": "All global risk parameters"
+      },
+      "isOwner()": {
+        "return": "true if `msg.sender` is the owner of the contract."
+      },
+      "operate((address,uint256)[],(uint8,uint256,(bool,uint8,uint8,uint256),uint256,uint256,address,uint256,bytes)[])": {
+        "params": {
+          "accounts": "A list of all accounts that will be used in this operation. Cannot contain                  duplicates. In each action, the relevant account will be referred-to by its                  index in the list.",
+          "actions": "An ordered list of all actions that will be taken in this operation. The                  actions will be processed in order."
+        }
+      },
+      "owner()": {
+        "return": "the address of the owner."
+      },
+      "renounceOwnership()": {
+        "details": "Allows the current owner to relinquish control of the contract."
+      },
+      "setOperators((address,bool)[])": {
+        "params": {
+          "args": "A list of OperatorArgs which have an address and a boolean. The boolean value              denotes whether to approve (true) or revoke approval (false) for that address."
+        }
+      },
+      "transferOwnership(address)": {
+        "details": "Allows the current owner to transfer control of the contract to a newOwner.",
+        "params": {
+          "newOwner": "The address to transfer ownership to."
+        }
+      }
+    },
+    "title": "SoloMargin"
+  },
+  "userdoc": {
+    "methods": {
+      "getAccountBalances((address,uint256))": {
+        "notice": "Get an account's summary for each market."
+      },
+      "getAccountPar((address,uint256),uint256)": {
+        "notice": "Get the principal value for a particular account and market."
+      },
+      "getAccountStatus((address,uint256))": {
+        "notice": "Get the status of an account (Normal, Liquidating, or Vaporizing)."
+      },
+      "getAccountValues((address,uint256))": {
+        "notice": "Get the total supplied and total borrowed value of an account."
+      },
+      "getAccountWei((address,uint256),uint256)": {
+        "notice": "Get the token balance for a particular account and market."
+      },
+      "getAdjustedAccountValues((address,uint256))": {
+        "notice": "Get the total supplied and total borrowed values of an account adjusted by the marginPremium of each market. Supplied values are divided by (1 + marginPremium) for each market and borrowed values are multiplied by (1 + marginPremium) for each market. Comparing these adjusted values gives the margin-ratio of the account which will be compared to the global margin-ratio when determining if the account can be liquidated."
+      },
+      "getEarningsRate()": {
+        "notice": "Get the global earnings-rate variable that determines what percentage of the interest paid by borrowers gets passed-on to suppliers."
+      },
+      "getIsGlobalOperator(address)": {
+        "notice": "Return true if a particular address is approved as a global operator. Such an address can act on any account as if it were the operator's own."
+      },
+      "getIsLocalOperator(address,address)": {
+        "notice": "Return true if a particular address is approved as an operator for an owner's accounts. Approved operators can act on the accounts of the owner as if it were the operator's own."
+      },
+      "getLiquidationSpread()": {
+        "notice": "Get the global liquidation spread. This is the spread between oracle prices that incentivizes the liquidation of risky positions."
+      },
+      "getLiquidationSpreadForPair(uint256,uint256)": {
+        "notice": "Get the adjusted liquidation spread for some market pair. This is equal to the global liquidation spread multiplied by (1 + spreadPremium) for each of the two markets."
+      },
+      "getMarginRatio()": {
+        "notice": "Get the global minimum margin-ratio that every position must maintain to prevent being liquidated."
+      },
+      "getMarket(uint256)": {
+        "notice": "Get basic information about a particular market."
+      },
+      "getMarketCachedIndex(uint256)": {
+        "notice": "Get the most recently cached interest index for a market."
+      },
+      "getMarketCurrentIndex(uint256)": {
+        "notice": "Get the interest index for a market if it were to be updated right now."
+      },
+      "getMarketInterestRate(uint256)": {
+        "notice": "Get the current borrower interest rate for a market."
+      },
+      "getMarketInterestSetter(uint256)": {
+        "notice": "Get the interest-setter address for a market."
+      },
+      "getMarketIsClosing(uint256)": {
+        "notice": "Return true if a particular market is in closing mode. Additional borrows cannot be taken from a market that is closing."
+      },
+      "getMarketMarginPremium(uint256)": {
+        "notice": "Get the margin premium for a market. A margin premium makes it so that any positions that include the market require a higher collateralization to avoid being liquidated."
+      },
+      "getMarketPrice(uint256)": {
+        "notice": "Get the price of the token for a market."
+      },
+      "getMarketPriceOracle(uint256)": {
+        "notice": "Get the price oracle address for a market."
+      },
+      "getMarketSpreadPremium(uint256)": {
+        "notice": "Get the spread premium for a market. A spread premium makes it so that any liquidations that include the market have a higher spread than the global default."
+      },
+      "getMarketTokenAddress(uint256)": {
+        "notice": "Get the ERC20 token address for a market."
+      },
+      "getMarketTotalPar(uint256)": {
+        "notice": "Get the total principal amounts (borrowed and supplied) for a market."
+      },
+      "getMarketWithInfo(uint256)": {
+        "notice": "Get comprehensive information about a particular market."
+      },
+      "getMinBorrowedValue()": {
+        "notice": "Get the global minimum-borrow value which is the minimum value of any new borrow on Solo."
+      },
+      "getNumExcessTokens(uint256)": {
+        "notice": "Get the number of excess tokens for a market. The number of excess tokens is calculated by taking the current number of tokens held in Solo, adding the number of tokens owed to Solo by borrowers, and subtracting the number of tokens owed to suppliers by Solo."
+      },
+      "getNumMarkets()": {
+        "notice": "Get the total number of markets."
+      },
+      "getRiskLimits()": {
+        "notice": "Get all risk parameter limits in a single struct. These are the maximum limits at which the risk parameters can be set by the admin of Solo."
+      },
+      "getRiskParams()": {
+        "notice": "Get all risk parameters in a single struct."
+      },
+      "operate((address,uint256)[],(uint8,uint256,(bool,uint8,uint8,uint256),uint256,uint256,address,uint256,bytes)[])": {
+        "notice": "The main entry-point to Solo that allows users and contracts to manage accounts. Take one or more actions on one or more accounts. The msg.sender must be the owner or operator of all accounts except for those being liquidated, vaporized, or traded with. One call to operate() is considered a singular \"operation\". Account collateralization is ensured only after the completion of the entire operation."
+      },
+      "ownerAddMarket(address,address,address,(uint256),(uint256))": {
+        "notice": "Add a new market to Solo. Must be for a previously-unsupported ERC20 token."
+      },
+      "ownerSetEarningsRate((uint256))": {
+        "notice": "Set the global earnings-rate variable that determines what percentage of the interest paid by borrowers gets passed-on to suppliers."
+      },
+      "ownerSetGlobalOperator(address,bool)": {
+        "notice": "Approve (or disapprove) an address that is permissioned to be an operator for all accounts in Solo. Intended only to approve smart-contracts."
+      },
+      "ownerSetInterestSetter(uint256,address)": {
+        "notice": "Set the interest-setter for a market."
+      },
+      "ownerSetIsClosing(uint256,bool)": {
+        "notice": "Set (or unset) the status of a market to \"closing\". The borrowedValue of a market cannot increase while its status is \"closing\"."
+      },
+      "ownerSetLiquidationSpread((uint256))": {
+        "notice": "Set the global liquidation spread. This is the spread between oracle prices that incentivizes the liquidation of risky positions."
+      },
+      "ownerSetMarginPremium(uint256,(uint256))": {
+        "notice": "Set a premium on the minimum margin-ratio for a market. This makes it so that any positions that include this market require a higher collateralization to avoid being liquidated."
+      },
+      "ownerSetMarginRatio((uint256))": {
+        "notice": "Set the global minimum margin-ratio that every position must maintain to prevent being liquidated."
+      },
+      "ownerSetMinBorrowedValue((uint256))": {
+        "notice": "Set the global minimum-borrow value which is the minimum value of any new borrow on Solo."
+      },
+      "ownerSetPriceOracle(uint256,address)": {
+        "notice": "Set the price oracle for a market."
+      },
+      "ownerSetSpreadPremium(uint256,(uint256))": {
+        "notice": "Set a premium on the liquidation spread for a market. This makes it so that any liquidations that include this market have a higher spread than the global default."
+      },
+      "ownerWithdrawExcessTokens(uint256,address)": {
+        "notice": "Withdraw an ERC20 token for which there is an associated market. Only excess tokens can be withdrawn. The number of excess tokens is calculated by taking the current number of tokens held in Solo, adding the number of tokens owed to Solo by borrowers, and subtracting the number of tokens owed to suppliers by Solo."
+      },
+      "ownerWithdrawUnsupportedTokens(address,address)": {
+        "notice": "Withdraw an ERC20 token for which there is no associated market."
+      },
+      "renounceOwnership()": {
+        "notice": "Renouncing to ownership will leave the contract without an owner. It will not be possible to call the functions with the `onlyOwner` modifier anymore."
+      },
+      "setOperators((address,bool)[])": {
+        "notice": "Approves/disapproves any number of operators. An operator is an external address that has the same permissions to manipulate an account as the owner of the account. Operators are simply addresses and therefore may either be externally-owned Ethereum accounts OR smart contracts.     * Operators are also able to act as AutoTrader contracts on behalf of the account owner if the operator is a smart contract and implements the IAutoTrader interface."
+      }
+    }
+  }
+}

--- a/tests/cli/init/from-contract-with-abi-and-structs.stderr
+++ b/tests/cli/init/from-contract-with-abi-and-structs.stderr
@@ -1,0 +1,12 @@
+- Create subgraph scaffold
+  Generate subgraph from ABI
+- Create subgraph scaffold
+  Write subgraph to directory
+- Create subgraph scaffold
+✔ Create subgraph scaffold
+- Initialize subgraph repository
+✔ Initialize subgraph repository
+- Install dependencies with yarn
+✔ Install dependencies with yarn
+- Generate ABI and schema types with yarn codegen
+✔ Generate ABI and schema types with yarn codegen

--- a/tests/cli/init/from-contract-with-abi-and-structs.stdout
+++ b/tests/cli/init/from-contract-with-abi-and-structs.stdout
@@ -1,0 +1,15 @@
+
+Subgraph user/subgraph-from-contract-with-abi-and-structs created in from-contract-with-abi-and-structs
+
+Next steps:
+
+  1. Run `graph auth https://api.thegraph.com/deploy/ <access-token>`
+     to authenticate with the hosted service. You can get the access token from
+     https://thegraph.com/explorer/dashboard/.
+
+  2. Type `cd from-contract-with-abi-and-structs` to enter the subgraph.
+
+  3. Run `yarn deploy` to deploy the subgraph to
+     https://thegraph.com/explorer/subgraph/user/subgraph-from-contract-with-abi-and-structs.
+
+Make sure to visit the documentation on https://thegraph.com/docs/ for further information.

--- a/tests/cli/init/from-contract-with-overloaded-elements.stderr
+++ b/tests/cli/init/from-contract-with-overloaded-elements.stderr
@@ -1,0 +1,12 @@
+- Create subgraph scaffold
+  Generate subgraph from ABI
+- Create subgraph scaffold
+  Write subgraph to directory
+- Create subgraph scaffold
+✔ Create subgraph scaffold
+- Initialize subgraph repository
+✔ Initialize subgraph repository
+- Install dependencies with yarn
+✔ Install dependencies with yarn
+- Generate ABI and schema types with yarn codegen
+✔ Generate ABI and schema types with yarn codegen

--- a/tests/cli/init/from-contract-with-overloaded-elements.stdout
+++ b/tests/cli/init/from-contract-with-overloaded-elements.stdout
@@ -1,0 +1,15 @@
+
+Subgraph user/subgraph-from-contract-with-overloaded-elements created in from-contract-with-overloaded-elements
+
+Next steps:
+
+  1. Run `graph auth https://api.thegraph.com/deploy/ <access-token>`
+     to authenticate with the hosted service. You can get the access token from
+     https://thegraph.com/explorer/dashboard/.
+
+  2. Type `cd from-contract-with-overloaded-elements` to enter the subgraph.
+
+  3. Run `yarn deploy` to deploy the subgraph to
+     https://thegraph.com/explorer/subgraph/user/subgraph-from-contract-with-overloaded-elements.
+
+Make sure to visit the documentation on https://thegraph.com/docs/ for further information.


### PR DESCRIPTION
Resolves #253.

Apart from adding a reusable name disambiguation helper for events, functions, event inputs and function inputs and outputs, this adds the following:

1. Entity type names, event names and event handlers generated by `graph init` are now disambiguated using the same logic as is used by `graph codegen`.

2. Event parameters that are of type `tuple` are now translated to multiple fields on the generated event entity type.