### PR TITLE
fix: point to deployed API endpoint for IPFS

### DIFF
--- a/.changeset/cyan-rats-jog.md
+++ b/.changeset/cyan-rats-jog.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+point to correct IPFS URL endpoint

--- a/packages/cli/src/command-helpers/ipfs.ts
+++ b/packages/cli/src/command-helpers/ipfs.ts
@@ -1,3 +1,3 @@
-const DEFAULT_IPFS_URL = 'https://api.thegraph.com/ipfs/' as const;
+const DEFAULT_IPFS_URL = 'https://api.thegraph.com/ipfs/api/v0' as const;
 
 export { DEFAULT_IPFS_URL };


### PR DESCRIPTION
We need to append `/api/v0` if I just use `apiPath` as option for `create` then it removed `/ipfs` so better to point to the full URL

closes https://github.com/graphprotocol/graph-tooling/issues/1274
