### PR TITLE
fix: publish readme to npm

### DIFF
--- a/.changeset/rich-crews-worry.md
+++ b/.changeset/rich-crews-worry.md
@@ -1,0 +1,6 @@
+---
+'@graphprotocol/graph-cli': patch
+'@graphprotocol/graph-ts': patch
+---
+
+publish readme with packages

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,7 @@
   },
   "main": "dist/cli.js",
   "files": [
+    "README.md",
     "CHANGELOG.md",
     "dist"
   ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,9 +11,9 @@
   },
   "main": "dist/cli.js",
   "files": [
-    "README.md",
     "CHANGELOG.md",
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -b tsconfig.build.json && copyfiles -u 1 src/**/*.graphql dist/ && chmod +x ./dist/bin.js",

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -5,6 +5,9 @@
   "main": "index.ts",
   "module": "index.ts",
   "types": "index.ts",
+  "files": [
+    "README.md"
+  ],
   "scripts": {
     "build": "asc --explicitStart --exportRuntime --runtime stub index.ts helper-functions.ts --lib graph-ts -b index.wasm",
     "format": "prettier --write -c **/*.{js,ts}",


### PR DESCRIPTION
| Before | After |
| -------|------|
|![CleanShot 2023-01-19 at 17 25 45](https://user-images.githubusercontent.com/44710980/213576074-5fec29ac-ad90-443f-9596-cc3848b26ba6.png) |![CleanShot 2023-01-19 at 17 24 46](https://user-images.githubusercontent.com/44710980/213575967-9fc8578c-41d0-41ef-85d5-aee73f87f002.png)|
|![CleanShot 2023-01-19 at 17 26 44](https://user-images.githubusercontent.com/44710980/213576242-63805266-360a-40aa-9814-b58dd3ae8978.png)|![CleanShot 2023-01-19 at 17 27 03](https://user-images.githubusercontent.com/44710980/213576272-3af3a01c-f546-4b65-ab29-5d7cd89139f9.png)|



Note: `graph-ts` today is fine but now that it lives in this repo it might break. This PR ensures it will work.

closes https://github.com/graphprotocol/graph-tooling/issues/1028