### PR TITLE
Allow path prefixes in data source and template names.

### DIFF
--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -1,5 +1,4 @@
 const immutable = require('immutable')
-const path = require('path')
 
 const tsCodegen = require('./typescript')
 const typesCodegen = require('./types')
@@ -9,7 +8,10 @@ const ABI = require('../abi')
 module.exports = class AbiCodeGenerator {
   constructor(abi) {
     this.abi = abi
-    this.name = path.basename(abi.name)
+    this.name = abi.name
+      .split('/')
+      .reverse()
+      .shift()
   }
 
   generateModuleImports() {

--- a/src/codegen/template.js
+++ b/src/codegen/template.js
@@ -1,5 +1,4 @@
 const immutable = require('immutable')
-const path = require('path')
 
 const tsCodegen = require('./typescript')
 
@@ -23,8 +22,12 @@ module.exports = class DataSourceTemplateCodeGenerator {
 
   _generateTemplateType() {
     let name = this.template.get('name')
+    let base = name
+      .split('/')
+      .reverse()
+      .shift()
 
-    let klass = tsCodegen.klass(path.basename(name), {
+    let klass = tsCodegen.klass(base, {
       export: true,
       extends: 'DataSourceTemplate',
     })

--- a/src/codegen/template.js
+++ b/src/codegen/template.js
@@ -1,4 +1,5 @@
 const immutable = require('immutable')
+const path = require('path')
 
 const tsCodegen = require('./typescript')
 
@@ -23,7 +24,10 @@ module.exports = class DataSourceTemplateCodeGenerator {
   _generateTemplateType() {
     let name = this.template.get('name')
 
-    let klass = tsCodegen.klass(name, { export: true, extends: 'DataSourceTemplate' })
+    let klass = tsCodegen.klass(path.basename(name), {
+      export: true,
+      extends: 'DataSourceTemplate',
+    })
     klass.addMethod(this._generateCreateMethod())
     klass.addMethod(this._generateCreateWithContextMethod())
     return klass


### PR DESCRIPTION
It's currently possible (although probably by "accident") to use / in the name of  dataSources and templates. For both, it then simply creates a sub-directory when running codegen. However, for templates it then creates invalid syntax in the templates.ts output. Everything else works fine though. I actually like this because it allows us to disambiguoate contract names for different versions of the same contract without adding weird version name suffixes to the name. A simple fix would be to add a path.basename to the code generator for templates.ts. It's a one-line fix on the script. Would you accept such a PR or is there something else tied to the name property in the manifest that would cause problems with the / character?