### PR TITLE
fix(package): resolve deps over https

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "license": "(Apache-2.0 OR MIT)",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {
@@ -13,7 +13,7 @@
     "dockerode": "2.5.8",
     "fs-extra": "9.0.0",
     "glob": "7.1.6",
-    "gluegun": "https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep",
+    "gluegun": "git+https://git@github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep",
     "graphql": "15.5.0",
     "immutable": "3.8.2",
     "ipfs-http-client": "34.0.0",


### PR DESCRIPTION
having the naked `https://github.com/...` field statement for a dependency incorrectly attempts to resolve the dependency via ssh.

adding `git+https://git@github.com/...` forces the package client to correctly resolve over HTTPs