### PR TITLE
refactor: remove immutable from Schema Code Generator

### DIFF
--- a/.changeset/hungry-turkeys-repeat.md
+++ b/.changeset/hungry-turkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+refactor out immutable.js usage from schema generation

--- a/packages/cli/src/codegen/schema.test.ts
+++ b/packages/cli/src/codegen/schema.test.ts
@@ -1,5 +1,4 @@
 import * as graphql from 'graphql/language';
-import immutable from 'immutable';
 import prettier from 'prettier';
 import Schema from '../schema';
 import SchemaCodeGenerator from './schema';
@@ -16,7 +15,7 @@ import {
 const formatTS = (code: string) => prettier.format(code, { parser: 'typescript', semi: false });
 
 const createSchemaCodeGen = (schema: string) =>
-  new SchemaCodeGenerator(new Schema('', schema, immutable.fromJS(graphql.parse(schema))));
+  new SchemaCodeGenerator(new Schema('', schema, graphql.parse(schema)));
 
 const testEntity = (generatedTypes: any[], expectedEntity: any) => {
   const entity = generatedTypes.find(type => type.name === expectedEntity.name);
@@ -57,7 +56,7 @@ describe('Schema code generator', () => {
       }
     `);
 
-    expect(codegen.generateTypes().size).toBe(0);
+    expect(codegen.generateTypes().length).toBe(0);
   });
 
   describe('Should generate correct classes for each entity', () => {
@@ -95,7 +94,7 @@ describe('Schema code generator', () => {
       const foo = generatedTypes.find((type: any) => type.name === 'Foo');
       expect(foo).toBe(undefined);
       // Account and Wallet
-      expect(generatedTypes.size).toBe(2);
+      expect(generatedTypes.length).toBe(2);
     });
 
     test('Account is an entity with the correct methods', () => {

--- a/packages/cli/src/codegen/schema.ts
+++ b/packages/cli/src/codegen/schema.ts
@@ -1,8 +1,15 @@
 /* eslint-disable unicorn/no-array-for-each */
-import immutable from 'immutable';
 import Schema from '../schema';
 import * as typesCodegen from './types';
 import * as tsCodegen from './typescript';
+import type {
+  DefinitionNode,
+  FieldDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  NamedTypeNode,
+  ObjectTypeDefinitionNode,
+  TypeNode,
+} from 'graphql/language';
 
 class IdField {
   static BYTES = Symbol('Bytes');
@@ -10,8 +17,14 @@ class IdField {
 
   private kind: typeof IdField.BYTES | typeof IdField.STRING;
 
-  constructor(idField: immutable.Map<any, any>) {
-    const typeName = idField.getIn(['type', 'type', 'name', 'value']);
+  constructor(idField: FieldDefinitionNode | undefined) {
+    if (idField?.type.kind !== 'NonNullType') {
+      throw Error('id field must be non-nullable');
+    }
+    if (idField.type.type.kind !== 'NamedType') {
+      throw Error('id field must be a named type');
+    }
+    const typeName = idField.type.type.name.value;
     this.kind = typeName === 'Bytes' ? IdField.BYTES : IdField.STRING;
   }
 
@@ -43,13 +56,13 @@ class IdField {
     return this.kind == IdField.BYTES ? 'id.toHexString()' : 'id';
   }
 
-  static fromFields(fields: immutable.List<any>) {
-    const idField = fields.find(field => field.getIn(['name', 'value']) === 'id');
+  static fromFields(fields: readonly FieldDefinitionNode[] | undefined) {
+    const idField = fields?.find(field => field.name.value === 'id');
     return new IdField(idField);
   }
 
-  static fromTypeDef(def: immutable.Map<any, any>) {
-    return IdField.fromFields(def.get('fields'));
+  static fromTypeDef(def: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode) {
+    return IdField.fromFields(def.fields);
   }
 }
 
@@ -81,30 +94,31 @@ export default class SchemaCodeGenerator {
     ];
   }
 
-  generateTypes() {
-    return this.schema.ast
-      .get('definitions')
-      .filter((def: any) => this._isEntityTypeDefinition(def))
-      .map((def: any) => this._generateEntityType(def));
+  generateTypes(): Array<tsCodegen.Class> {
+    return this.schema.ast.definitions
+      .map(def => {
+        if (this._isEntityTypeDefinition(def)) {
+          return this._generateEntityType(def);
+        }
+      })
+      .filter(Boolean) as Array<tsCodegen.Class>;
   }
 
-  _isEntityTypeDefinition(def: immutable.Map<any, any>) {
+  _isEntityTypeDefinition(def: DefinitionNode): def is ObjectTypeDefinitionNode {
     return (
-      def.get('kind') === 'ObjectTypeDefinition' &&
-      def
-        .get('directives')
-        .find((directive: any) => directive.getIn(['name', 'value']) === 'entity') !== undefined
+      def.kind === 'ObjectTypeDefinition' &&
+      def.directives?.find(directive => directive.name.value === 'entity') !== undefined
     );
   }
 
-  _isInterfaceDefinition(def: immutable.Map<any, any>) {
-    return def.get('kind') === 'InterfaceTypeDefinition';
+  _isInterfaceDefinition(def: DefinitionNode): def is InterfaceTypeDefinitionNode {
+    return def.kind === 'InterfaceTypeDefinition';
   }
 
-  _generateEntityType(def: immutable.Map<any, any>) {
-    const name = def.getIn(['name', 'value']) as string;
+  _generateEntityType(def: ObjectTypeDefinitionNode) {
+    const name = def.name.value;
     const klass = tsCodegen.klass(name, { export: true, extends: 'Entity' });
-    const fields = def.get('fields');
+    const fields = def.fields;
     const idField = IdField.fromFields(fields);
 
     // Generate and add a constructor
@@ -114,18 +128,17 @@ export default class SchemaCodeGenerator {
     this._generateStoreMethods(name, idField).forEach(method => klass.addMethod(method));
 
     // Generate and add entity field getters and setters
-    def
-      .get('fields')
-      .reduce(
-        (methods: any, field: any) => methods.concat(this._generateEntityFieldMethods(def, field)),
-        immutable.List(),
+    def.fields
+      ?.reduce(
+        (methods, field) => methods.concat(this._generateEntityFieldMethods(def, field)),
+        [] as tsCodegen.Method[],
       )
       .forEach((method: any) => klass.addMethod(method));
 
     return klass;
   }
 
-  _generateConstructor(_entityName: string, fields: immutable.List<any>) {
+  _generateConstructor(_entityName: string, fields: readonly FieldDefinitionNode[] | undefined) {
     const idField = IdField.fromFields(fields);
     return tsCodegen.method(
       'constructor',
@@ -138,8 +151,11 @@ export default class SchemaCodeGenerator {
     );
   }
 
-  _generateStoreMethods(entityName: any, idField: any) {
-    return immutable.List.of<tsCodegen.Method | tsCodegen.StaticMethod>(
+  _generateStoreMethods(
+    entityName: string,
+    idField: IdField,
+  ): Array<tsCodegen.Method | tsCodegen.StaticMethod> {
+    return [
       tsCodegen.method(
         'save',
         [],
@@ -163,25 +179,27 @@ export default class SchemaCodeGenerator {
         return changetype<${entityName} | null>(store.get('${entityName}', ${idField.tsToString()}))
         `,
       ),
-    );
+    ];
   }
 
-  _generateEntityFieldMethods(entityDef: any, fieldDef: immutable.Map<any, any>) {
+  _generateEntityFieldMethods(
+    entityDef: ObjectTypeDefinitionNode,
+    fieldDef: FieldDefinitionNode,
+  ): Array<tsCodegen.Method> {
     return (
-      immutable
-        .List([
-          this._generateEntityFieldGetter(entityDef, fieldDef),
-          this._generateEntityFieldSetter(entityDef, fieldDef),
-        ])
+      [
+        this._generateEntityFieldGetter(entityDef, fieldDef),
+        this._generateEntityFieldSetter(entityDef, fieldDef),
+      ]
         // generator can return null if the field is not supported
         // so we filter all falsy values
-        .filter(Boolean)
+        .filter(Boolean) as Array<tsCodegen.Method>
     );
   }
 
-  _generateEntityFieldGetter(_entityDef: any, fieldDef: immutable.Map<any, any>) {
-    const name = fieldDef.getIn(['name', 'value']);
-    const gqlType = fieldDef.get('type');
+  _generateEntityFieldGetter(_entityDef: ObjectTypeDefinitionNode, fieldDef: FieldDefinitionNode) {
+    const name = fieldDef.name.value;
+    const gqlType = fieldDef.type;
     const fieldValueType = this._valueTypeFromGraphQl(gqlType);
     const returnType = this._typeFromGraphQl(gqlType);
     const isNullable = returnType instanceof tsCodegen.NullableType;
@@ -204,16 +222,16 @@ export default class SchemaCodeGenerator {
     );
   }
 
-  _generateEntityFieldSetter(_entityDef: any, fieldDef: immutable.Map<any, any>) {
-    const name = fieldDef.getIn(['name', 'value']);
-    const isDerivedField = !!fieldDef
-      .get('directives')
-      .find((directive: any) => directive.getIn(['name', 'value']) === 'derivedFrom');
+  _generateEntityFieldSetter(_entityDef: ObjectTypeDefinitionNode, fieldDef: FieldDefinitionNode) {
+    const name = fieldDef.name.value;
+    const isDerivedField = !!fieldDef.directives?.find(
+      directive => directive.name.value === 'derivedFrom',
+    );
 
     // We cannot have setters for derived fields
     if (isDerivedField) return null;
 
-    const gqlType = fieldDef.get('type');
+    const gqlType = fieldDef.type;
     const fieldValueType = this._valueTypeFromGraphQl(gqlType);
     const paramType = this._typeFromGraphQl(gqlType);
     const isNullable = paramType instanceof tsCodegen.NullableType;
@@ -251,18 +269,16 @@ Suggestion: add an '!' to the member type of the List, change from '[${baseType}
     );
   }
 
-  _resolveFieldType(gqlType: immutable.Map<any, any>) {
-    const typeName = gqlType.getIn(['name', 'value']);
+  _resolveFieldType(gqlType: NamedTypeNode) {
+    const typeName = gqlType.name.value;
 
     // If this is a reference to another type, the field has the type of
     // the referred type's id field
-    const typeDef = this.schema.ast
-      .get('definitions')
-      .find(
-        (def: any) =>
-          (this._isEntityTypeDefinition(def) || this._isInterfaceDefinition(def)) &&
-          def.getIn(['name', 'value']) === typeName,
-      );
+    const typeDef = this.schema.ast.definitions?.find(
+      def =>
+        (this._isEntityTypeDefinition(def) || this._isInterfaceDefinition(def)) &&
+        def.name.value === typeName,
+    ) as ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode | undefined;
     if (typeDef) {
       return IdField.fromTypeDef(typeDef).typeName();
     }
@@ -273,34 +289,37 @@ Suggestion: add an '!' to the member type of the List, change from '[${baseType}
    * types, that's the type from the subgraph schema. For references to
    * other entity types, this is the same as the type of the id of the
    * referred type, i.e., `string` or `Bytes`*/
-  _valueTypeFromGraphQl(gqlType: immutable.Map<any, any>): any {
-    if (gqlType.get('kind') === 'NonNullType') {
-      return this._valueTypeFromGraphQl(gqlType.get('type'));
+  _valueTypeFromGraphQl(gqlType: TypeNode): string {
+    if (gqlType.kind === 'NonNullType') {
+      return this._valueTypeFromGraphQl(gqlType.type);
     }
-    if (gqlType.get('kind') === 'ListType') {
-      return '[' + this._valueTypeFromGraphQl(gqlType.get('type')) + ']';
+    if (gqlType.kind === 'ListType') {
+      return '[' + this._valueTypeFromGraphQl(gqlType.type) + ']';
     }
     return this._resolveFieldType(gqlType);
   }
 
   /** Determine the base type of `gqlType` by removing any non-null
    * constraints and using the type of elements of lists */
-  _baseType(gqlType: immutable.Map<any, any>): any {
-    if (gqlType.get('kind') === 'NonNullType') {
-      return this._baseType(gqlType.get('type'));
+  _baseType(gqlType: TypeNode): string {
+    if (gqlType.kind === 'NonNullType') {
+      return this._baseType(gqlType.type);
     }
-    if (gqlType.get('kind') === 'ListType') {
-      return this._baseType(gqlType.get('type'));
+    if (gqlType.kind === 'ListType') {
+      return this._baseType(gqlType.type);
     }
-    return gqlType.getIn(['name', 'value']);
+    return gqlType.name.value;
   }
 
-  _typeFromGraphQl(gqlType: immutable.Map<any, any>, nullable = true): any {
-    if (gqlType.get('kind') === 'NonNullType') {
-      return this._typeFromGraphQl(gqlType.get('type'), false);
+  _typeFromGraphQl(
+    gqlType: TypeNode,
+    nullable = true,
+  ): tsCodegen.ArrayType | tsCodegen.NullableType | tsCodegen.NamedType {
+    if (gqlType.kind === 'NonNullType') {
+      return this._typeFromGraphQl(gqlType.type, false);
     }
-    if (gqlType.get('kind') === 'ListType') {
-      const type = tsCodegen.arrayType(this._typeFromGraphQl(gqlType.get('type')));
+    if (gqlType.kind === 'ListType') {
+      const type = tsCodegen.arrayType(this._typeFromGraphQl(gqlType.type) as tsCodegen.NamedType);
       return nullable ? tsCodegen.nullableType(type) : type;
     }
     // NamedType

--- a/packages/cli/src/codegen/typescript.ts
+++ b/packages/cli/src/codegen/typescript.ts
@@ -1,5 +1,5 @@
 class Param {
-  constructor(public name: string, public type: string | NamedType | NullableType) {
+  constructor(public name: string, public type: string | NamedType | ArrayType | NullableType) {
     this.name = name;
     this.type = type;
   }
@@ -13,7 +13,7 @@ class Method {
   constructor(
     public name: string,
     public params: Param[],
-    public returnType: string | NamedType | null | undefined,
+    public returnType: string | NamedType | ArrayType | NullableType | null | undefined,
     public body: string,
   ) {
     this.name = name;
@@ -175,11 +175,12 @@ class ModuleImports {
 
 const namedType = (name: string) => new NamedType(name);
 const arrayType = (name: NamedType) => new ArrayType(name);
-const param = (name: string, type: string | NamedType) => new Param(name, type);
+const param = (name: string, type: string | NamedType | ArrayType | NullableType) =>
+  new Param(name, type);
 const method = (
   name: string,
   params: Param[],
-  returnType: string | NamedType | null | undefined,
+  returnType: string | NamedType | ArrayType | NullableType | null | undefined,
   body: string,
 ) => new Method(name, params, returnType, body);
 const staticMethod = (

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -1,14 +1,10 @@
 import fs from 'fs-extra';
 import * as graphql from 'graphql/language';
-import immutable from 'immutable';
 import SchemaCodeGenerator from './codegen/schema';
+import type { DocumentNode } from 'graphql/language';
 
 export default class Schema {
-  constructor(
-    public filename: string,
-    public document: string,
-    public ast: immutable.Collection<any, any>,
-  ) {
+  constructor(public filename: string, public document: string, public ast: DocumentNode) {
     this.filename = filename;
     this.document = document;
     this.ast = ast;
@@ -21,6 +17,6 @@ export default class Schema {
   static async load(filename: string) {
     const document = await fs.readFile(filename, 'utf-8');
     const ast = graphql.parse(document);
-    return new Schema(filename, document, immutable.fromJS(ast));
+    return new Schema(filename, document, ast);
   }
 }


### PR DESCRIPTION
Immutable makes it harder to debug code and there is no real need. So start to remove it from the Schema generation, so we can work directly with objects from GraphQL.

Related #1025 