### PR TITLE
feat: disallow nullable primitive types

### DIFF
--- a/.changeset/violet-ghosts-pump.md
+++ b/.changeset/violet-ghosts-pump.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': minor
+---
+
+Disallow nullable primitive types. In AssemblyScript, nullable primitive types are not allowed. An error will be thrown when it encounters a nullable primitive type in the GraphQL Schema.

--- a/packages/cli/src/codegen/schema.test.ts
+++ b/packages/cli/src/codegen/schema.test.ts
@@ -462,7 +462,9 @@ describe('Schema code generator', () => {
     try {
       codegen.generateTypes();
     } catch (err) {
-      expect(err.message).toBe(`A primitive type cannot be nullable. AssemblyScript does not support nullable primitives.\nConsider changing the type of "Account.isActive" from "Boolean" to "Boolean!"`);
+      expect(err.message).toBe(
+        `A primitive type cannot be nullable. AssemblyScript does not support nullable primitives.\nConsider changing the type of "Account.isActive" from "Boolean" to "Boolean!"`,
+      );
     }
   });
 });

--- a/packages/cli/src/codegen/schema.test.ts
+++ b/packages/cli/src/codegen/schema.test.ts
@@ -12,7 +12,6 @@ import {
   Param,
   StaticMethod,
 } from './typescript';
-import { writeFileSync } from 'fs-extra';
 
 const formatTS = (code: string) => prettier.format(code, { parser: 'typescript', semi: false });
 

--- a/packages/cli/src/codegen/schema.ts
+++ b/packages/cli/src/codegen/schema.ts
@@ -186,7 +186,7 @@ export default class SchemaCodeGenerator {
     const returnType = this._typeFromGraphQl({
       gqlType,
       entityDef: _entityDef,
-      fieldDef: fieldDef,
+      fieldDef,
     });
     const isNullable = returnType instanceof tsCodegen.NullableType;
 


### PR DESCRIPTION
In Assembly script `0,null, false` all will be represented the same way aka `0 byte` but the conversion we do today does not make sense. In GraphQL type system we can represent a nullable primitive type (i.e. a boolean or a int32) that when translated to TS we are asserting that it is not nullable which is false assumption because it will crash. With this change we are going to disallow nullable for primitive types.

closes #1196 