### PR TITLE
fix: normalize node url using normalize-url

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "jayson": "^3.0.2",
     "js-yaml": "^3.13.1",
     "node-fetch": "^2.3.0",
+    "normalize-url": "^5.2.1",
     "pkginfo": "^0.4.1",
     "prettier": "^1.13.5",
     "request": "^2.88.0",

--- a/src/command-helpers/node.js
+++ b/src/command-helpers/node.js
@@ -1,8 +1,9 @@
+const normalizeUrl = require('normalize-url')
 const URL = require('url').URL
 
 const validateNodeUrl = node => new URL(node)
 
-const normalizeNodeUrl = node => new URL(node).toString()
+const normalizeNodeUrl = node => normalizeUrl(node, { stripHash: true })
 
 module.exports = {
   validateNodeUrl,

--- a/src/commands/auth.js
+++ b/src/commands/auth.js
@@ -59,7 +59,7 @@ module.exports = {
 
     try {
       await saveAccessToken(node, accessToken)
-      print.success(`Access token set for ${node}`)
+      print.success(`Access token set for ${normalizeNodeUrl(node)}`)
     } catch (e) {
       print.error(e)
       process.exitCode = 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -4219,6 +4219,11 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+normalize-url@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-5.2.1.tgz#492a22a8443e604b13cef4b3a97983d66f08bf65"
+  integrity sha512-bFT2ilr7p37ZPEQ9LO9HP/tdFIAE7Q4UoeojXNKeLjs0vXxZetM+C2K9jdbVS7b6ut66CflVLgk1yqHJVrXmiw==
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"


### PR DESCRIPTION
This pr introduces normalize-url to add slightly more "aggressive" url normalization behavior. E.g. trimming of trailing slashes, removal of `#` hashes, etc.

I just ran into this "problem" (auth failing) and it took me quite a bit of time to realize that it's my fault (ran `yarn graph auth` without a trailing slash in the url but tried to deploy to the same node url but with a trailing slash). 

I hope this change saves future ppl (includign myself) from this headache ;-)