### PR TITLE
Check directories above for libs

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -234,7 +234,9 @@ class Compiler {
       }
 
       if (libs === undefined) {
-        throw Error(`could not find \`node_modules\` path`)
+        throw Error(
+          `could not locate \`node_modules\` in parent directories of subgraph manifest`,
+        )
       }
 
       let global = path.join(libs, '@graphprotocol', 'graph-ts', 'global', 'global.ts')

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -223,8 +223,9 @@ class Compiler {
       // Look for `node_modules` in the same dir as `subgraph.yaml`.
       let libs = path.join(baseDir, 'node_modules')
       if (!fs.existsSync(libs)) {
-        // It's not there, so look in up to three directories above.
-        for (let i = 1; i <= 3; i++) {
+        // It's not there, so look in the directories above. This, in practice, checks all ancestor
+        // directories but keeps the loop simple.
+        for (let i = 1; i <= 100; i++) {
           let upwardPath = path.resolve(libs, ...Array(i).fill('..'), 'node_modules')
           if (fs.existsSync(upwardPath)) {
             libs = upwardPath

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -220,7 +220,17 @@ class Compiler {
         throw e
       }
 
+      // Look for `node_modules` in the same dir as `subgraph.yaml`.
       let libs = path.join(baseDir, 'node_modules')
+      if (!fs.existsSync(libs)) {
+        // It's not there, so look in up to three directories above.
+        for (let i = 1; i <= 3; i++) {
+          let upwardPath = path.resolve(libs, ...Array(i).fill('..'), 'node_modules')
+          if (fs.existsSync(upwardPath)) {
+            libs = upwardPath
+          }
+        }
+      }
       let global = path.join(libs, '@graphprotocol', 'graph-ts', 'global', 'global.ts')
       global = path.relative(baseDir, global)
 


### PR DESCRIPTION
To fix #359 we still needed to be able to find `node_modules` based on the `subgraph.yaml` path. This makes it so that we also check a few directories above to find `node_modules`, there may still be cases this doesn't cover, but it covers the known use case.