### PR TITLE
Fix travis: Go back to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: node_js
 node_js:
   - "10"


### PR DESCRIPTION
The new default dist is xenial, because trusty has reached end-of-life, but our `graph auth` test fails on xenial.