### PR TITLE
graph init: Skip Etherscan if --abi is provided

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -111,10 +111,12 @@ const processInitForm = async (
           return value
         }
 
-        // Try loading the ABI from Etherscan
-        try {
-          abiFromEtherscan = await loadAbiFromEtherscan(network, value)
-        } catch (e) {}
+        // Try loading the ABI from Etherscan, if none was provided
+        if (!abi) {
+          try {
+            abiFromEtherscan = await loadAbiFromEtherscan(network, value)
+          } catch (e) {}
+        }
         return value
       },
     },


### PR DESCRIPTION
If `--abi` is provided and the user is guided through the init form, we want to skip downloading the ABI from Etherscan to a) not confuse the user and b) to not override the user-provided ABI.

Reported on Discord earlier today.