### PR TITLE
fix: do not generate setters from derived fields

### DIFF
--- a/.changeset/three-lemons-dance.md
+++ b/.changeset/three-lemons-dance.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+do not generate setters for derived fields

--- a/packages/cli/src/codegen/schema.test.ts
+++ b/packages/cli/src/codegen/schema.test.ts
@@ -241,18 +241,6 @@ describe('Schema code generator', () => {
               }
             `,
           },
-          {
-            name: 'set wallets',
-            params: [new Param('value', new NullableType(new ArrayType(new NamedType('string'))))],
-            returnType: undefined,
-            body: `
-              if (!value) {
-                this.unset('wallets')
-              } else {
-                this.set('wallets', Value.fromStringArray(<Array<string>>value))
-              }
-            `,
-          },
         ],
       });
     });


### PR DESCRIPTION
Derived fields are only meant for reverse lookups and not meant to be set, explained in [docs](https://thegraph.com/docs/en/developing/creating-a-subgraph/#reverse-lookups).

closes https://github.com/graphprotocol/graph-tooling/issues/943

