### PR TITLE
Make types non-nullable by default

### DIFF
--- a/src/codegen/schema.js
+++ b/src/codegen/schema.js
@@ -236,7 +236,7 @@ Suggestion: add an '!' to the member type of the List, change from '${fieldValue
       : gqlType.getIn(['name', 'value'])
   }
 
-  _typeFromGraphQl(gqlType, nullable = true) {
+  _typeFromGraphQl(gqlType, nullable = false) {
     if (gqlType.get('kind') === 'NonNullType') {
       return this._typeFromGraphQl(gqlType.get('type'), false)
     } else if (gqlType.get('kind') === 'ListType') {


### PR DESCRIPTION
### Description

There is a discrepancy between how the graphql types are generated during scaffolding and how they are read during code generation. 

If I have an abi like this https://github.com/nevermined-io/contracts/blob/5b8680b3c581ec50877ed8451c623c8480ac000d/artifacts/AccessProofCondition.mumbai.json#L3-L52 and using the cli to run `graph init` with `--index-events` it will generate the following schema.

```graphql
type AccessProofConditionFulfilled @entity {
  id: ID!
  _agreementId: Bytes! # bytes32
  _origHash: BigInt! # uint256
  _buyer: [BigInt]! # uint256[2]
  _provider: [BigInt]! # uint256[2]
  _cipher: [BigInt]! # uint256[2]
  _proof: Bytes! # bytes
  _conditionId: Bytes! # bytes32
}
```

Now during code generation when the `uint256[]` types are converted from graphql it complains that lists cannot have nullable types.

Changing a default is probably not the best idea but I'm glad to help if someone points me in the right direction