### PR TITLE
fix: only show substreams possible network instead of everything

### DIFF
--- a/.changeset/smart-cycles-sit.md
+++ b/.changeset/smart-cycles-sit.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+only allow mainnet for substreams in network selection for init

--- a/packages/cli/src/protocols/index.ts
+++ b/packages/cli/src/protocols/index.ts
@@ -74,7 +74,7 @@ export default class Protocol {
   }
 
   static availableNetworks() {
-    let networks = immutable.fromJS({
+    return immutable.fromJS({
       arweave: ['arweave-mainnet'],
       ethereum: [
         'mainnet',
@@ -124,16 +124,6 @@ export default class Protocol {
       'arweave' | 'ethereum' | 'near' | 'cosmos' | 'substreams',
       immutable.List<string>
     >;
-
-    const allNetworks: string[] = [];
-    // eslint-disable-next-line unicorn/no-array-for-each
-    networks.forEach(value => {
-      allNetworks.push(...value);
-    });
-
-    networks = networks.set('substreams', immutable.List(allNetworks));
-
-    return networks;
   }
 
   static normalizeName(name: ProtocolName) {


### PR DESCRIPTION
**Before**


[![asciicast](https://asciinema.org/a/gq9jMF0MiPyZBPBaQDWHXuEWG.svg)](https://asciinema.org/a/gq9jMF0MiPyZBPBaQDWHXuEWG)


**After**

[![asciicast](https://asciinema.org/a/yZArTMo8Zh1x4NmiiFyzntsgh.svg)](https://asciinema.org/a/yZArTMo8Zh1x4NmiiFyzntsgh)


Related #1326 
Closes https://github.com/graphprotocol/graph-tooling/issues/1332