### PR TITLE
fix: all examples should install latest version

### DIFF
--- a/examples/arweave-blocks-transactions/package.json
+++ b/examples/arweave-blocks-transactions/package.json
@@ -19,7 +19,7 @@
     "remove-local": "graph remove arweave-example --node http://localhost:8020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "workspace:*",
-    "@graphprotocol/graph-ts": "workspace:*"
+    "@graphprotocol/graph-cli": "latest",
+    "@graphprotocol/graph-ts": "latest"
   }
 }

--- a/examples/arweave-blocks-transactions/package.json
+++ b/examples/arweave-blocks-transactions/package.json
@@ -19,7 +19,7 @@
     "remove-local": "graph remove arweave-example --node http://localhost:8020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "latest",
-    "@graphprotocol/graph-ts": "latest"
+    "@graphprotocol/graph-cli": "0.49.0",
+    "@graphprotocol/graph-ts": "0.30.0"
   }
 }

--- a/examples/cosmos-block-filtering/package.json
+++ b/examples/cosmos-block-filtering/package.json
@@ -24,8 +24,8 @@
     "babel-register": "^6.26.0"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "latest",
-    "@graphprotocol/graph-ts": "latest",
+    "@graphprotocol/graph-cli": "0.49.0",
+    "@graphprotocol/graph-ts": "0.30.0",
     "mustache": "^4.2.0"
   }
 }

--- a/examples/cosmos-block-filtering/package.json
+++ b/examples/cosmos-block-filtering/package.json
@@ -24,8 +24,8 @@
     "babel-register": "^6.26.0"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "workspace:*",
-    "@graphprotocol/graph-ts": "workspace:*",
+    "@graphprotocol/graph-cli": "latest",
+    "@graphprotocol/graph-ts": "latest",
     "mustache": "^4.2.0"
   }
 }

--- a/examples/cosmos-osmosis-token-swaps/package.json
+++ b/examples/cosmos-osmosis-token-swaps/package.json
@@ -22,7 +22,7 @@
     "babel-register": "^6.26.0"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "workspace:*",
-    "@graphprotocol/graph-ts": "workspace:*"
+    "@graphprotocol/graph-cli": "latest",
+    "@graphprotocol/graph-ts": "latest"
   }
 }

--- a/examples/cosmos-osmosis-token-swaps/package.json
+++ b/examples/cosmos-osmosis-token-swaps/package.json
@@ -22,7 +22,7 @@
     "babel-register": "^6.26.0"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "latest",
-    "@graphprotocol/graph-ts": "latest"
+    "@graphprotocol/graph-cli": "0.49.0",
+    "@graphprotocol/graph-ts": "0.30.0"
   }
 }

--- a/examples/cosmos-validator-delegations/package.json
+++ b/examples/cosmos-validator-delegations/package.json
@@ -25,8 +25,8 @@
     "babel-register": "^6.26.0"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "workspace:*",
-    "@graphprotocol/graph-ts": "workspace:*",
+    "@graphprotocol/graph-cli": "latest",
+    "@graphprotocol/graph-ts": "latest",
     "mustache": "^4.2.0"
   }
 }

--- a/examples/cosmos-validator-delegations/package.json
+++ b/examples/cosmos-validator-delegations/package.json
@@ -25,8 +25,8 @@
     "babel-register": "^6.26.0"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "latest",
-    "@graphprotocol/graph-ts": "latest",
+    "@graphprotocol/graph-cli": "0.49.0",
+    "@graphprotocol/graph-ts": "0.30.0",
     "mustache": "^4.2.0"
   }
 }

--- a/examples/cosmos-validator-rewards/package.json
+++ b/examples/cosmos-validator-rewards/package.json
@@ -24,8 +24,8 @@
     "babel-register": "^6.26.0"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "latest",
-    "@graphprotocol/graph-ts": "latest",
+    "@graphprotocol/graph-cli": "0.49.0",
+    "@graphprotocol/graph-ts": "0.30.0",
     "mustache": "^4.2.0"
   }
 }

--- a/examples/cosmos-validator-rewards/package.json
+++ b/examples/cosmos-validator-rewards/package.json
@@ -24,8 +24,8 @@
     "babel-register": "^6.26.0"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "workspace:*",
-    "@graphprotocol/graph-ts": "workspace:*",
+    "@graphprotocol/graph-cli": "latest",
+    "@graphprotocol/graph-ts": "latest",
     "mustache": "^4.2.0"
   }
 }

--- a/examples/ethereum-basic-event-handlers/package.json
+++ b/examples/ethereum-basic-event-handlers/package.json
@@ -31,8 +31,8 @@
     "typescript": "^5.0.4"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "workspace:*",
-    "@graphprotocol/graph-ts": "workspace:*",
+    "@graphprotocol/graph-cli": "latest",
+    "@graphprotocol/graph-ts": "latest",
     "@nomicfoundation/hardhat-toolbox": "^2.0.2",
     "apollo-fetch": "^0.7.0",
     "hardhat": "^2.13.1"

--- a/examples/ethereum-basic-event-handlers/package.json
+++ b/examples/ethereum-basic-event-handlers/package.json
@@ -31,8 +31,8 @@
     "typescript": "^5.0.4"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "latest",
-    "@graphprotocol/graph-ts": "latest",
+    "@graphprotocol/graph-cli": "0.49.0",
+    "@graphprotocol/graph-ts": "0.30.0",
     "@nomicfoundation/hardhat-toolbox": "^2.0.2",
     "apollo-fetch": "^0.7.0",
     "hardhat": "^2.13.1"

--- a/examples/ethereum-gravatar/package.json
+++ b/examples/ethereum-gravatar/package.json
@@ -18,8 +18,8 @@
     "deploy-local": "graph deploy example --ipfs http://127.0.0.1:5001 --node http://127.0.0.1:8020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "latest",
-    "@graphprotocol/graph-ts": "latest",
+    "@graphprotocol/graph-cli": "0.49.0",
+    "@graphprotocol/graph-ts": "0.30.0",
     "@nomicfoundation/hardhat-toolbox": "^2.0.2",
     "hardhat": "^2.13.1"
   }

--- a/examples/ethereum-gravatar/package.json
+++ b/examples/ethereum-gravatar/package.json
@@ -18,8 +18,8 @@
     "deploy-local": "graph deploy example --ipfs http://127.0.0.1:5001 --node http://127.0.0.1:8020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "workspace:*",
-    "@graphprotocol/graph-ts": "workspace:*",
+    "@graphprotocol/graph-cli": "latest",
+    "@graphprotocol/graph-ts": "latest",
     "@nomicfoundation/hardhat-toolbox": "^2.0.2",
     "hardhat": "^2.13.1"
   }

--- a/examples/example-subgraph/package.json
+++ b/examples/example-subgraph/package.json
@@ -13,7 +13,7 @@
     "codegen": "../../packages/cli/bin/run codegen --output-dir src/types/ subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "latest"
+    "@graphprotocol/graph-ts": "0.30.0"
   },
   "resolutions": {
     "assemblyscript": "0.19.10"

--- a/examples/example-subgraph/package.json
+++ b/examples/example-subgraph/package.json
@@ -13,7 +13,7 @@
     "codegen": "../../packages/cli/bin/run codegen --output-dir src/types/ subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "workspace:*"
+    "@graphprotocol/graph-ts": "latest"
   },
   "resolutions": {
     "assemblyscript": "0.19.10"

--- a/examples/near-blocks/package.json
+++ b/examples/near-blocks/package.json
@@ -17,7 +17,7 @@
     "deploy-local": "graph deploy example --ipfs http://localhost:5001 --node http://127.0.0.1:8020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "latest",
-    "@graphprotocol/graph-ts": "latest"
+    "@graphprotocol/graph-cli": "0.49.0",
+    "@graphprotocol/graph-ts": "0.30.0"
   }
 }

--- a/examples/near-blocks/package.json
+++ b/examples/near-blocks/package.json
@@ -17,7 +17,7 @@
     "deploy-local": "graph deploy example --ipfs http://localhost:5001 --node http://127.0.0.1:8020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "workspace:*",
-    "@graphprotocol/graph-ts": "workspace:*"
+    "@graphprotocol/graph-cli": "latest",
+    "@graphprotocol/graph-ts": "latest"
   }
 }

--- a/examples/near-receipts/package.json
+++ b/examples/near-receipts/package.json
@@ -17,7 +17,7 @@
     "deploy-local": "graph deploy example --ipfs http://localhost:5001 --node http://127.0.0.1:8020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "latest",
-    "@graphprotocol/graph-ts": "latest"
+    "@graphprotocol/graph-cli": "0.49.0",
+    "@graphprotocol/graph-ts": "0.30.0"
   }
 }

--- a/examples/near-receipts/package.json
+++ b/examples/near-receipts/package.json
@@ -17,7 +17,7 @@
     "deploy-local": "graph deploy example --ipfs http://localhost:5001 --node http://127.0.0.1:8020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "workspace:*",
-    "@graphprotocol/graph-ts": "workspace:*"
+    "@graphprotocol/graph-cli": "latest",
+    "@graphprotocol/graph-ts": "latest"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,10 +46,10 @@ importers:
   examples/arweave-blocks-transactions:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: latest
+        specifier: 0.49.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: latest
+        specifier: 0.30.0
         version: link:../../packages/ts
 
   examples/cosmos-block-filtering:
@@ -62,10 +62,10 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: latest
+        specifier: 0.49.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: latest
+        specifier: 0.30.0
         version: link:../../packages/ts
       mustache:
         specifier: ^4.2.0
@@ -81,10 +81,10 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: latest
+        specifier: 0.49.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: latest
+        specifier: 0.30.0
         version: link:../../packages/ts
 
   examples/cosmos-validator-delegations:
@@ -100,10 +100,10 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: latest
+        specifier: 0.49.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: latest
+        specifier: 0.30.0
         version: link:../../packages/ts
       mustache:
         specifier: ^4.2.0
@@ -119,10 +119,10 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: latest
+        specifier: 0.49.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: latest
+        specifier: 0.30.0
         version: link:../../packages/ts
       mustache:
         specifier: ^4.2.0
@@ -171,10 +171,10 @@ importers:
         version: 5.0.4
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: latest
+        specifier: 0.49.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: latest
+        specifier: 0.30.0
         version: link:../../packages/ts
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^2.0.2
@@ -189,10 +189,10 @@ importers:
   examples/ethereum-gravatar:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: latest
+        specifier: 0.49.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: latest
+        specifier: 0.30.0
         version: link:../../packages/ts
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^2.0.2
@@ -204,25 +204,25 @@ importers:
   examples/example-subgraph:
     devDependencies:
       '@graphprotocol/graph-ts':
-        specifier: latest
+        specifier: 0.30.0
         version: link:../../packages/ts
 
   examples/near-blocks:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: latest
+        specifier: 0.49.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: latest
+        specifier: 0.30.0
         version: link:../../packages/ts
 
   examples/near-receipts:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: latest
+        specifier: 0.49.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: latest
+        specifier: 0.30.0
         version: link:../../packages/ts
 
   packages/cli:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,10 +46,10 @@ importers:
   examples/arweave-blocks-transactions:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/ts
 
   examples/cosmos-block-filtering:
@@ -62,10 +62,10 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/ts
       mustache:
         specifier: ^4.2.0
@@ -81,10 +81,10 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/ts
 
   examples/cosmos-validator-delegations:
@@ -100,10 +100,10 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/ts
       mustache:
         specifier: ^4.2.0
@@ -119,10 +119,10 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/ts
       mustache:
         specifier: ^4.2.0
@@ -171,10 +171,10 @@ importers:
         version: 5.0.4
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/ts
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^2.0.2
@@ -189,10 +189,10 @@ importers:
   examples/ethereum-gravatar:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/ts
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^2.0.2
@@ -204,25 +204,25 @@ importers:
   examples/example-subgraph:
     devDependencies:
       '@graphprotocol/graph-ts':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/ts
 
   examples/near-blocks:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/ts
 
   examples/near-receipts:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: workspace:*
+        specifier: latest
         version: link:../../packages/ts
 
   packages/cli:


### PR DESCRIPTION
when someone clones the repo we do not want them to use `workspace:*` instead they should install whatever the `latest` tag is
