### PR TITLE
removed the abi path argument from write abi function

### DIFF
--- a/src/command-helpers/scaffold.js
+++ b/src/command-helpers/scaffold.js
@@ -79,12 +79,12 @@ const writeScaffold = async (scaffold, directory, spinner) => {
   await writeScaffoldDirectory(scaffold, directory, spinner)
 }
 
-const writeABI = async (abi, contractName, abiPath = `./abis/${contractName}.json`) => {
+const writeABI = async (abi, contractName) => {
   let data = prettier.format(JSON.stringify(abi.data), {
     parser: 'json',
   })
 
-  await fs.writeFile(abiPath, data, { encoding: 'utf-8' })
+  await fs.writeFile(`./abis/${contractName}.json`, data, { encoding: 'utf-8' })
 }
 
 const writeSchema = async (abi, protocol, schemaPath, entities) => {

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -95,7 +95,7 @@ module.exports = {
     let { collisionEntities, onlyCollisions, abiData } = updateEventNamesOnCollision(ethabi, entities, contractName, mergeEntities)
     ethabi.data = abiData
 
-    await writeABI(ethabi, contractName, abi)
+    await writeABI(ethabi, contractName)
     await writeSchema(ethabi, protocol, result.getIn(['schema', 'file']), collisionEntities)
     await writeMapping(ethabi, protocol, contractName, collisionEntities)
 


### PR DESCRIPTION
In some cases the local abi file that's given as an argument is not a file we want to be overwriting so it's better to have it always write a file in the abis folder.