### PR TITLE
fix: init to use latest graph-ts version

### DIFF
--- a/.changeset/moody-jeans-ring.md
+++ b/.changeset/moody-jeans-ring.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+upgrade to latest graph-ts version

--- a/packages/cli/src/scaffold/index.ts
+++ b/packages/cli/src/scaffold/index.ts
@@ -73,7 +73,7 @@ export default class Scaffold {
         },
         dependencies: {
           '@graphprotocol/graph-cli': GRAPH_CLI_VERSION,
-          '@graphprotocol/graph-ts': `0.29.1`,
+          '@graphprotocol/graph-ts': `0.30.0`,
         },
         devDependencies: this.protocol.hasEvents() ? { 'matchstick-as': `0.5.0` } : undefined,
       }),


### PR DESCRIPTION
created #1358 so we don't have to manually keep this in sync.