### PR TITLE
commands/test: Use 18000-style ports for standalone graph-node as well

### DIFF
--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -399,6 +399,16 @@ const startGraphNode = async (standaloneNode, standaloneNodeArgs, nodeOutputChun
         'postgresql://graph:let-me-in@localhost:15432/graph',
         '--ethereum-rpc',
         'test:http://localhost:18545',
+        '--http-port',
+        '18000',
+        '--ws-port',
+        '18001',
+        '--admin-port',
+        '18020',
+        '--index-node-port',
+        '18030',
+        '--metrics-port',
+        '18040',
       ]
 
       let defaultEnv = {


### PR DESCRIPTION
I forgot this in the previous PR that changed all test environment ports from e.g. `8000` to `18000` to avoid collisions with regular graph-node dev environments.