### PR TITLE
chore: use workspace version for graph ts

### DIFF
--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -16,7 +16,7 @@
     "truffle-hdwallet-provider": "1.0.6"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.29.2",
+    "@graphprotocol/graph-ts": "workspace:*",
     "apollo-fetch": "^0.7.0"
   },
   "resolutions": {

--- a/examples/example-subgraph/package.json
+++ b/examples/example-subgraph/package.json
@@ -8,7 +8,7 @@
     "codegen": "../../packages/cli/dist/bin.js codegen --output-dir src/types/ subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.29.2"
+    "@graphprotocol/graph-ts": "workspace:*"
   },
   "resolutions": {
     "assemblyscript": "0.19.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
 
   examples/basic-event-handlers:
     specifiers:
-      '@graphprotocol/graph-ts': 0.29.1
+      '@graphprotocol/graph-ts': workspace:*
       apollo-fetch: ^0.7.0
       babel-polyfill: 6.26.0
       babel-register: 6.26.0
@@ -47,7 +47,7 @@ importers:
 
   examples/example-subgraph:
     specifiers:
-      '@graphprotocol/graph-ts': 0.29.1
+      '@graphprotocol/graph-ts': workspace:*
     devDependencies:
       '@graphprotocol/graph-ts': link:../../packages/ts
 


### PR DESCRIPTION
this should fix issue with CI breaking each time we update versions. Examples will always use the local version.
