### PR TITLE
Make `--from-contract` generate a more instructive scaffold

### DIFF
--- a/src/abi.js
+++ b/src/abi.js
@@ -5,19 +5,21 @@ const path = require('path')
 const AbiCodeGenerator = require('./codegen/abi')
 
 const buildOldSignatureParameter = input => {
-  return input.type === 'tuple'
-    ? `(${input.components
+  return input.get('type') === 'tuple'
+    ? `(${input
+        .get('components')
         .map(component => buildSignatureParameter(component))
         .join(',')})`
-    : `${input.type}`
+    : `${input.get('type')}`
 }
 
 const buildSignatureParameter = input => {
-  return input.type === 'tuple'
-    ? `(${input.indexed ? 'indexed ' : ''}${input.components
+  return input.get('type') === 'tuple'
+    ? `(${input.get('indexed') ? 'indexed ' : ''}${input
+        .get('components')
         .map(component => buildSignatureParameter(component))
         .join(',')})`
-    : `${input.indexed ? 'indexed ' : ''}${input.type}`
+    : `${input.get('indexed') ? 'indexed ' : ''}${input.get('type')}`
 }
 
 module.exports = class ABI {
@@ -32,13 +34,13 @@ module.exports = class ABI {
   }
 
   static oldEventSignature(event) {
-    return `${event.name}(${(event.inputs || [])
+    return `${event.get('name')}(${(event.get('inputs') || [])
       .map(input => buildOldSignatureParameter(input))
       .join(',')})`
   }
 
   static eventSignature(event) {
-    return `${event.name}(${(event.inputs || [])
+    return `${event.get('name')}(${(event.get('inputs') || [])
       .map(input => buildSignatureParameter(input))
       .join(',')})`
   }
@@ -46,14 +48,12 @@ module.exports = class ABI {
   oldEventSignatures() {
     return this.data
       .filter(entry => entry.get('type') === 'event')
-      .map(event => event.toJS())
       .map(ABI.oldEventSignature)
   }
 
   eventSignatures() {
     return this.data
       .filter(entry => entry.get('type') === 'event')
-      .map(event => event.toJS())
       .map(ABI.eventSignature)
   }
 
@@ -79,13 +79,13 @@ module.exports = class ABI {
     return this.callFunctions()
       .filter(entry => entry.get('type') !== 'constructor')
       .map(entry => {
-        const name = entry.get('name', '<default>');
+        const name = entry.get('name', '<default>')
         const inputs = entry
           .get('inputs', immutable.List())
-          .map(input => input.get('type'));
+          .map(input => input.get('type'))
 
-        return `${name}(${inputs.join(',')})`;
-      });
+        return `${name}(${inputs.join(',')})`
+      })
   }
 
   static normalized(json) {

--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -329,14 +329,7 @@ module.exports = class AbiCodeGenerator {
     )
 
     // Get view/pure functions from the contract
-    let allowedMutability = ['view', 'pure', 'nonpayable', 'constant']
-    let functions = this.abi.data.filter(
-      member =>
-        member.get('type') === 'function' &&
-        member.get('outputs', immutable.List()).size !== 0 &&
-        (allowedMutability.includes(member.get('stateMutability')) ||
-          (member.get('stateMutability') === undefined && !member.get('payable', false))),
-    )
+    let functions = this.callableFunctions()
 
     // Disambiguate functions with duplicate names
     functions = util.disambiguateNames({
@@ -573,5 +566,16 @@ module.exports = class AbiCodeGenerator {
     } else {
       return inputType
     }
+  }
+
+  callableFunctions() {
+    let allowedMutability = ['view', 'pure', 'nonpayable', 'constant']
+    return this.abi.data.filter(
+      member =>
+        member.get('type') === 'function' &&
+        member.get('outputs', immutable.List()).size !== 0 &&
+        (allowedMutability.includes(member.get('stateMutability')) ||
+          (member.get('stateMutability') === undefined && !member.get('payable', false))),
+    )
   }
 }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -27,7 +27,7 @@ ${chalk.dim('Choose mode with one of:')}
 ${chalk.dim('Options for --from-contract:')}
 
       --abi <path>              Path to the contract ABI (default: download from Etherscan)
-      --network <mainnet|kovan|rinkeby|ropsten>
+      --network <mainnet|kovan|rinkeby|ropsten|goerli>
                                 Selects the network the contract is deployed to
 `
 
@@ -35,7 +35,7 @@ const processInitForm = async (
   toolbox,
   { abi, address, allowSimpleName, directory, fromExample, network, subgraphName },
 ) => {
-  let networkChoices = ['mainnet', 'kovan', 'rinkeby', 'ropsten']
+  let networkChoices = ['mainnet', 'kovan', 'rinkeby', 'ropsten', 'goerli']
   let addressPattern = /^(0x)?[0-9a-fA-F]{40}$/
 
   let abiFromEtherscan = undefined

--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -220,7 +220,8 @@ const generatePlaceholderHandlers = ({ abi, events }) =>
       index === 0
         ? `
     export function handle${event._alias}(event: ${event._alias}): void {
-      // Entities can be loaded from the store using an event ID (a string)
+      // Entities can be loaded from the store using a string ID; this ID
+      // needs to be unique across all entities of the same type
       let entity = ExampleEntity.load(event.transaction.from.toHex())
 
       // Entities only exist after they have been saved to the store;

--- a/src/scaffold.test.js
+++ b/src/scaffold.test.js
@@ -156,7 +156,8 @@ import {
 import { ExampleEntity } from "../generated/schema"
 
 export function handleExampleEvent(event: ExampleEvent): void {
-  // Entities can be loaded from the store using an event ID (a string)
+  // Entities can be loaded from the store using a string ID; this ID
+  // needs to be unique across all entities of the same type
   let entity = ExampleEntity.load(event.transaction.from.toHex())
 
   // Entities only exist after they have been saved to the store;


### PR DESCRIPTION
This changes the default scaffold create by `graph init --from-contract` to

1. only generate a single example entity rather than entities for all events
2. generate empty event handlers (apart from one)
3. add one event handler that includes an example of how to work with entities as well as comments about binding contracts and making calls.

Generating a subgraph that indexes events 1:1 is still possible by using the `--index-events` flag.

As a little extra feature, this PR also adds support for creating subgraphs from contracts on the Goerli testnet.

The two sections below show what is generated for `0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d` on `mainnet`.

## Generated schema

The example entity has two fixed fields (`id` and `count`, to show how an existing entity can be updated) and up to two fields taken from the first event type we can find (to show how event parameters can be passed on to entities).

``` graphql
type ExampleEntity @entity {
  id: ID!
  count: BigInt!
  newContract: Bytes! # address
  initializedWith: Bytes! # bytes
}
```

## Generated mapping

``` typescript
import { BigInt } from "@graphprotocol/graph-ts"
import { Contract, Upgrade, OwnerUpdate } from "../generated/Contract/Contract"
import { ExampleEntity } from "../generated/schema"

export function handleUpgrade(event: Upgrade): void {
  // Entities can be loaded from the store using an event ID (a string)
  let entity = ExampleEntity.load(event.transaction.from.toHex())

  // Entities only exist after they have been saved to the store;
  // `null` checks allow to create entities on demand
  if (entity == null) {
    entity = new ExampleEntity(event.transaction.from.toHex())

    // Entity fields can be set using simple assignments
    entity.count = BigInt.fromI32(0)
  }

  // BigInt and BigDecimal math are supported
  entity.count = entity.count + BigInt.fromI32(1)

  // Entity fields can be set based on event parameters
  entity.newContract = event.params.newContract
  entity.initializedWith = event.params.initializedWith

  // Entities can be written to the store with `.save()`
  entity.save()

  // Note: If a handler doesn't require existing field values, it is faster
  // _not_ to load the entity from the store. Instead, create it fresh with
  // `new Entity(...)`, set the fields that should be updated and save the
  // entity back to the store. Fields that were not set or unset remain
  // unchanged, allowing for partial updates to be applied.

  // It is also possible to access smart contracts from mappings. For
  // example, the contract that has emitted the event can be connected to
  // with:
  //
  // let contract = Contract.bind(event.address)
  //
  // The following functions can then be called on this contract to access
  // state variables and other data:
  //
  // - contract.proxyOwner(...)
  // - contract.currentContract(...)
  // - contract.owner(...)
}

export function handleOwnerUpdate(event: OwnerUpdate): void {}
```