### PR TITLE
fix: convert ETH tuple array to GraphQL bytes array

### DIFF
--- a/.changeset/hungry-crabs-promise.md
+++ b/.changeset/hungry-crabs-promise.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+return tuple arrays as a Bytes array in GraphQL

--- a/packages/cli/src/codegen/types/conversions.ts
+++ b/packages/cli/src/codegen/types/conversions.ts
@@ -312,7 +312,7 @@ const ASSEMBLYSCRIPT_TO_VALUE = [
   ],
   ['Array<Array<string>>', /\[\[.*\]\]/, (code: any) => `Value.fromStringMatrix(${code})`],
   ['Array<Array<string | null>>', null, (code: any) => `Value.fromStringMatrix(${code})`], // is this overwriting the Array null below?
-
+  ['Array<ethereum.Tuple>', '[Bytes]', (code: any) => `Value.fromArray(${code})`],
   // Arrays
 
   ['Array<Address>', '[Bytes]', (code: any) => `Value.fromBytesArray(${code})`],


### PR DESCRIPTION
As per #846 it was crashing because during `init` when we convert ABI -> AssemblyScript -> Value. `Value` is what gets returned as GraphQL type and it was failing to convert from AS -> Value.

In this PR, making it such that for tuples we return an array of bytes given tuples are complext and this is good enough for generated code. For complex scenarios makes more sense user define and deal with complext types themselves.

closes #846 