### PR TITLE
Fix uncaught exceptions caused by incorrect async mapping

### DIFF
--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -151,8 +151,8 @@ module.exports = class TypeGenerator {
       `Failed to generate types for contract ABIs`,
       `Warnings while generating types for contract ABIs`,
       async spinner => {
-        return await abis.map(
-          async (abi, name) => await this._generateTypesForABI(abi, spinner),
+        return await Promise.all(
+          abis.map(async (abi, name) => await this._generateTypesForABI(abi, spinner)),
         )
       },
     )
@@ -363,9 +363,11 @@ module.exports = class TypeGenerator {
       `Failed to generate types for data source template ABIs`,
       `Warnings while generating types for data source template ABIs`,
       async spinner => {
-        return await abis.map(
-          async (abi, name) =>
-            await this._generateTypesForDataSourceTemplateABI(abi, spinner),
+        return await Promise.all(
+          abis.map(
+            async (abi, name) =>
+              await this._generateTypesForDataSourceTemplateABI(abi, spinner),
+          ),
         )
       },
     )


### PR DESCRIPTION
This was the cause for the
```
node_modules/binaryen/index.js:7
if(n){p=__dirname+"/";var ea,fa;a.read=function(c,e){var
b=q(c);b||(ea||(ea=require("fs")),fa||(fa=require("path")),c=fa.normalize(c),b=ea.readFileSync(c));return
e?b:b.toString()};a.readBinary=function(c){c=a.read(c,!0);c.buffer||(c=new
Uint8Array(c));assert(c.buffer);return
c};1<process.argv.length&&(a.thisProgram=process.argv[1].replace(/\\/g,"/"));a.arguments=process.argv.slice(2);process.on("uncaughtException",function(c){if(!(c
instanceof ha))throw c;});process.on("unhandledRejection",u);a.quit=
```
errors that we have seen every now and then.