### PR TITLE
codegen: Fix `get` for nullable fields

### DIFF
--- a/src/codegen/schema.js
+++ b/src/codegen/schema.js
@@ -129,7 +129,7 @@ module.exports = class SchemaCodeGenerator {
                             'value',
                             fieldValueType
                           )}`
-    let getNullable = `if (value === null) {
+    let getNullable = `if (value === null || value.kind === ValueKind.NULL) {
                           return null
                         } else {
                           ${getNonNullable}


### PR DESCRIPTION
We forgot to check for explicit null values. This started coming up after https://github.com/graphprotocol/graph-node/pull/1428 I believe. I checked that this fixes the livepeer subgraph.