### PR TITLE
Change default test environment ports

### DIFF
--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -5,8 +5,8 @@
     "codegen": "graph codegen",
     "build": "graph build",
     "test": "truffle test --network test",
-    "create-local": "graph create test/basic-event-handlers --node http://127.0.0.1:8020",
-    "deploy-local": "graph deploy test/basic-event-handlers --ipfs http://localhost:5001 --node http://127.0.0.1:8020"
+    "create-test": "graph create test/basic-event-handlers --node http://127.0.0.1:18020",
+    "deploy-test": "graph deploy test/basic-event-handlers --ipfs http://localhost:15001 --node http://127.0.0.1:18020"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.17.1",

--- a/examples/basic-event-handlers/test/handlers.js
+++ b/examples/basic-event-handlers/test/handlers.js
@@ -6,9 +6,9 @@ const GravatarRegistry = artifacts.require('./GravatarRegistry.sol')
 
 const srcDir = path.join(__dirname, '..')
 
-const fetchSubgraphs = createApolloFetch({ uri: 'http://localhost:8030/graphql' })
+const fetchSubgraphs = createApolloFetch({ uri: 'http://localhost:18030/graphql' })
 const fetchSubgraph = createApolloFetch({
-  uri: 'http://localhost:8000/subgraphs/name/test/basic-event-handlers',
+  uri: 'http://localhost:18000/subgraphs/name/test/basic-event-handlers',
 })
 
 const waitForSubgraphToBeSynced = async () =>
@@ -61,8 +61,8 @@ contract('Basic event handlers', accounts => {
 
     // Create and deploy the subgraph
     await system.run(`yarn codegen`, { cwd: srcDir })
-    await system.run(`yarn create-local`, { cwd: srcDir })
-    await system.run(`yarn deploy-local`, { cwd: srcDir })
+    await system.run(`yarn create-test`, { cwd: srcDir })
+    await system.run(`yarn deploy-test`, { cwd: srcDir })
 
     // Wait for the subgraph to be indexed
     await waitForSubgraphToBeSynced()

--- a/examples/basic-event-handlers/truffle.js
+++ b/examples/basic-event-handlers/truffle.js
@@ -20,7 +20,7 @@ module.exports = {
     },
     test: {
       host: 'localhost',
-      port: 8545,
+      port: 18545,
       network_id: '*',
       gas: '100000000000',
       gasPrice: '1',

--- a/resources/test/docker-compose-standalone-node.yml
+++ b/resources/test/docker-compose-standalone-node.yml
@@ -3,17 +3,17 @@ services:
   ethereum:
     image: trufflesuite/ganache-cli:latest
     ports:
-      - '8545:8545'
-      - '8546:8546'
+      - '18545:8545'
+      - '18546:8546'
     command: -d -l 100000000000 -g 1 --noVMErrorsOnRPCResponse
   ipfs:
     image: ipfs/go-ipfs
     ports:
-      - '5001:5001'
+      - '15001:5001'
   postgres:
     image: postgres
     ports:
-      - '5432:5432'
+      - '15432:5432'
     environment:
       POSTGRES_USER: graph
       POSTGRES_PASSWORD: let-me-in

--- a/resources/test/docker-compose.yml
+++ b/resources/test/docker-compose.yml
@@ -3,11 +3,11 @@ services:
   graph-node:
     image: graphprotocol/graph-node:latest
     ports:
-      - '8000:8000'
-      - '8001:8001'
-      - '8020:8020'
-      - '8030:8030'
-      - '8040:8040'
+      - '18000:8000'
+      - '18001:8001'
+      - '18020:8020'
+      - '18030:8030'
+      - '18040:8040'
     depends_on:
       - ipfs
       - ethereum
@@ -23,17 +23,17 @@ services:
   ethereum:
     image: trufflesuite/ganache-cli:latest
     ports:
-      - '8545:8545'
-      - '8546:8546'
+      - '18545:8545'
+      - '18546:8546'
     command: -d -l 100000000000 -g 1 --noVMErrorsOnRPCResponse
   ipfs:
     image: ipfs/go-ipfs
     ports:
-      - '5001:5001'
+      - '15001:5001'
   postgres:
     image: postgres
     ports:
-      - '5432:5432'
+      - '15432:5432'
     environment:
       POSTGRES_USER: graph
       POSTGRES_PASSWORD: let-me-in

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -26,9 +26,9 @@ Options:
       --node-image <image>      Custom Graph Node image to test against (default: graphprotocol/graph-node:latest)
       --standalone-node <cmd>   Use a standalone Graph Node outside Docker Compose (optional)
       --standalone-node-args    Custom arguments to be passed to the standalone Graph Node (optional)
-      --skip-wait-for-ipfs      Don't wait for IPFS to be up at localhost:5001 (optional)
-      --skip-wait-for-ethereum  Don't wait for Ethereum to be up at localhost:8545 (optional)
-      --skip-wait-for-postgres  Don't wait for Postgres to be up at localhost:5432 (optional)
+      --skip-wait-for-ipfs      Don't wait for IPFS to be up at localhost:15001 (optional)
+      --skip-wait-for-ethereum  Don't wait for Ethereum to be up at localhost:18545 (optional)
+      --skip-wait-for-postgres  Don't wait for Postgres to be up at localhost:15432 (optional)
 `
 
 module.exports = {
@@ -321,7 +321,7 @@ const waitForTestEnvironment = async ({
           async () =>
             new Promise((resolve, reject) => {
               http
-                .get('http://localhost:5001/api/v0/version', response => {
+                .get('http://localhost:15001/api/v0/version', response => {
                   resolve()
                 })
                 .on('error', e => {
@@ -341,7 +341,7 @@ const waitForTestEnvironment = async ({
           async () =>
             new Promise((resolve, reject) => {
               http
-                .get('http://localhost:8545', response => {
+                .get('http://localhost:18545', response => {
                   resolve()
                 })
                 .on('error', e => {
@@ -361,11 +361,7 @@ const waitForTestEnvironment = async ({
           async () =>
             new Promise((resolve, reject) => {
               try {
-                let socket = net.connect(
-                  5432,
-                  'localhost',
-                  () => resolve(),
-                )
+                let socket = net.connect(15432, 'localhost', () => resolve())
                 socket.on('error', e =>
                   reject(new Error(`Could not connect to Postgres: ${e}`)),
                 )
@@ -398,11 +394,11 @@ const startGraphNode = async (standaloneNode, standaloneNodeArgs, nodeOutputChun
     async spinner => {
       let defaultArgs = [
         '--ipfs',
-        'localhost:5001',
+        'localhost:15001',
         '--postgres-url',
-        'postgresql://graph:let-me-in@localhost:5432/graph',
+        'postgresql://graph:let-me-in@localhost:15432/graph',
         '--ethereum-rpc',
-        'test:http://localhost:8545',
+        'test:http://localhost:18545',
       ]
 
       let defaultEnv = {
@@ -441,7 +437,7 @@ const waitForGraphNode = async () =>
         async () =>
           new Promise((resolve, reject) => {
             http
-              .get('http://localhost:8000', { timeout: 10000 }, () => resolve())
+              .get('http://localhost:18000', { timeout: 10000 }, () => resolve())
               .on('error', e => reject(e))
           }),
       )


### PR DESCRIPTION
Moving all host ports from e.g. 8000 and 5432 to 18000 and 15432 allows to run the tests alongside an already running graph-node environment. This is particularly useful for developers, who may want to run tests while keeping their development environment up and running.