### PR TITLE
fix: shorthand for help and version command

### DIFF
--- a/.changeset/wild-goats-battle.md
+++ b/.changeset/wild-goats-battle.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+bring back short hand for version and help

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -72,6 +72,8 @@
   },
   "oclif": {
     "bin": "graph",
-    "commands": "./dist/commands"
+    "commands": "./dist/commands",
+    "additionalHelpFlags": ["-h"],
+    "additionalVersionFlags": ["-v"]
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -73,7 +73,11 @@
   "oclif": {
     "bin": "graph",
     "commands": "./dist/commands",
-    "additionalHelpFlags": ["-h"],
-    "additionalVersionFlags": ["-v"]
+    "additionalHelpFlags": [
+      "-h"
+    ],
+    "additionalVersionFlags": [
+      "-v"
+    ]
   }
 }


### PR DESCRIPTION
missed in oclif migration. I did try adding tests but then realized we need better way since updating version would mean we need a snapshot update which can be annoying to do each time.

Closes #1206

