### PR TITLE
fix: append /api/v0 to graph IPFS endpoint

### DIFF
--- a/.changeset/twelve-frogs-walk.md
+++ b/.changeset/twelve-frogs-walk.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+append /api/v0 automatically to Graph IPFS endpoint

--- a/packages/cli/src/command-helpers/compiler.test.ts
+++ b/packages/cli/src/command-helpers/compiler.test.ts
@@ -1,0 +1,43 @@
+import { appendApiVersionForGraph } from './compiler';
+
+describe('appendApiVersionForGraph', () => {
+  it('append /api/v0 to Prod URL with trailing slash', () => {
+    expect(appendApiVersionForGraph('https://api.thegraph.com/ipfs/')).toBe(
+      'https://api.thegraph.com/ipfs/api/v0',
+    );
+  });
+
+  it('append /api/v0 to Prod URL without trailing slash', () => {
+    expect(appendApiVersionForGraph('https://api.thegraph.com/ipfs')).toBe(
+      'https://api.thegraph.com/ipfs/api/v0',
+    );
+  });
+
+  it('append /api/v0 to Staging URL without trailing slash', () => {
+    expect(appendApiVersionForGraph('https://staging.api.thegraph.com/ipfs')).toBe(
+      'https://staging.api.thegraph.com/ipfs/api/v0',
+    );
+  });
+
+  it('do nothing if Prod URL has /api/v0', () => {
+    expect(appendApiVersionForGraph('https://api.thegraph.com/ipfs/api/v0')).toBe(
+      'https://api.thegraph.com/ipfs/api/v0',
+    );
+  });
+
+  it('do nothing if Prod URL has no /ipfs', () => {
+    expect(appendApiVersionForGraph('https://api.thegraph.com')).toBe(
+      'https://api.thegraph.com',
+    );
+  });
+
+  it('do nothing for non-graph endpoint', () => {
+    expect(appendApiVersionForGraph('https://ipfs.saihaj.dev/')).toBe('https://ipfs.saihaj.dev/');
+  });
+
+  it('do nothing for non-graph endpoint ending with /ipfs', () => {
+    expect(appendApiVersionForGraph('https://ipfs.saihaj.dev/ipfs/')).toBe(
+      'https://ipfs.saihaj.dev/ipfs/',
+    );
+  });
+});

--- a/packages/cli/src/command-helpers/compiler.test.ts
+++ b/packages/cli/src/command-helpers/compiler.test.ts
@@ -26,9 +26,7 @@ describe('appendApiVersionForGraph', () => {
   });
 
   it('do nothing if Prod URL has no /ipfs', () => {
-    expect(appendApiVersionForGraph('https://api.thegraph.com')).toBe(
-      'https://api.thegraph.com',
-    );
+    expect(appendApiVersionForGraph('https://api.thegraph.com')).toBe('https://api.thegraph.com');
   });
 
   it('do nothing for non-graph endpoint', () => {


### PR DESCRIPTION
previously we were appending the /api/v0 but with the new constructor and using URL object it doesn't work. So created a helper that accounts for The Graph API endpoint and appends if needed
