### PR TITLE
cli: add derived loader

### DIFF
--- a/packages/cli/src/codegen/schema.test.ts
+++ b/packages/cli/src/codegen/schema.test.ts
@@ -30,6 +30,7 @@ const testEntity = (generatedTypes: any[], expectedEntity: any) => {
   expect(members).toStrictEqual(expectedEntity.members);
 
   for (const expectedMethod of expectedEntity.methods) {
+
     const method = methods.find((method: any) => method.name === expectedMethod.name);
 
     expectedMethod.static
@@ -231,14 +232,9 @@ describe('Schema code generator', () => {
           {
             name: 'get wallets',
             params: [],
-            returnType: new NullableType(new ArrayType(new NamedType('string'))),
+            returnType: new NamedType('WalletLoader'),
             body: `
-              let value = this.get('wallets')
-              if (!value || value.kind == ValueKind.NULL) {
-                return null
-              } else {
-                return value.toStringArray()
-              }
+              return new WalletLoader("Account", this.get('id')!.toString(), "wallets") 
             `,
           },
           {

--- a/packages/cli/src/type-generator.ts
+++ b/packages/cli/src/type-generator.ts
@@ -153,6 +153,7 @@ export default class TypeGenerator {
             GENERATED_FILE_NOTE,
             ...codeGenerator.generateModuleImports(),
             ...codeGenerator.generateTypes(),
+            ...codeGenerator.generateDerivedLoaders(),
           ].join('\n'),
           {
             parser: 'typescript',

--- a/packages/ts/index.ts
+++ b/packages/ts/index.ts
@@ -23,6 +23,7 @@ export * from './common/value';
  */
 export declare namespace store {
   function get(entity: string, id: string): Entity | null;
+  function loadRelated(entity: string, id: string, field: string): Array<Entity>;
   function set(entity: string, id: string, data: Entity): void;
   function remove(entity: string, id: string): void;
 }


### PR DESCRIPTION
This is the continuation of the PR https://github.com/graphprotocol/graph-node/pull/4434 and is related to https://github.com/graphprotocol/graph-node/issues/4004

Thanks to @poonai for part of the code from #977.



### What does this PR do?
- adds `loadRelated(entity, id, field)` to the host
- creates a `<Entity>Loader` generator for accessing `load()` in a more explicit way
- fix the tests related to derived fields