### PR TITLE
Default to IPFS 0.4.23 for `graph test`

### DIFF
--- a/resources/test/docker-compose-standalone-node.yml
+++ b/resources/test/docker-compose-standalone-node.yml
@@ -7,7 +7,7 @@ services:
       - '18546:8546'
     command: -d -l 100000000000 -g 1 --noVMErrorsOnRPCResponse
   ipfs:
-    image: ipfs/go-ipfs
+    image: ipfs/go-ipfs:v0.4.23
     ports:
       - '15001:5001'
   postgres:

--- a/resources/test/docker-compose.yml
+++ b/resources/test/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - '18546:8546'
     command: -d -l 100000000000 -g 1 --noVMErrorsOnRPCResponse
   ipfs:
-    image: ipfs/go-ipfs
+    image: ipfs/go-ipfs:v0.4.23
     ports:
       - '15001:5001'
   postgres:


### PR DESCRIPTION
The IPFS docker tag `latest` has changed incompatibly. Let's stick to 0.4.x for now.