### PR TITLE
Assert expected stdout/stderr before exit code in CLI tests

### DIFF
--- a/tests/cli/util.js
+++ b/tests/cli/util.js
@@ -30,14 +30,14 @@ const cliTest = (title, args, testPath, options) => {
         expectedStderr = fs.readFileSync(resolvePath(`./${testPath}.stderr`), 'utf-8')
       } catch (e) {}
 
-      if (expectedExitCode !== undefined) {
-        expect(exitCode).toBe(expectedExitCode)
-      }
       if (expectedStdout !== undefined) {
         expect(stripAnsi(stdout)).toBe(expectedStdout)
       }
       if (expectedStderr !== undefined) {
         expect(stripAnsi(stderr)).toBe(expectedStderr)
+      }
+      if (expectedExitCode !== undefined) {
+        expect(exitCode).toBe(expectedExitCode)
       }
     },
     (options !== undefined && options.timeout) || undefined,


### PR DESCRIPTION
This is just more useful, because you want to see _how_ tests fail
and the test output is more informative than the exit code.