### PR TITLE
test: Avoid sending 'undefined' argument to matchstick

### DIFF
--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -46,7 +46,7 @@ module.exports = {
 
     let binary = new Binary(platform, url, version);
     await binary.install(force);
-    binary.run(datasource);
+    datasource ? binary.run(datasource) : binary.run();
   }
 }
 


### PR DESCRIPTION
When calling `graph test`, under the hood it's executing matchstick binary with the arguments passed to `graph test`.
If you pass a test name, for example `graph test gns`, it works fine. The issue is when you don't pass any argument, it calls `matchstick undefined`, so matchstick fails with error message that there's no test named 'undefined'.

Example from running `npx graph test` from demo-subgraph repo:

![image](https://user-images.githubusercontent.com/2818438/138902431-5f71be92-3cd2-49dc-84a0-9af955d8515d.png)
