### PR TITLE
Generate code for functions that use deprecated JSON fields

### DIFF
--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -334,7 +334,8 @@ module.exports = class AbiCodeGenerator {
       member =>
         member.get('type') === 'function' &&
         member.get('outputs', immutable.List()).size !== 0 &&
-        allowedMutability.indexOf(member.get('stateMutability')) !== -1,
+        (allowedMutability.indexOf(member.get('stateMutability')) >= 0 ||
+          (member.get('payable') === false && member.get('constant') === true)),
     )
 
     // Disambiguate functions with duplicate names

--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -334,8 +334,8 @@ module.exports = class AbiCodeGenerator {
       member =>
         member.get('type') === 'function' &&
         member.get('outputs', immutable.List()).size !== 0 &&
-        (allowedMutability.indexOf(member.get('stateMutability')) >= 0 ||
-          (member.get('payable') === false && member.get('constant') === true)),
+        (allowedMutability.includes(member.get('stateMutability')) ||
+          (member.get('stateMutability') === undefined && !member.get('payable', false))),
     )
 
     // Disambiguate functions with duplicate names

--- a/src/codegen/abi.test.js
+++ b/src/codegen/abi.test.js
@@ -21,6 +21,14 @@ describe('ABI code generation', () => {
         JSON.stringify([
           {
             constant: true,
+            inputs: [],
+            name: 'read',
+            outputs: [{ name: '', type: 'bytes32' }],
+            payable: false,
+            type: 'function',
+          },
+          {
+            constant: true,
             inputs: [
               {
                 name: 'proposalId',
@@ -143,6 +151,7 @@ describe('ABI code generation', () => {
       let contract = generatedTypes.find(type => type.name === 'Contract')
       expect(contract.methods.map(method => [method.name, method.params])).toEqual([
         ['bind', immutable.List([ts.param('address', 'Address')])],
+        ['read', immutable.List()],
         [
           'getProposal',
           immutable.List([
@@ -157,6 +166,7 @@ describe('ABI code generation', () => {
       let contract = generatedTypes.find(type => type.name === 'Contract')
       expect(contract.methods.map(method => [method.name, method.returnType])).toEqual([
         ['bind', ts.namedType('Contract')],
+        ['read', ts.namedType('Bytes')],
         ['getProposal', ts.namedType('Contract__getProposalResultValue0Struct')],
       ])
     })


### PR DESCRIPTION
Specifically, add support for generating callable methods for functions that don't use `stateMutability` and use the deprecated `payable`/`constant` fields instead.

This fix includes updated tests to prevent regressions.