### PR TITLE
Fail subgraph validation if functions are not found in ABIs

### DIFF
--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -393,6 +393,7 @@ At least one such handler must be defined.`,
       ...Subgraph.validateContractAddresses(manifest),
       ...Subgraph.validateEthereumContractHandlers(manifest),
       ...Subgraph.validateEvents(manifest, { resolveFile }),
+      ...Subgraph.validateCallFunctions(manifest, { resolveFile }),
     )
 
     if (errors.size > 0) {
@@ -404,7 +405,6 @@ At least one such handler must be defined.`,
       ...Subgraph.validateRepository(manifest, { resolveFile }),
       ...Subgraph.validateDescription(manifest, { resolveFile }),
       ...Subgraph.validateEthereumContractHandlers(manifest),
-      ...Subgraph.validateCallFunctions(manifest, { resolveFile }),
     )
 
     return {

--- a/tests/cli/validation.test.js
+++ b/tests/cli/validation.test.js
@@ -32,6 +32,14 @@ describe('Validation', () => {
     },
   )
   cliTest(
+    'Call function not found in the ABI',
+    ['codegen', '--skip-migrations'],
+    'validation/call-function-not-found',
+    {
+      exitCode: 1,
+    },
+  )
+  cliTest(
     'Missing entity "id" field',
     ['codegen', '--skip-migrations'],
     'validation/missing-entity-id',

--- a/tests/cli/validation/call-function-not-found.stderr
+++ b/tests/cli/validation/call-function-not-found.stderr
@@ -1,5 +1,5 @@
 - Load subgraph from subgraph.yaml
-✖ Failed to load subgraph from subgraph.yaml: Failed to load subgraph: Error in subgraph.yaml:
+✖ Failed to load subgraph from subgraph.yaml: Error in subgraph.yaml:
 
   Path: dataSources > 0 > callHandlers > 0
   Call function with signature 'doSomething(uint256)' not present in ABI 'ExampleContract'.


### PR DESCRIPTION
This also puts a test in place to check that we really do fail (before we
would just warn about invalid function signatures). The test was there before
but not used; its expected output had to be slightly updated.