### PR TITLE
feat: validate existence of specified handlers in manifest

### DIFF
--- a/.changeset/silly-cougars-obey.md
+++ b/.changeset/silly-cougars-obey.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': minor
+---
+
+validate existence for handlers specified in manifest during build

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -106,7 +106,7 @@ export default class BuildCommand extends Command {
     if (watch) {
       await compiler.watchAndCompile();
     } else {
-      const result = await compiler.compile();
+      const result = await compiler.compile({ validate: false });
       if (result === false) {
         this.exit(1);
       }

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -289,7 +289,7 @@ $ graph create --node ${node} ${subgraphName}`;
         }
       });
     } else {
-      const result = await compiler.compile();
+      const result = await compiler.compile({ validate: true });
       if (result === undefined || result === false) {
         // Compilation failed, not deploying.
         process.exitCode = 1;


### PR DESCRIPTION
Today we do not run any validation when `graph build` runs. This PR introduces a way to load the generated `wasm` and ensure that it has all the handlers in it. If not we throw an error.

While working on this I did see and should be worked on in future
1. We have validation logic written but it is never invoked anywhere. We should figure out how to refactor the existing `Subgraph` class for the `Protocol` to provide better way to handle validation in a cheaper way.
2. Configuring unit tests for `graph build` are not straightforward since we are asserting the existence of `graph-ts` and  e2e just take longer to run  

closes #981 