### PR TITLE
fix: make generated list children non-nullable

### DIFF
--- a/.changeset/small-foxes-fix.md
+++ b/.changeset/small-foxes-fix.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+make generated list children non-nullable

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "editor.formatOnSave": true,
   "yaml.schemas": {
     "https://json.schemastore.org/github-issue-config.json": ".github/ISSUE_TEMPLATE/config.yml"
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "editor.formatOnSave": true,
   "yaml.schemas": {
     "https://json.schemastore.org/github-issue-config.json": ".github/ISSUE_TEMPLATE/config.yml"
   }

--- a/packages/cli/src/scaffold/ethereum.test.ts
+++ b/packages/cli/src/scaffold/ethereum.test.ts
@@ -117,7 +117,7 @@ type ExampleEntity @entity {
   id: Bytes!
   count: BigInt!
   a: BigInt! # uint256
-  b: [Bytes]! # bytes[4]
+  b: [Bytes!]! # bytes[4]
 }
 `);
   });
@@ -127,7 +127,7 @@ type ExampleEntity @entity {
 type ExampleEvent @entity(immutable: true) {
   id: Bytes!
   a: BigInt! # uint256
-  b: [Bytes]! # bytes[4]
+  b: [Bytes!]! # bytes[4]
   param2: String! # string
   c_c1: BigInt! # uint256
   c_value1: Bytes! # bytes32

--- a/packages/cli/src/scaffold/schema.ts
+++ b/packages/cli/src/scaffold/schema.ts
@@ -4,19 +4,26 @@ import * as util from '../codegen/util';
 import Protocol from '../protocols';
 
 export function abiEvents(abi: { data: immutable.Collection<any, any> }) {
-  return util.disambiguateNames({
+  return (util.disambiguateNames({
     // @ts-expect-error improve typings of disambiguateNames to handle iterables
     values: abi.data.filter(item => item.get('type') === 'event'),
     // @ts-expect-error improve typings of disambiguateNames to handle iterables
     getName: event => event.get('name'),
     // @ts-expect-error improve typings of disambiguateNames to handle iterables
     setName: (event, name) => event.set('_alias', name),
-  }) as unknown as immutable.List<any>;
+  }) as unknown) as immutable.List<any>;
 }
 
 export const protocolTypeToGraphQL = (protocol: string, name: string) => {
   const ascType = ascTypeForProtocol(protocol, name);
-  return valueTypeForAsc(ascType);
+  // TODO: we need to figure out how to improve types
+  // but for now this always is returning a string
+  const convertedType = valueTypeForAsc(ascType) as string;
+
+  // TODO: this is a hack to make array type non-nullable
+  // We should refactor the way we convert the Values from ASC to GraphQL
+  // For arrays we always want non-nullable children
+  return convertedType.endsWith(']') ? convertedType.replace(']', '!]') : convertedType;
 };
 
 export const generateField = ({

--- a/packages/cli/src/scaffold/schema.ts
+++ b/packages/cli/src/scaffold/schema.ts
@@ -4,14 +4,14 @@ import * as util from '../codegen/util';
 import Protocol from '../protocols';
 
 export function abiEvents(abi: { data: immutable.Collection<any, any> }) {
-  return (util.disambiguateNames({
+  return util.disambiguateNames({
     // @ts-expect-error improve typings of disambiguateNames to handle iterables
     values: abi.data.filter(item => item.get('type') === 'event'),
     // @ts-expect-error improve typings of disambiguateNames to handle iterables
     getName: event => event.get('name'),
     // @ts-expect-error improve typings of disambiguateNames to handle iterables
     setName: (event, name) => event.set('_alias', name),
-  }) as unknown) as immutable.List<any>;
+  }) as unknown as immutable.List<any>;
 }
 
 export const protocolTypeToGraphQL = (protocol: string, name: string) => {

--- a/packages/cli/tests/cli/init.test.ts
+++ b/packages/cli/tests/cli/init.test.ts
@@ -4,102 +4,102 @@ import { cliTest } from './util';
 describe('Init', () => {
   const baseDir = path.join(__dirname, 'init');
 
-  describe.only('Ethereum', () => {
+  describe('Ethereum', () => {
     const ethereumBaseDir = path.join(baseDir, 'ethereum');
 
-    // cliTest(
-    //   'From example',
-    //   [
-    //     'init',
-    //     '--protocol',
-    //     'ethereum',
-    //     '--studio',
-    //     '--from-example',
-    //     'ethereum/gravatar',
-    //     'user/example-subgraph',
-    //     path.join(ethereumBaseDir, 'from-example'),
-    //   ],
-    //   path.join('init', 'ethereum', 'from-example'),
-    //   {
-    //     exitCode: 0,
-    //     timeout: 100_000,
-    //     cwd: ethereumBaseDir,
-    //     deleteDir: true,
-    //   },
-    // );
+    cliTest(
+      'From example',
+      [
+        'init',
+        '--protocol',
+        'ethereum',
+        '--studio',
+        '--from-example',
+        'ethereum/gravatar',
+        'user/example-subgraph',
+        path.join(ethereumBaseDir, 'from-example'),
+      ],
+      path.join('init', 'ethereum', 'from-example'),
+      {
+        exitCode: 0,
+        timeout: 100_000,
+        cwd: ethereumBaseDir,
+        deleteDir: true,
+      },
+    );
 
-    // cliTest(
-    //   'From contract',
-    //   [
-    //     'init',
-    //     '--protocol',
-    //     'ethereum',
-    //     '--studio',
-    //     '--from-contract',
-    //     '0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d',
-    //     '--network',
-    //     'mainnet',
-    //     'user/subgraph-from-contract',
-    //     path.join(ethereumBaseDir, 'from-contract'),
-    //   ],
-    //   path.join('init', 'ethereum', 'from-contract'),
-    //   {
-    //     exitCode: 0,
-    //     timeout: 100_000,
-    //     cwd: ethereumBaseDir,
-    //     deleteDir: true,
-    //   },
-    // );
+    cliTest(
+      'From contract',
+      [
+        'init',
+        '--protocol',
+        'ethereum',
+        '--studio',
+        '--from-contract',
+        '0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d',
+        '--network',
+        'mainnet',
+        'user/subgraph-from-contract',
+        path.join(ethereumBaseDir, 'from-contract'),
+      ],
+      path.join('init', 'ethereum', 'from-contract'),
+      {
+        exitCode: 0,
+        timeout: 100_000,
+        cwd: ethereumBaseDir,
+        deleteDir: true,
+      },
+    );
 
-    // cliTest(
-    //   'From contract with abi',
-    //   [
-    //     'init',
-    //     '--protocol',
-    //     'ethereum',
-    //     '--studio',
-    //     '--from-contract',
-    //     '0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d',
-    //     '--abi',
-    //     path.join(ethereumBaseDir, 'abis', 'Marketplace.json'),
-    //     '--network',
-    //     'mainnet',
-    //     'user/subgraph-from-contract-with-abi',
-    //     path.join(ethereumBaseDir, 'from-contract-with-abi'),
-    //   ],
-    //   path.join('init', 'ethereum', 'from-contract-with-abi'),
-    //   {
-    //     exitCode: 0,
-    //     timeout: 100_000,
-    //     cwd: ethereumBaseDir,
-    //     deleteDir: true,
-    //   },
-    // );
+    cliTest(
+      'From contract with abi',
+      [
+        'init',
+        '--protocol',
+        'ethereum',
+        '--studio',
+        '--from-contract',
+        '0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d',
+        '--abi',
+        path.join(ethereumBaseDir, 'abis', 'Marketplace.json'),
+        '--network',
+        'mainnet',
+        'user/subgraph-from-contract-with-abi',
+        path.join(ethereumBaseDir, 'from-contract-with-abi'),
+      ],
+      path.join('init', 'ethereum', 'from-contract-with-abi'),
+      {
+        exitCode: 0,
+        timeout: 100_000,
+        cwd: ethereumBaseDir,
+        deleteDir: true,
+      },
+    );
 
-    // cliTest(
-    //   'From contract with abi and structs',
-    //   [
-    //     'init',
-    //     '--protocol',
-    //     'ethereum',
-    //     '--studio',
-    //     '--from-contract',
-    //     '0x1E0447b19BB6EcFdAe1e4AE1694b0C3659614e4e',
-    //     '--abi',
-    //     path.join(ethereumBaseDir, 'abis', 'SoloMargin.json'),
-    //     '--network',
-    //     'mainnet',
-    //     'user/subgraph-from-contract-with-abi-and-structs',
-    //     path.join(ethereumBaseDir, 'from-contract-with-abi-and-structs'),
-    //   ],
-    //   path.join('init', 'ethereum', 'from-contract-with-abi-and-structs'),
-    //   {
-    //     exitCode: 0,
-    //     timeout: 100_000,
-    //     cwd: ethereumBaseDir,
-    //     deleteDir: true,
-    //   },
-    // );
+    cliTest(
+      'From contract with abi and structs',
+      [
+        'init',
+        '--protocol',
+        'ethereum',
+        '--studio',
+        '--from-contract',
+        '0x1E0447b19BB6EcFdAe1e4AE1694b0C3659614e4e',
+        '--abi',
+        path.join(ethereumBaseDir, 'abis', 'SoloMargin.json'),
+        '--network',
+        'mainnet',
+        'user/subgraph-from-contract-with-abi-and-structs',
+        path.join(ethereumBaseDir, 'from-contract-with-abi-and-structs'),
+      ],
+      path.join('init', 'ethereum', 'from-contract-with-abi-and-structs'),
+      {
+        exitCode: 0,
+        timeout: 100_000,
+        cwd: ethereumBaseDir,
+        deleteDir: true,
+      },
+    );
 
     cliTest(
       'From contract with list items in abi',
@@ -126,30 +126,30 @@ describe('Init', () => {
       },
     );
 
-    // cliTest(
-    //   'From contract with overloaded elements',
-    //   [
-    //     'init',
-    //     '--protocol',
-    //     'ethereum',
-    //     '--studio',
-    //     '--from-contract',
-    //     '0x1E0447b19BB6EcFdAe1e4AE1694b0C3659614e4e',
-    //     '--abi',
-    //     path.join(ethereumBaseDir, 'abis', 'OverloadedElements.json'),
-    //     '--network',
-    //     'mainnet',
-    //     'user/subgraph-from-contract-with-overloaded-elements',
-    //     path.join(ethereumBaseDir, 'from-contract-with-overloaded-elements'),
-    //   ],
-    //   path.join('init', 'ethereum', 'from-contract-with-overloaded-elements'),
-    //   {
-    //     exitCode: 0,
-    //     timeout: 100_000,
-    //     cwd: ethereumBaseDir,
-    //     deleteDir: true,
-    //   },
-    // );
+    cliTest(
+      'From contract with overloaded elements',
+      [
+        'init',
+        '--protocol',
+        'ethereum',
+        '--studio',
+        '--from-contract',
+        '0x1E0447b19BB6EcFdAe1e4AE1694b0C3659614e4e',
+        '--abi',
+        path.join(ethereumBaseDir, 'abis', 'OverloadedElements.json'),
+        '--network',
+        'mainnet',
+        'user/subgraph-from-contract-with-overloaded-elements',
+        path.join(ethereumBaseDir, 'from-contract-with-overloaded-elements'),
+      ],
+      path.join('init', 'ethereum', 'from-contract-with-overloaded-elements'),
+      {
+        exitCode: 0,
+        timeout: 100_000,
+        cwd: ethereumBaseDir,
+        deleteDir: true,
+      },
+    );
   });
 
   describe('NEAR', () => {

--- a/packages/cli/tests/cli/init.test.ts
+++ b/packages/cli/tests/cli/init.test.ts
@@ -4,80 +4,105 @@ import { cliTest } from './util';
 describe('Init', () => {
   const baseDir = path.join(__dirname, 'init');
 
-  describe('Ethereum', () => {
+  describe.only('Ethereum', () => {
     const ethereumBaseDir = path.join(baseDir, 'ethereum');
 
-    cliTest(
-      'From example',
-      [
-        'init',
-        '--protocol',
-        'ethereum',
-        '--studio',
-        '--from-example',
-        'ethereum/gravatar',
-        'user/example-subgraph',
-        path.join(ethereumBaseDir, 'from-example'),
-      ],
-      path.join('init', 'ethereum', 'from-example'),
-      {
-        exitCode: 0,
-        timeout: 100_000,
-        cwd: ethereumBaseDir,
-        deleteDir: true,
-      },
-    );
+    // cliTest(
+    //   'From example',
+    //   [
+    //     'init',
+    //     '--protocol',
+    //     'ethereum',
+    //     '--studio',
+    //     '--from-example',
+    //     'ethereum/gravatar',
+    //     'user/example-subgraph',
+    //     path.join(ethereumBaseDir, 'from-example'),
+    //   ],
+    //   path.join('init', 'ethereum', 'from-example'),
+    //   {
+    //     exitCode: 0,
+    //     timeout: 100_000,
+    //     cwd: ethereumBaseDir,
+    //     deleteDir: true,
+    //   },
+    // );
+
+    // cliTest(
+    //   'From contract',
+    //   [
+    //     'init',
+    //     '--protocol',
+    //     'ethereum',
+    //     '--studio',
+    //     '--from-contract',
+    //     '0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d',
+    //     '--network',
+    //     'mainnet',
+    //     'user/subgraph-from-contract',
+    //     path.join(ethereumBaseDir, 'from-contract'),
+    //   ],
+    //   path.join('init', 'ethereum', 'from-contract'),
+    //   {
+    //     exitCode: 0,
+    //     timeout: 100_000,
+    //     cwd: ethereumBaseDir,
+    //     deleteDir: true,
+    //   },
+    // );
+
+    // cliTest(
+    //   'From contract with abi',
+    //   [
+    //     'init',
+    //     '--protocol',
+    //     'ethereum',
+    //     '--studio',
+    //     '--from-contract',
+    //     '0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d',
+    //     '--abi',
+    //     path.join(ethereumBaseDir, 'abis', 'Marketplace.json'),
+    //     '--network',
+    //     'mainnet',
+    //     'user/subgraph-from-contract-with-abi',
+    //     path.join(ethereumBaseDir, 'from-contract-with-abi'),
+    //   ],
+    //   path.join('init', 'ethereum', 'from-contract-with-abi'),
+    //   {
+    //     exitCode: 0,
+    //     timeout: 100_000,
+    //     cwd: ethereumBaseDir,
+    //     deleteDir: true,
+    //   },
+    // );
+
+    // cliTest(
+    //   'From contract with abi and structs',
+    //   [
+    //     'init',
+    //     '--protocol',
+    //     'ethereum',
+    //     '--studio',
+    //     '--from-contract',
+    //     '0x1E0447b19BB6EcFdAe1e4AE1694b0C3659614e4e',
+    //     '--abi',
+    //     path.join(ethereumBaseDir, 'abis', 'SoloMargin.json'),
+    //     '--network',
+    //     'mainnet',
+    //     'user/subgraph-from-contract-with-abi-and-structs',
+    //     path.join(ethereumBaseDir, 'from-contract-with-abi-and-structs'),
+    //   ],
+    //   path.join('init', 'ethereum', 'from-contract-with-abi-and-structs'),
+    //   {
+    //     exitCode: 0,
+    //     timeout: 100_000,
+    //     cwd: ethereumBaseDir,
+    //     deleteDir: true,
+    //   },
+    // );
 
     cliTest(
-      'From contract',
-      [
-        'init',
-        '--protocol',
-        'ethereum',
-        '--studio',
-        '--from-contract',
-        '0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d',
-        '--network',
-        'mainnet',
-        'user/subgraph-from-contract',
-        path.join(ethereumBaseDir, 'from-contract'),
-      ],
-      path.join('init', 'ethereum', 'from-contract'),
-      {
-        exitCode: 0,
-        timeout: 100_000,
-        cwd: ethereumBaseDir,
-        deleteDir: true,
-      },
-    );
-
-    cliTest(
-      'From contract with abi',
-      [
-        'init',
-        '--protocol',
-        'ethereum',
-        '--studio',
-        '--from-contract',
-        '0xF87E31492Faf9A91B02Ee0dEAAd50d51d56D5d4d',
-        '--abi',
-        path.join(ethereumBaseDir, 'abis', 'Marketplace.json'),
-        '--network',
-        'mainnet',
-        'user/subgraph-from-contract-with-abi',
-        path.join(ethereumBaseDir, 'from-contract-with-abi'),
-      ],
-      path.join('init', 'ethereum', 'from-contract-with-abi'),
-      {
-        exitCode: 0,
-        timeout: 100_000,
-        cwd: ethereumBaseDir,
-        deleteDir: true,
-      },
-    );
-
-    cliTest(
-      'From contract with abi and structs',
+      'From contract with list items in abi',
       [
         'init',
         '--protocol',
@@ -86,13 +111,13 @@ describe('Init', () => {
         '--from-contract',
         '0x1E0447b19BB6EcFdAe1e4AE1694b0C3659614e4e',
         '--abi',
-        path.join(ethereumBaseDir, 'abis', 'SoloMargin.json'),
+        path.join(ethereumBaseDir, 'abis', 'Airdropped.json'),
         '--network',
         'mainnet',
-        'user/subgraph-from-contract-with-abi-and-structs',
-        path.join(ethereumBaseDir, 'from-contract-with-abi-and-structs'),
+        'user/subgraph-from-contract-with-lists-in-abi',
+        path.join(ethereumBaseDir, 'from-contract-with-lists-in-abi'),
       ],
-      path.join('init', 'ethereum', 'from-contract-with-abi-and-structs'),
+      path.join('init', 'ethereum', 'from-contract-with-lists-in-abi'),
       {
         exitCode: 0,
         timeout: 100_000,
@@ -101,30 +126,30 @@ describe('Init', () => {
       },
     );
 
-    cliTest(
-      'From contract with overloaded elements',
-      [
-        'init',
-        '--protocol',
-        'ethereum',
-        '--studio',
-        '--from-contract',
-        '0x1E0447b19BB6EcFdAe1e4AE1694b0C3659614e4e',
-        '--abi',
-        path.join(ethereumBaseDir, 'abis', 'OverloadedElements.json'),
-        '--network',
-        'mainnet',
-        'user/subgraph-from-contract-with-overloaded-elements',
-        path.join(ethereumBaseDir, 'from-contract-with-overloaded-elements'),
-      ],
-      path.join('init', 'ethereum', 'from-contract-with-overloaded-elements'),
-      {
-        exitCode: 0,
-        timeout: 100_000,
-        cwd: ethereumBaseDir,
-        deleteDir: true,
-      },
-    );
+    // cliTest(
+    //   'From contract with overloaded elements',
+    //   [
+    //     'init',
+    //     '--protocol',
+    //     'ethereum',
+    //     '--studio',
+    //     '--from-contract',
+    //     '0x1E0447b19BB6EcFdAe1e4AE1694b0C3659614e4e',
+    //     '--abi',
+    //     path.join(ethereumBaseDir, 'abis', 'OverloadedElements.json'),
+    //     '--network',
+    //     'mainnet',
+    //     'user/subgraph-from-contract-with-overloaded-elements',
+    //     path.join(ethereumBaseDir, 'from-contract-with-overloaded-elements'),
+    //   ],
+    //   path.join('init', 'ethereum', 'from-contract-with-overloaded-elements'),
+    //   {
+    //     exitCode: 0,
+    //     timeout: 100_000,
+    //     cwd: ethereumBaseDir,
+    //     deleteDir: true,
+    //   },
+    // );
   });
 
   describe('NEAR', () => {

--- a/packages/cli/tests/cli/init/ethereum/abis/Airdropped.json
+++ b/packages/cli/tests/cli/init/ethereum/abis/Airdropped.json
@@ -1,0 +1,27 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address[]",
+        "name": "to",
+        "type": "address[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "quantity",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fromTokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Airdropped",
+    "type": "event"
+  }
+]

--- a/packages/cli/tests/cli/init/ethereum/from-contract-with-lists-in-abi.stdout
+++ b/packages/cli/tests/cli/init/ethereum/from-contract-with-lists-in-abi.stdout
@@ -1,0 +1,12 @@
+
+Subgraph user/subgraph-from-contract-with-lists-in-abi created in from-contract-with-lists-in-abi
+
+Next steps:
+
+  1. Run `graph auth` to authenticate with your deploy key.
+
+  2. Type `cd from-contract-with-lists-in-abi` to enter the subgraph.
+
+  3. Run `yarn deploy` to deploy the subgraph.
+
+Make sure to visit the documentation on https://thegraph.com/docs/ for further information.


### PR DESCRIPTION
This fixes the issue where the ABI -> GraphQL type was doing a simple 1:1 mapping where `Array<Bytes> -> [Bytes]` but for `graph-node` we require that list items are `non-nullable` so we need to make it `Array<Bytes> -> [Bytes!]`. I didn't want to introduce a big refactor so for now just making something that will work and accompanied test case. But [we should revisit refactoring this logic](https://github.com/graphprotocol/graph-tooling/issues/1198).

closes https://github.com/graphprotocol/graph-tooling/issues/1058

