### PR TITLE
Migration fixes, IPFS upload optimization

### DIFF
--- a/src/command-helpers/compiler.js
+++ b/src/command-helpers/compiler.js
@@ -3,7 +3,7 @@ const toolbox = require('gluegun/toolbox')
 const Compiler = require('../compiler')
 
 // Helper function to construct a subgraph compiler
-const createCompiler = (manifest, { ipfs, outputDir, outputFormat }) => {
+const createCompiler = (manifest, { ipfs, outputDir, outputFormat, skipMigrations }) => {
   // Parse the IPFS URL
   let url
   try {
@@ -29,6 +29,7 @@ The IPFS URL must be of the following format: http(s)://host[:port]/[path]`)
     subgraphManifest: manifest,
     outputDir: outputDir,
     outputFormat: outputFormat,
+    skipMigrations,
   })
 }
 

--- a/src/migrations/mapping_api_version_0_0_1.js
+++ b/src/migrations/mapping_api_version_0_0_1.js
@@ -42,15 +42,19 @@ module.exports = {
     // and replace the values in the data structures here; unfortunately
     // writing that back to the file messes with the formatting more than
     // we'd like; that's why for now, we use a simple patching approach
-    await toolbox.patching.replace(manifestFile, 'apiVersion: 0.0.1', 'apiVersion: 0.0.2')
     await toolbox.patching.replace(
       manifestFile,
-      "apiVersion: '0.0.1'",
+      new RegExp('apiVersion: 0.0.1', 'g'),
+      'apiVersion: 0.0.2',
+    )
+    await toolbox.patching.replace(
+      manifestFile,
+      new RegExp("apiVersion: '0.0.1'", 'g'),
       "apiVersion: '0.0.2'",
     )
     await toolbox.patching.replace(
       manifestFile,
-      'apiVersion: "0.0.1"',
+      new RegExp('apiVersion: "0.0.1"', 'g'),
       'apiVersion: "0.0.2"',
     )
   },

--- a/src/migrations/mapping_api_version_0_0_2.js
+++ b/src/migrations/mapping_api_version_0_0_2.js
@@ -42,15 +42,19 @@ module.exports = {
     // and replace the values in the data structures here; unfortunately
     // writing that back to the file messes with the formatting more than
     // we'd like; that's why for now, we use a simple patching approach
-    await toolbox.patching.replace(manifestFile, 'apiVersion: 0.0.2', 'apiVersion: 0.0.3')
     await toolbox.patching.replace(
       manifestFile,
-      "apiVersion: '0.0.2'",
+      new RegExp('apiVersion: 0.0.2', 'g'),
+      'apiVersion: 0.0.3',
+    )
+    await toolbox.patching.replace(
+      manifestFile,
+      new RegExp("apiVersion: '0.0.2'", 'g'),
       "apiVersion: '0.0.3'",
     )
     await toolbox.patching.replace(
       manifestFile,
-      'apiVersion: "0.0.2"',
+      new RegExp('apiVersion: "0.0.2"', 'g'),
       'apiVersion: "0.0.3"',
     )
   },


### PR DESCRIPTION
This PR fixes a couple of things:

1. Existing `apiVersion` migrations are updated to replace _all_ `apiVersion` occurrences. Before, only the first would be replaced.

2. `--skip-migrations` is now properly passed on to the compiler. For some time, it wasn't.

These fixes are necessary for https://github.com/daostack/subgraph/pull/318 to work.

Another change made in this PR is that during a `graph build --ipfs ...` and `graph deploy`, files are only uploaded to IPFS once. Any repeated upload attempts simply pick the IPFS hash from a short-lived cache. This speeds up build/deploy for subgraphs that reuse ABIs or mappings across many data sources (like DAOstack).