### PR TITLE
test: run postgres with C collate and UTF8 and fix `--node` flag for deploy 

### DIFF
--- a/.changeset/strange-mayflies-count.md
+++ b/.changeset/strange-mayflies-count.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Prioirtize node flag. If provided we do not need to go lookup what product to deploy to

--- a/examples/basic-event-handlers/docker-compose.yml
+++ b/examples/basic-event-handlers/docker-compose.yml
@@ -38,4 +38,4 @@ services:
       POSTGRES_USER: graph
       POSTGRES_PASSWORD: let-me-in
       POSTGRES_DB: graph
-      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
+      POSTGRES_INITDB_ARGS: '-E UTF8 --locale=C'

--- a/examples/basic-event-handlers/docker-compose.yml
+++ b/examples/basic-event-handlers/docker-compose.yml
@@ -38,3 +38,4 @@ services:
       POSTGRES_USER: graph
       POSTGRES_PASSWORD: let-me-in
       POSTGRES_DB: graph
+      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -116,7 +116,7 @@ export default class DeployCommand extends Command {
 
     // We are given a node URL, so we prioritize that over the product flag
     const product = nodeFlag
-      ? productFlag 
+      ? productFlag
       : studio
       ? 'subgraph-studio'
       : productFlag ||

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -114,7 +114,10 @@ export default class DeployCommand extends Command {
       },
     } = await this.parse(DeployCommand);
 
-    const product = studio
+    // We are given a node URL, so we prioritize that over the product flag
+    const product = nodeFlag
+      ? productFlag 
+      : studio
       ? 'subgraph-studio'
       : productFlag ||
         (await ux.prompt('Which product to deploy for?', {


### PR DESCRIPTION
Test was failing 
1. We needed to provide collate for the Postgres DB
2. `--node` flag was making user choose a service from prompt which is a bug because if user is giving us `--node` then we just deploy to that node.