### PR TITLE
fix: build issues with substreams

### DIFF
--- a/.changeset/shiny-zebras-accept.md
+++ b/.changeset/shiny-zebras-accept.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+global files are not needed when using substreams

--- a/packages/cli/src/compiler/index.ts
+++ b/packages/cli/src/compiler/index.ts
@@ -32,7 +32,7 @@ export default class Compiler {
   private libsDirs: string[];
   /**
    * Path to the global.ts file in the graph-ts package.
-   * 
+   *
    * @note if you are using substreams as a protocol, this will be undefined.
    */
   private globalsFile?: string;

--- a/packages/cli/src/compiler/index.ts
+++ b/packages/cli/src/compiler/index.ts
@@ -30,7 +30,12 @@ export default class Compiler {
   private sourceDir: string;
   private blockIpfsMethods?: RegExpMatchArray;
   private libsDirs: string[];
-  private globalsFile: string;
+  /**
+   * Path to the global.ts file in the graph-ts package.
+   * 
+   * @note if you are using substreams as a protocol, this will be undefined.
+   */
+  private globalsFile?: string;
   private protocol: Protocol;
   private ABI: any;
 
@@ -40,45 +45,41 @@ export default class Compiler {
     this.sourceDir = path.dirname(options.subgraphManifest);
     this.blockIpfsMethods = options.blockIpfsMethods;
     this.libsDirs = [];
-
-    if (options.protocol.name !== 'substreams') {
-      for (
-        let dir: string | undefined = path.resolve(this.sourceDir);
-        // Terminate after the root dir or when we have found node_modules
-        dir !== undefined;
-        // Continue with the parent directory, terminate after the root dir
-        dir = path.dirname(dir) === dir ? undefined : path.dirname(dir)
-      ) {
-        if (fs.existsSync(path.join(dir, 'node_modules'))) {
-          this.libsDirs.push(path.join(dir, 'node_modules'));
-        }
-      }
-
-      if (this.libsDirs.length === 0) {
-        throw Error(`could not locate \`node_modules\` in parent directories of subgraph manifest`);
-      }
-
-      const globalsFile = path.join('@graphprotocol', 'graph-ts', 'global', 'global.ts');
-      const globalsLib = this.libsDirs.find(item => {
-        return fs.existsSync(path.join(item, globalsFile));
-      });
-
-      if (!globalsLib) {
-        throw Error(
-          'Could not locate `@graphprotocol/graph-ts` package in parent directories of subgraph manifest.',
-        );
-      }
-
-      this.globalsFile = path.join(globalsLib, globalsFile);
-    }
-
-    // @ts-expect-error assigned or not, we dont care
-    if (!this.globalsFile) {
-      throw new Error('Globals file is missing.');
-    }
-
     this.protocol = this.options.protocol;
     this.ABI = this.protocol.getABI();
+
+    if (options.protocol.name === 'substreams') {
+      return;
+    }
+
+    for (
+      let dir: string | undefined = path.resolve(this.sourceDir);
+      // Terminate after the root dir or when we have found node_modules
+      dir !== undefined;
+      // Continue with the parent directory, terminate after the root dir
+      dir = path.dirname(dir) === dir ? undefined : path.dirname(dir)
+    ) {
+      if (fs.existsSync(path.join(dir, 'node_modules'))) {
+        this.libsDirs.push(path.join(dir, 'node_modules'));
+      }
+    }
+
+    if (this.libsDirs.length === 0) {
+      throw Error(`could not locate \`node_modules\` in parent directories of subgraph manifest`);
+    }
+
+    const globalsFile = path.join('@graphprotocol', 'graph-ts', 'global', 'global.ts');
+    const globalsLib = this.libsDirs.find(item => {
+      return fs.existsSync(path.join(item, globalsFile));
+    });
+
+    if (!globalsLib) {
+      throw Error(
+        'Could not locate `@graphprotocol/graph-ts` package in parent directories of subgraph manifest.',
+      );
+    }
+
+    this.globalsFile = path.join(globalsLib, globalsFile);
 
     process.on('uncaughtException', e => {
       toolbox.print.error(`UNCAUGHT EXCEPTION: ${e}`);
@@ -316,6 +317,11 @@ export default class Compiler {
       fs.mkdirsSync(path.dirname(outFile));
 
       const libs = this.libsDirs.join(',');
+      if (!this.globalsFile) {
+        throw Error(
+          'Could not locate `@graphprotocol/graph-ts` package in parent directories of subgraph manifest.',
+        );
+      }
       const global = path.relative(baseDir, this.globalsFile);
 
       asc.compile({
@@ -382,6 +388,11 @@ export default class Compiler {
       fs.mkdirsSync(path.dirname(outFile));
 
       const libs = this.libsDirs.join(',');
+      if (!this.globalsFile) {
+        throw Error(
+          'Could not locate `@graphprotocol/graph-ts` package in parent directories of subgraph manifest.',
+        );
+      }
       const global = path.relative(baseDir, this.globalsFile);
 
       asc.compile({


### PR DESCRIPTION
### Summary

For Substreams we actually don't care about globals files. This will unblock the issue for now.

| Before | After |
| ------|------|
| [![asciicast](https://asciinema.org/a/lKWD7vNLi628ZfkYnXkNGVxVQ.svg)](https://asciinema.org/a/lKWD7vNLi628ZfkYnXkNGVxVQ) |  [![asciicast](https://asciinema.org/a/NQi3iZTDIUiRVVhY0264BAHr3.svg)](https://asciinema.org/a/NQi3iZTDIUiRVVhY0264BAHr3) |

closes https://github.com/graphprotocol/graph-tooling/issues/1067

---------
Long term I think we should consider refactoring `Compiler` into modular pieces which we can combine different modules based on protocol because today's structure is not extensible enough. 