### PR TITLE
Fix graph init failing when adding multiple contracts

### DIFF
--- a/.changeset/wicked-nails-drive.md
+++ b/.changeset/wicked-nails-drive.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': minor
+---
+
+Fix graph init failing to add more than one contract

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1026,7 +1026,7 @@ async function addAnotherContract(
 
     let contract = '';
     for (;;) {
-      contract = await ux.prompt(`Contract ${ProtocolContract.identifierName()}`, {
+      contract = await ux.prompt(`\nContract ${ProtocolContract.identifierName()}`, {
         required: true,
       });
       const { valid, error } = validateContract(contract, ProtocolContract);
@@ -1036,7 +1036,7 @@ async function addAnotherContract(
       this.log(`✖ ${error}`);
     }
 
-    const localAbi = await ux.prompt('Provide local ABI path? (y/n)', {
+    const localAbi = await ux.prompt('\nProvide local ABI path? (y/n)', {
       required: true,
       type: 'single',
     });
@@ -1044,10 +1044,10 @@ async function addAnotherContract(
 
     let abiPath = '';
     if (abiFromFile) {
-      abiPath = await ux.prompt('ABI file (path)', { required: true });
+      abiPath = await ux.prompt('\nABI file (path)', { required: true });
     }
 
-    const contractName = await ux.prompt('Contract Name', { required: true, default: 'Contract' });
+    const contractName = await ux.prompt('\nContract Name', { required: true, default: 'Contract' });
 
     // Get the cwd before process.chdir in order to switch back in the end of command execution
     const cwd = process.cwd();
@@ -1057,7 +1057,7 @@ async function addAnotherContract(
         process.chdir(directory);
       }
 
-      const commandLine = ['add', contract, '--contract-name', contractName];
+      const commandLine = [contract, '--contract-name', contractName];
 
       if (abiFromFile) {
         if (abiPath.includes(directory)) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1047,7 +1047,10 @@ async function addAnotherContract(
       abiPath = await ux.prompt('\nABI file (path)', { required: true });
     }
 
-    const contractName = await ux.prompt('\nContract Name', { required: true, default: 'Contract' });
+    const contractName = await ux.prompt('\nContract Name', {
+      required: true,
+      default: 'Contract',
+    });
 
     // Get the cwd before process.chdir in order to switch back in the end of command execution
     const cwd = process.cwd();


### PR DESCRIPTION
Fixes #1135 

The issue was that the args being passed to AddComand() from `graph init` was wrong. 
