### PR TITLE
scaffold.js: load() transaction hash as unique id

### DIFF
--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -222,12 +222,12 @@ const generatePlaceholderHandlers = ({ abi, events, contractName }) =>
     export function handle${event._alias}(event: ${event._alias}): void {
       // Entities can be loaded from the store using a string ID; this ID
       // needs to be unique across all entities of the same type
-      let entity = ExampleEntity.load(event.transaction.from.toHex())
+      let entity = ExampleEntity.load(event.transaction.hash.toHex())
 
       // Entities only exist after they have been saved to the store;
       // \`null\` checks allow to create entities on demand
       if (entity == null) {
-        entity = new ExampleEntity(event.transaction.from.toHex())
+        entity = new ExampleEntity(event.transaction.hash.toHex())
 
         // Entity fields can be set using simple assignments
         entity.count = BigInt.fromI32(0)

--- a/src/scaffold.test.js
+++ b/src/scaffold.test.js
@@ -159,12 +159,12 @@ import { ExampleEntity } from "../generated/schema"
 export function handleExampleEvent(event: ExampleEvent): void {
   // Entities can be loaded from the store using a string ID; this ID
   // needs to be unique across all entities of the same type
-  let entity = ExampleEntity.load(event.transaction.from.toHex())
+  let entity = ExampleEntity.load(event.transaction.hash.toHex())
 
   // Entities only exist after they have been saved to the store;
   // \`null\` checks allow to create entities on demand
   if (entity == null) {
-    entity = new ExampleEntity(event.transaction.from.toHex())
+    entity = new ExampleEntity(event.transaction.hash.toHex())
 
     // Entity fields can be set using simple assignments
     entity.count = BigInt.fromI32(0)


### PR DESCRIPTION
Just went thru the Curator program and am sending this quick PR to suggest a small change that might save future subgraph creators a little pain during setup, especially the first time.

When I set up the subgraph for my project the first time, the auto-generated `mapping.ts` file looked like this:
```
// Entities can be loaded from the store using a string ID; this ID
// needs to be unique across all entities of the same type
let entity = ExampleEntity.load(event.transaction.from.toHex())
```

I can't remember exactly what the problem was (maybe it was throwing errors at some point?) but changing the above to use the `hash` instead of `from` field fixed the problem. I'm assuming this is because the `from` was not unique in the contract I was setting up the subgraph for (it had been in production for a while), and this is probably the case with most contracts that people will try to index that are already in production:
```
let entity = ExampleEntity.load(event.transaction.hash.toHex())
```

I'm thinking this small change would save future devs that are new to the protocol some time, since it hung me up trying to figure out what was wrong.

Also updated the test file for the change I made (in `scaffold.test.js`) but please note that I didn't actually run the test. I'm assuming you probably have some automation that will run it.

Best,
Lauren