### PR TITLE
Check for ValueKind.NULL in getters

### DIFF
--- a/src/codegen/schema.js
+++ b/src/codegen/schema.js
@@ -125,9 +125,8 @@ module.exports = class SchemaCodeGenerator {
     let fieldValueType = this._valueTypeFromGraphQl(gqlType)
     let returnType = this._typeFromGraphQl(gqlType)
 
-
     let getNonNullable = `return ${typesCodegen.valueToAsc('value', fieldValueType)}`
-    let getNullable = `if (value === null) {
+    let getNullable = `if (value === null || value.kind == ValueKind.NULL) {
                           return null
                         } else {
                           ${getNonNullable}


### PR DESCRIPTION
For nullable entity fields, we should check if its missing or if it is present but `ValueKind.NULL`, before giving a `Value is not a String.` kind of error.