### PR TITLE
Allow file data sources (with no network) to deploy to the studio

### DIFF
--- a/packages/cli/src/command-helpers/studio.test.ts
+++ b/packages/cli/src/command-helpers/studio.test.ts
@@ -33,6 +33,21 @@ describe('Version Command Helpers', () => {
         );
       });
 
+      test('And no network is passed', () => {
+        expect(() =>
+          validateStudioNetwork({
+            studio: true,
+            network: undefined,
+          }),
+        ).not.toThrow(
+          new Error(
+            `The Subgraph Studio only allows subgraphs for these networks: ${allowedStudioNetworks.join(
+              ', ',
+            )}`,
+          ),
+        );
+      });
+
       test("And it's NOT an allowed network", () => {
         expect(() =>
           validateStudioNetwork({

--- a/packages/cli/src/command-helpers/studio.ts
+++ b/packages/cli/src/command-helpers/studio.ts
@@ -32,10 +32,12 @@ export const validateStudioNetwork = ({
   network: string;
 }) => {
   const isStudio = studio || product === 'subgraph-studio';
-  const isAllowedNetwork = !network || allowedStudioNetworks.includes(
-    // @ts-expect-error we're checking if the network is allowed
-    network,
-  );
+  const isAllowedNetwork =
+    !network ||
+    allowedStudioNetworks.includes(
+      // @ts-expect-error we're checking if the network is allowed
+      network,
+    );
 
   if (isStudio && !isAllowedNetwork) {
     throw new Error(

--- a/packages/cli/src/command-helpers/studio.ts
+++ b/packages/cli/src/command-helpers/studio.ts
@@ -32,7 +32,7 @@ export const validateStudioNetwork = ({
   network: string;
 }) => {
   const isStudio = studio || product === 'subgraph-studio';
-  const isAllowedNetwork = allowedStudioNetworks.includes(
+  const isAllowedNetwork = !network || allowedStudioNetworks.includes(
     // @ts-expect-error we're checking if the network is allowed
     network,
   );

--- a/packages/cli/src/command-helpers/studio.ts
+++ b/packages/cli/src/command-helpers/studio.ts
@@ -29,7 +29,7 @@ export const validateStudioNetwork = ({
 }: {
   studio?: string | boolean;
   product?: string;
-  network: string;
+  network?: string;
 }) => {
   const isStudio = studio || product === 'subgraph-studio';
   const isAllowedNetwork =


### PR DESCRIPTION
Currently `graph deploy --studio ...` with a file data sources subgraph returns:
```
Error: The Subgraph Studio only allows subgraphs for these networks: mainnet, rinkeby, goerli, gnosis, chapel, optimism-goerli, clover, 
    fantom-testnet, arbitrum-goerli, fuji, celo-alfajores, mumbai, aurora-testnet, near-testnet, theta-testnet-001, osmo-test-4, base-testnet, celo, 
    arbitrum-one, avalanche
```
This is because all datasources for a subgraph are checked against that list, and file data sources don't have a network specified.
This PR skips that check if a data source doesn't have a network (at least one data source must have a network, so the deployment will be checked) - this works, but might not be a preferred approach