### PR TITLE
Fix request to get latest matchstick version tag in the test command

### DIFF
--- a/.changeset/pretty-items-wave.md
+++ b/.changeset/pretty-items-wave.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Fixes 403 Forbidden response when fetching the latest matchstick tag

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -92,6 +92,11 @@ export default class TestCommand extends Command {
       this.log('Fetching latest version tag...');
       const result = await fetch(
         'https://api.github.com/repos/LimeChain/matchstick/releases/latest',
+        {
+          headers: {
+            'User-Agent': '@graphprotocol/graph-cli',
+          },
+        },
       );
       const json = await result.json();
       opts.latestVersion = json.tag_name;


### PR DESCRIPTION
Adds `User-Agent` header to the fetch latest tag request to the GitHub API, which resulted in 403 Forbidden

closes #1302 