### PR TITLE
Don't throw in `@derivedFrom` validation

### DIFF
--- a/tests/cli/validation.test.js
+++ b/tests/cli/validation.test.js
@@ -117,7 +117,15 @@ describe('Validation', () => {
     ['codegen', '--skip-migrations'],
     'validation/missing-or-invalid-derived-from-fields',
     {
-      exitCode: 1
-    }
+      exitCode: 1,
+    },
+  )
+  cliTest(
+    '@derivedFrom target type missing',
+    ['codegen', '--skip-migrations'],
+    'validation/derived-from-target-type-missing',
+    {
+      exitCode: 1,
+    },
   )
 })

--- a/tests/cli/validation/derived-from-target-type-missing.stderr
+++ b/tests/cli/validation/derived-from-target-type-missing.stderr
@@ -1,0 +1,5 @@
+- Load subgraph from subgraph.yaml
+✖ Failed to load subgraph from subgraph.yaml: Error in schema.graphql:
+
+  Foo:
+  - Field 'bars': Unknown type 'Bars'.

--- a/tests/cli/validation/derived-from-target-type-missing/Abi.json
+++ b/tests/cli/validation/derived-from-target-type-missing/Abi.json
@@ -1,0 +1,6 @@
+[
+  {
+    "type": "event",
+    "name": "ExampleEvent"
+  }
+]

--- a/tests/cli/validation/derived-from-target-type-missing/schema.graphql
+++ b/tests/cli/validation/derived-from-target-type-missing/schema.graphql
@@ -1,0 +1,4 @@
+type Foo @entity {
+  id: ID!
+  bars: [Bars!]! @derivedFrom(field: "foo")
+}

--- a/tests/cli/validation/derived-from-target-type-missing/subgraph.yaml
+++ b/tests/cli/validation/derived-from-target-type-missing/subgraph.yaml
@@ -1,0 +1,22 @@
+specVersion: 0.0.1
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: ExampleSubgraph
+    source:
+      address: '22843e74c59580b3eaf6c233fa67d8b7c561a835'
+      abi: ExampleContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.1
+      language: wasm/assemblyscript
+      file: ./mapping.ts
+      entities:
+        - ExampleEntity
+      abis:
+        - name: ExampleContract
+          file: ./Abi.json
+      eventHandlers:
+        - event: ExampleEvent(string)
+          handler: handleExampleEvent


### PR DESCRIPTION
When a `@derivedFrom` target entity/interface type does not exist, we used to throw a `Cannot read property 'fields' of undefined` error. Instead, we want to skip validating the `@derivedFrom` directive any further and let the field type validation catch the missing type.