### PR TITLE
add .gitignore file support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.30.0-alpha.1",
+  "version": "0.30.0",
   "license": "(Apache-2.0 OR MIT)",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.30.0",
+  "version": "0.30.0-alpha.1",
   "license": "(Apache-2.0 OR MIT)",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -623,7 +623,7 @@ const createGitignore = async (toolbox, directory) =>
     `Failed to create .gitignore file`,
     `Warnings while creating .gitignore file`,
     async (spinner) => {
-      // Remove .gitignore file if exist else create .gitignore
+      // Remove .gitignore file if it exists and create a new one
       let gitignoreFilePath = path.join(directory, '.gitignore')
       if (toolbox.filesystem.exists(gitignoreFilePath)) {
         await toolbox.filesystem.remove(gitignoreFilePath)

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -619,9 +619,9 @@ const initRepository = async (toolbox, directory) =>
 
 const createGitignore = async (toolbox, directory) =>
   await withSpinner(
-    `Initialize subgraph repository`,
-    `Failed to initialize subgraph repository`,
-    `Warnings while initializing subgraph repository`,
+    `Create .gitignore file`,
+    `Failed to create .gitignore file`,
+    `Warnings while creating .gitignore file`,
     async (spinner) => {
       // Remove .gitignore file if exist else create .gitignore
       let gitignoreFilePath = path.join(directory, '.gitignore')

--- a/tests/cli/init/ethereum/from-contract-with-abi-and-structs.stderr
+++ b/tests/cli/init/ethereum/from-contract-with-abi-and-structs.stderr
@@ -8,6 +8,8 @@
 ✔ Initialize networks config
 - Initialize subgraph repository
 ✔ Initialize subgraph repository
+- Create .gitignore file
+✔ Create .gitignore file
 - Install dependencies with yarn
 ✔ Install dependencies with yarn
 - Generate ABI and schema types with yarn codegen

--- a/tests/cli/init/ethereum/from-contract-with-abi.stderr
+++ b/tests/cli/init/ethereum/from-contract-with-abi.stderr
@@ -7,7 +7,9 @@
 - Initialize networks config
 ✔ Initialize networks config
 - Initialize subgraph repository
-✔ Initialize subgraph repository
+✔ Initialize subgraph 
+- Create .gitignore file
+✔ Create .gitignore file
 - Install dependencies with yarn
 ✔ Install dependencies with yarn
 - Generate ABI and schema types with yarn codegen

--- a/tests/cli/init/ethereum/from-contract-with-abi.stderr
+++ b/tests/cli/init/ethereum/from-contract-with-abi.stderr
@@ -7,7 +7,7 @@
 - Initialize networks config
 ✔ Initialize networks config
 - Initialize subgraph repository
-✔ Initialize subgraph 
+✔ Initialize subgraph repository
 - Create .gitignore file
 ✔ Create .gitignore file
 - Install dependencies with yarn

--- a/tests/cli/init/ethereum/from-contract-with-overloaded-elements.stderr
+++ b/tests/cli/init/ethereum/from-contract-with-overloaded-elements.stderr
@@ -8,6 +8,8 @@
 ✔ Initialize networks config
 - Initialize subgraph repository
 ✔ Initialize subgraph repository
+- Create .gitignore file
+✔ Create .gitignore file
 - Install dependencies with yarn
 ✔ Install dependencies with yarn
 - Generate ABI and schema types with yarn codegen

--- a/tests/cli/init/ethereum/from-contract.stderr
+++ b/tests/cli/init/ethereum/from-contract.stderr
@@ -10,6 +10,8 @@
 ✔ Initialize networks config
 - Initialize subgraph repository
 ✔ Initialize subgraph repository
+- Create .gitignore file
+✔ Create .gitignore file
 - Install dependencies with yarn
 ✔ Install dependencies with yarn
 - Generate ABI and schema types with yarn codegen

--- a/tests/cli/init/ethereum/from-example.stderr
+++ b/tests/cli/init/ethereum/from-example.stderr
@@ -6,6 +6,8 @@
 ✔ Update subgraph name and commands in package.json
 - Initialize subgraph repository
 ✔ Initialize subgraph repository
+- Create .gitignore file
+✔ Create .gitignore file
 - Install dependencies with yarn
 ✔ Install dependencies with yarn
 - Generate ABI and schema types with yarn codegen

--- a/tests/cli/init/near/from-contract.stderr
+++ b/tests/cli/init/near/from-contract.stderr
@@ -8,6 +8,8 @@
 ✔ Initialize networks config
 - Initialize subgraph repository
 ✔ Initialize subgraph repository
+- Create .gitignore file
+✔ Create .gitignore file
 - Install dependencies with yarn
 ✔ Install dependencies with yarn
 - Generate ABI and schema types with yarn codegen


### PR DESCRIPTION
previously graph init does not create .gitignore file
With this pull request, graph init will be able to create .gitignore file
changes are made in src/commands/init.js file, gitignoreFileContent string & createGitignore function are written.
createGitignore function is placed in two functions (initSubgraphFromExample & initSubgraphFromContract) at appropriate position after the initRepository function. 
