### PR TITLE
Add code linting and formatting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,20 @@
 {
+  "parser": "babel-eslint",
   "parserOptions": {
-    "ecmaVersion": 2017,
+    "ecmaVersion": 2020,
+    "sourceType": "module",
     "ecmaFeatures": {
+      "modules": true,
+      "experimentalObjectRestSpread": true
     }
   },
-  "env": {
-    "node": true
+  "extends": ["eslint:recommended"],
+  "rules": {
+    "comma-dangle": 0,
+    "no-console": 1,
+    "no-unused-vars": "warn",
+    "no-undef": "warn",
+    "no-empty": "warn",
+    "no-unexpected-multiline": "warn"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "graph": "bin/graph"
   },
   "devDependencies": {
-    "eslint": "^6.0.1",
+    "babel-eslint": "^10.1.0",
+    "eslint": "7.12.1",
     "jest": "^26.0.0",
+    "prettier": "2.1.2",
     "spawn-command": "^0.0.2-1",
     "strip-ansi": "^6.0.0",
     "tern": "^0.24.0"
@@ -41,6 +43,9 @@
     "test": "jest --verbose",
     "test:init": "jest tests/cli/init.test.js --verbose",
     "test:validation": "jest tests/cli/validation.test.js --verbose",
+    "format": "./node_modules/.bin/prettier --write src/*.js src/**/*.js src/**/**/*.js",
+    "lint": "./node_modules/.bin/eslint . --ext .js",
+    "prepare": "yarn format && yarn lint",
     "release:patch": "npm version patch && npm publish && git push origin master && git push --tags",
     "release:minor": "npm version minor && npm publish && git push origin master && git push --tags"
   }

--- a/src/codegen/util.test.js
+++ b/src/codegen/util.test.js
@@ -64,7 +64,10 @@ describe('Codegen utilities', () => {
         value: {
           type: 'tuple',
           name: 'value',
-          components: [{ name: 'a', type: 'string' }, { name: 'b', type: 'uint256' }],
+          components: [
+            { name: 'a', type: 'string' },
+            { name: 'b', type: 'uint256' },
+          ],
         },
         path: ['value'],
         index: 0,

--- a/src/command-helpers/gluegun.js
+++ b/src/command-helpers/gluegun.js
@@ -35,7 +35,7 @@ const fixParameters = (parameters, booleanOptions) => {
 
   if (unexpectedStringOptions.length > 1) {
     throw new Error(
-      `Unexpected value provided for one or more of ${optionNames}. See --help for more information.`
+      `Unexpected value provided for one or more of ${optionNames}. See --help for more information.`,
     )
   } else if (unexpectedStringOptions.length == 1) {
     let params = parameters.array

--- a/src/command-helpers/jsonrpc.js
+++ b/src/command-helpers/jsonrpc.js
@@ -14,10 +14,10 @@ const createJsonRpcClient = url => {
     return jayson.Client.http(params)
   } else {
     toolbox.print.error(
-      `Unsupported protocol: ${url.protocol.substring(0, url.protocol.length - 1)}`
+      `Unsupported protocol: ${url.protocol.substring(0, url.protocol.length - 1)}`,
     )
     toolbox.print.error(
-      'The Graph Node URL must be of the following format: http(s)://host[:port]/[path]'
+      'The Graph Node URL must be of the following format: http(s)://host[:port]/[path]',
     )
     return null
   }

--- a/src/commands/auth.js
+++ b/src/commands/auth.js
@@ -4,7 +4,7 @@ const { saveAccessToken } = require('../command-helpers/auth')
 
 const HELP = `
 ${chalk.bold('graph auth')} [options] ${chalk.bold('<node>')} ${chalk.bold(
-  '<access-token>'
+  '<access-token>',
 )}
 
 ${chalk.dim('Options:')}

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -76,7 +76,7 @@ module.exports = {
     client.request('subgraph_create', { name: subgraphName }, function(
       requestError,
       jsonRpcError,
-      res
+      res,
     ) {
       if (jsonRpcError) {
         spinner.fail(`Error creating the subgraph: ${jsonRpcError.message}`)

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -38,7 +38,16 @@ ${chalk.dim('Options for --from-contract:')}
 
 const processInitForm = async (
   toolbox,
-  {abi, address, allowSimpleName, directory, fromExample, network, subgraphName, contractName},
+  {
+    abi,
+    address,
+    allowSimpleName,
+    directory,
+    fromExample,
+    network,
+    subgraphName,
+    contractName,
+  },
 ) => {
   let networkChoices = ['mainnet', 'kovan', 'rinkeby', 'ropsten', 'goerli', 'poa-core']
   let addressPattern = /^(0x)?[0-9a-fA-F]{40}$/
@@ -156,9 +165,9 @@ const processInitForm = async (
       skip: () => fromExample !== undefined,
       validate: value => value && value.length > 0,
       result: value => {
-        contractName = value;
-        return value;
-      }
+        contractName = value
+        return value
+      },
     },
   ]
 
@@ -177,9 +186,10 @@ const loadAbiFromBlockScout = async (network, address) =>
     `Warnings while fetching ABI from BlockScout`,
     async spinner => {
       let result = await fetch(
-        `https://blockscout.com/${
-          network.replace('-', '/')
-        }/api?module=contract&action=getabi&address=${address}`,
+        `https://blockscout.com/${network.replace(
+          '-',
+          '/',
+        )}/api?module=contract&action=getabi&address=${address}`,
       )
       let json = await result.json()
 
@@ -262,7 +272,7 @@ module.exports = {
 
     let subgraphName, directory
     try {
-      ;[subgraphName, directory] = fixParameters(toolbox.parameters, {
+      [subgraphName, directory] = fixParameters(toolbox.parameters, {
         fromExample,
         allowSimpleName,
         help,
@@ -367,7 +377,7 @@ module.exports = {
       fromExample,
       network,
       subgraphName,
-      contractName
+      contractName,
     })
 
     // Exit immediately when the form is cancelled
@@ -398,7 +408,7 @@ module.exports = {
           network: inputs.network,
           address: inputs.address,
           indexEvents,
-          contractName: inputs.contractName
+          contractName: inputs.contractName,
         },
         { commands },
       )
@@ -588,7 +598,16 @@ const initSubgraphFromExample = async (
 
 const initSubgraphFromContract = async (
   toolbox,
-  {allowSimpleName, subgraphName, directory, abi, network, address, indexEvents, contractName},
+  {
+    allowSimpleName,
+    subgraphName,
+    directory,
+    abi,
+    network,
+    address,
+    indexEvents,
+    contractName,
+  },
   { commands },
 ) => {
   let { print } = toolbox

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -76,7 +76,7 @@ module.exports = {
     client.request('subgraph_remove', { name: subgraphName }, function(
       requestError,
       jsonRpcError,
-      res
+      res,
     ) {
       if (jsonRpcError) {
         spinner.fail(`Error removing the subgraph: ${jsonRpcError.message}`)

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -491,7 +491,7 @@ const collectGraphNodeLogs = async (tempdir, standaloneNode, nodeOutputChunks) =
       follow: false,
       cwd: path.join(tempdir, 'compose'),
     })
-    return stripAnsi(logs.out.trim()).replace(/graph-node_1  \| /g, '')
+    return stripAnsi(logs.out.trim()).replace(/graph-node_1 {2}\| /g, '')
   }
 }
 
@@ -500,7 +500,7 @@ const collectEthereumLogs = async tempdir => {
     follow: false,
     cwd: path.join(tempdir, 'compose'),
   })
-  return stripAnsi(logs.out.trim()).replace(/ethereum_1  \| /g, '')
+  return stripAnsi(logs.out.trim()).replace(/ethereum_1 {2}\| /g, '')
 }
 
 const runTests = async testCommand =>

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -271,11 +271,7 @@ class Compiler {
       let outputFile = path.relative(baseDir, outFile)
 
       // Create output directory
-      try {
-        fs.mkdirsSync(path.dirname(outFile))
-      } catch (e) {
-        throw e
-      }
+      fs.mkdirsSync(path.dirname(outFile))
 
       let libs = this.libsDirs.join(',')
       let global = path.relative(baseDir, this.globalsFile)
@@ -353,11 +349,7 @@ class Compiler {
       let outputFile = path.relative(baseDir, outFile)
 
       // Create output directory
-      try {
-        fs.mkdirsSync(path.dirname(outFile))
-      } catch (e) {
-        throw e
-      }
+      fs.mkdirsSync(path.dirname(outFile))
 
       let libs = this.libsDirs.join(',')
       let global = path.relative(baseDir, this.globalsFile)

--- a/src/migrations/mapping_api_version_0_0_1.js
+++ b/src/migrations/mapping_api_version_0_0_1.js
@@ -26,7 +26,7 @@ module.exports = {
       manifest &&
       typeof manifest === 'object' &&
       Array.isArray(manifest.dataSources) &&
-      manifest.dataSources.reduce(
+      (manifest.dataSources.reduce(
         (hasOldMappings, dataSource) =>
           hasOldMappings ||
           (typeof dataSource === 'object' &&
@@ -34,7 +34,17 @@ module.exports = {
             typeof dataSource.mapping === 'object' &&
             dataSource.mapping.apiVersion === '0.0.1'),
         false,
-      )
+      ) ||
+        (Array.isArray(manifest.templates) &&
+          manifest.templates.reduce(
+            (hasOldMappings, template) =>
+              hasOldMappings ||
+              (typeof template === 'object' &&
+                template.mapping &&
+                typeof template.mapping === 'object' &&
+                template.mapping.apiVersion === '0.0.1'),
+            false,
+          )))
     )
   },
   apply: async ({ manifestFile }) => {

--- a/src/migrations/mapping_api_version_0_0_2.js
+++ b/src/migrations/mapping_api_version_0_0_2.js
@@ -20,13 +20,13 @@ module.exports = {
 
     let manifest = yaml.safeLoad(fs.readFileSync(manifestFile, 'utf-8'))
     return (
-      // Only migrate if the graph-ts version is > 0.5.1...
+      // Only migrate if the graph-ts version is > 0.12.0...
       semver.gt(graphTsVersion, '0.12.0') &&
       // ...and we have a manifest with mapping > apiVersion = 0.0.2
       manifest &&
       typeof manifest === 'object' &&
       Array.isArray(manifest.dataSources) &&
-      manifest.dataSources.reduce(
+      (manifest.dataSources.reduce(
         (hasOldMappings, dataSource) =>
           hasOldMappings ||
           (typeof dataSource === 'object' &&
@@ -34,7 +34,17 @@ module.exports = {
             typeof dataSource.mapping === 'object' &&
             dataSource.mapping.apiVersion === '0.0.2'),
         false,
-      )
+      ) ||
+        (Array.isArray(manifest.templates) &&
+          manifest.templates.reduce(
+            (hasOldMappings, template) =>
+              hasOldMappings ||
+              (typeof template === 'object' &&
+                template.mapping &&
+                typeof template.mapping === 'object' &&
+                template.mapping.apiVersion === '0.0.2'),
+            false,
+          )))
     )
   },
   apply: async ({ manifestFile }) => {

--- a/src/migrations/mapping_api_version_0_0_3.js
+++ b/src/migrations/mapping_api_version_0_0_3.js
@@ -26,7 +26,7 @@ module.exports = {
       manifest &&
       typeof manifest === 'object' &&
       Array.isArray(manifest.dataSources) &&
-      manifest.dataSources.reduce(
+      (manifest.dataSources.reduce(
         (hasOldMappings, dataSource) =>
           hasOldMappings ||
           (typeof dataSource === 'object' &&
@@ -34,7 +34,17 @@ module.exports = {
             typeof dataSource.mapping === 'object' &&
             dataSource.mapping.apiVersion === '0.0.3'),
         false,
-      )
+      ) ||
+        (Array.isArray(manifest.templates) &&
+          manifest.templates.reduce(
+            (hasOldMappings, template) =>
+              hasOldMappings ||
+              (typeof template === 'object' &&
+                template.mapping &&
+                typeof template.mapping === 'object' &&
+                template.mapping.apiVersion === '0.0.3'),
+            false,
+          )))
     )
   },
   apply: async ({ manifestFile }) => {

--- a/src/scaffold.test.js
+++ b/src/scaffold.test.js
@@ -1,11 +1,6 @@
 const ABI = require('./abi')
 const immutable = require('immutable')
-const {
-  generateEventFieldAssignments,
-  generateManifest,
-  generateMapping,
-  generateSchema,
-} = require('./scaffold')
+const { generateManifest, generateMapping, generateSchema } = require('./scaffold')
 
 const TEST_EVENT = {
   name: 'ExampleEvent',
@@ -80,7 +75,7 @@ describe('Subgraph scaffolding', () => {
         abi: TEST_ABI,
         network: 'kovan',
         address: '0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d',
-        contractName: 'Contract'
+        contractName: 'Contract',
       }),
     ).toEqual(`\
 specVersion: 0.0.1
@@ -204,7 +199,9 @@ export function handleExampleEvent1(event: ExampleEvent1): void {}
   })
 
   test('Mapping (for indexing events)', () => {
-    expect(generateMapping({ abi: TEST_ABI, indexEvents: true, contractName: 'Contract' })).toEqual(`\
+    expect(
+      generateMapping({ abi: TEST_ABI, indexEvents: true, contractName: 'Contract' }),
+    ).toEqual(`\
 import {
   ExampleEvent as ExampleEventEvent,
   ExampleEvent1 as ExampleEvent1Event

--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -2,8 +2,6 @@ const fs = require('fs-extra')
 const immutable = require('immutable')
 const path = require('path')
 const prettier = require('prettier')
-const graphql = require('graphql/language')
-const chalk = require('chalk')
 const toolbox = require('gluegun/toolbox')
 
 const ABI = require('./abi')

--- a/src/validation/manifest.js
+++ b/src/validation/manifest.js
@@ -67,7 +67,10 @@ const validators = immutable.fromJS({
 
   NonNullType: (value, ctx) =>
     value !== null && value !== undefined
-      ? validateValue(value, ctx.update('type', type => type.get('type')))
+      ? validateValue(
+          value,
+          ctx.update('type', type => type.get('type')),
+        )
       : immutable.fromJS([
           {
             path: ctx.get('path'),

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -221,7 +221,8 @@ const entityTypeByName = (defs, name) =>
     .filter(
       def =>
         def.kind === 'InterfaceTypeDefinition' ||
-        (def.kind === 'ObjectTypeDefinition' && def.directives.find(directive => directive.name.value === 'entity'))
+        (def.kind === 'ObjectTypeDefinition' &&
+          def.directives.find(directive => directive.name.value === 'entity')),
     )
     .find(def => def.name.value === name)
 
@@ -341,7 +342,11 @@ does not exist on type '${targetEntity.name.value}'`,
 
   // The field we are deriving from must either have type 'def' or one of the
   // interface types that 'def' is implementing
-  if (!backRefEntity || (backRefEntity.name.value !== def.name.value && !def.interfaces.find(intf => intf.name.value === backRefEntity.name.value))) {
+  if (
+    !backRefEntity ||
+    (backRefEntity.name.value !== def.name.value &&
+      !def.interfaces.find(intf => intf.name.value === backRefEntity.name.value))
+  ) {
     return immutable.fromJS([
       {
         loc: directive.loc,

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -55,7 +55,7 @@ module.exports = class Watcher {
               files.push(path.resolve(path.join(dirname, filename)))
               return files
             }, files),
-          []
+          [],
         )
 
         let diff = (xs, ys) => ({

--- a/tests/cli/util.js
+++ b/tests/cli/util.js
@@ -22,7 +22,7 @@ const cliTest = (title, args, testPath, options) => {
       let expectedStdout = undefined
       try {
         expectedStdout = fs.readFileSync(resolvePath(`./${testPath}.stdout`), 'utf-8')
-      } catch (e) {}
+      } catch (e) { }
 
       let expectedStderr = undefined
       try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -670,10 +670,10 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
-  integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
+acorn-jsx@^5.2.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
+  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
 acorn-loose@^6.0.0:
   version "6.1.0"
@@ -696,11 +696,6 @@ acorn@^6.0.0, acorn@^6.2.0:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
-
-acorn@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
-  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
 
 acorn@^7.1.1:
   version "7.1.1"
@@ -1262,6 +1257,14 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -1352,10 +1355,10 @@ cli-table3@~0.5.0:
   optionalDependencies:
     colors "^1.1.2"
 
-cli-width@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
-  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 cliui@^6.0.0:
   version "6.0.0"
@@ -1866,11 +1869,11 @@ escodegen@^1.14.1:
     source-map "~0.6.1"
 
 eslint-scope@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
-  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
   dependencies:
-    esrecurse "^4.1.0"
+    esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
 eslint-utils@^1.4.3:
@@ -1929,12 +1932,12 @@ eslint@^6.0.1:
     v8-compile-cache "^2.0.3"
 
 espree@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-6.1.2.tgz#6c272650932b4f91c3714e5e7b5f5e2ecf47262d"
-  integrity sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
+  integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
   dependencies:
-    acorn "^7.1.0"
-    acorn-jsx "^5.1.0"
+    acorn "^7.1.1"
+    acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
 
 esprima@^4.0.0, esprima@^4.0.1:
@@ -1943,23 +1946,28 @@ esprima@^4.0.0, esprima@^4.0.1:
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esquery@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
-  integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
-    estraverse "^4.0.0"
+    estraverse "^5.1.0"
 
-esrecurse@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
-  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
-    estraverse "^4.1.0"
+    estraverse "^5.2.0"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+estraverse@^5.1.0, estraverse@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -2149,9 +2157,9 @@ fb-watchman@^2.0.0:
     bser "2.1.1"
 
 figures@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-3.1.0.tgz#4b198dd07d8d71530642864af2d45dd9e459c4ec"
-  integrity sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
 
@@ -2612,22 +2620,22 @@ ini@~1.3.0:
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
 inquirer@^7.0.0:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.3.tgz#f9b4cd2dff58b9f73e8d43759436ace15bed4567"
-  integrity sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
+  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
   dependencies:
     ansi-escapes "^4.2.1"
-    chalk "^2.4.2"
+    chalk "^4.1.0"
     cli-cursor "^3.1.0"
-    cli-width "^2.0.0"
+    cli-width "^3.0.0"
     external-editor "^3.0.3"
     figures "^3.0.0"
-    lodash "^4.17.15"
+    lodash "^4.17.19"
     mute-stream "0.0.8"
-    run-async "^2.2.0"
-    rxjs "^6.5.3"
+    run-async "^2.4.0"
+    rxjs "^6.6.0"
     string-width "^4.1.0"
-    strip-ansi "^5.1.0"
+    strip-ansi "^6.0.0"
     through "^2.3.6"
 
 ip-regex@^2.0.0, ip-regex@^2.1.0:
@@ -2940,11 +2948,6 @@ is-potential-custom-element-name@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
   integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
-
-is-promise@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
-  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
 is-promise@~1, is-promise@~1.0.0:
   version "1.0.1"
@@ -3794,6 +3797,11 @@ lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.19:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^3.0.0:
   version "3.0.0"
@@ -4950,17 +4958,15 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-run-async@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
-  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
-  dependencies:
-    is-promise "^2.1.0"
+run-async@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
-rxjs@^6.5.3:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
-  integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
+rxjs@^6.6.0:
+  version "6.6.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.6.tgz#14d8417aa5a07c5e633995b525e1e3c0dec03b70"
+  integrity sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==
   dependencies:
     tslib "^1.9.0"
 
@@ -5412,9 +5418,9 @@ strip-final-newline@^2.0.0:
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-json-comments@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
-  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -5645,9 +5651,9 @@ tr46@^2.0.0:
     punycode "^2.1.1"
 
 tslib@^1.9.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Use `babel-eslint` and `prettify` to lint and format project code, and include in the `prepare` script so they is automatically run with a build. 

_Note: This was done on top of https://github.com/graphprotocol/graph-cli/pull/625, so probably best to wait until that is merged, then rebase and merge this._