### PR TITLE
fix: only ask for subgraph name and directory for init examples

### DIFF
--- a/.changeset/witty-seals-battle.md
+++ b/.changeset/witty-seals-battle.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Only ask directory and subgraph name when using `graph init --from-example ...`

--- a/examples/substreams-powered-subgraph/.gitignore
+++ b/examples/substreams-powered-subgraph/.gitignore
@@ -3,4 +3,3 @@ target/
 .idea
 src/pb/
 node_modules/
-yarn.lock

--- a/examples/substreams-powered-subgraph/package.json
+++ b/examples/substreams-powered-subgraph/package.json
@@ -9,7 +9,8 @@
   "private": true,
   "scripts": {
     "subgraph:build": "graph build",
-    "subgraph:deploy": "graph deploy",
+    "deploy": "graph deploy",
+    "codegen": "graph codegen",
     "substreams:build": "cargo build --target wasm32-unknown-unknown --release",
     "substreams:clean": "rm -rf ./target && rm -rf ./src/pb",
     "substreams:package": "substreams pack ./substreams.yaml",

--- a/examples/substreams-powered-subgraph/package.json
+++ b/examples/substreams-powered-subgraph/package.json
@@ -8,9 +8,9 @@
   },
   "private": true,
   "scripts": {
-    "subgraph:build": "graph build",
-    "deploy": "graph deploy",
     "codegen": "graph codegen",
+    "deploy": "graph deploy",
+    "subgraph:build": "graph build",
     "substreams:build": "cargo build --target wasm32-unknown-unknown --release",
     "substreams:clean": "rm -rf ./target && rm -rf ./src/pb",
     "substreams:package": "substreams pack ./substreams.yaml",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -160,7 +160,8 @@ export default class InitCommand extends Command {
     const commands = {
       link: yarn ? 'yarn link @graphprotocol/graph-cli' : 'npm link @graphprotocol/graph-cli',
       install: yarn ? 'yarn' : 'npm install',
-      codegen: yarn ? 'yarn codegen' : 'npm run codegen',
+      // this ensure we run code-generation from our CLI instead of some script in package.json
+      codegen: yarn ? 'yarn graph codegen' : 'npx graph codegen',
       deploy: yarn ? 'yarn deploy' : 'npm run deploy',
     };
 
@@ -841,13 +842,11 @@ Make sure to visit the documentation on https://thegraph.com/docs/ for further i
 async function initSubgraphFromExample(
   this: InitCommand,
   {
-    // protocolInstance,
     fromExample,
     allowSimpleName,
     subgraphName,
     directory,
   }: {
-    // protocolInstance: Protocol;
     fromExample: string | boolean;
     allowSimpleName?: boolean;
     subgraphName: string;
@@ -971,14 +970,12 @@ async function initSubgraphFromExample(
     return;
   }
 
-  // if (!isSubstreams) {
-  //   // Run code-generation
-  //   const codegen = await runCodegen(directory, commands.codegen);
-  //   if (codegen !== true) {
-  //     this.exit(1);
-  //     return;
-  //   }
-  // }
+  // Run code-generation
+  const codegen = await runCodegen(directory, commands.codegen);
+  if (codegen !== true) {
+    this.exit(1);
+    return;
+  }
 
   printNextSteps.bind(this)({ subgraphName, directory }, { commands });
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -160,8 +160,7 @@ export default class InitCommand extends Command {
     const commands = {
       link: yarn ? 'yarn link @graphprotocol/graph-cli' : 'npm link @graphprotocol/graph-cli',
       install: yarn ? 'yarn' : 'npm install',
-      // this ensure we run code-generation from our CLI instead of some script in package.json
-      codegen: yarn ? 'yarn graph codegen' : 'npx graph codegen',
+      codegen: yarn ? 'yarn codegen' : 'npm run codegen',
       deploy: yarn ? 'yarn deploy' : 'npm run deploy',
     };
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -8,7 +8,6 @@ import {
   loadAbiFromEtherscan,
   loadStartBlockForContract,
 } from '../command-helpers/abi';
-import * as DataSourcesExtractor from '../command-helpers/data-sources';
 import { initNetworksConfig } from '../command-helpers/network';
 import { chooseNodeUrl } from '../command-helpers/node';
 import { generateScaffold, writeScaffold } from '../command-helpers/scaffold';
@@ -174,8 +173,6 @@ export default class InitCommand extends Command {
           allowSimpleName,
           directory,
           subgraphName,
-          studio,
-          product,
         },
         { commands },
       );
@@ -262,8 +259,6 @@ export default class InitCommand extends Command {
           fromExample,
           subgraphName: answers.subgraphName,
           directory: answers.directory,
-          studio: true,
-          product: 'subgraph-studio',
         },
         { commands },
       );
@@ -851,16 +846,12 @@ async function initSubgraphFromExample(
     allowSimpleName,
     subgraphName,
     directory,
-    studio,
-    product,
   }: {
     // protocolInstance: Protocol;
     fromExample: string | boolean;
     allowSimpleName?: boolean;
     subgraphName: string;
     directory: string;
-    studio: boolean;
-    product?: string;
   },
   {
     commands,
@@ -921,20 +912,6 @@ async function initSubgraphFromExample(
   if (!cloned) {
     this.exit(1);
     return;
-  }
-
-  try {
-    // It doesn't matter if we changed the URL we clone the YAML,
-    // we'll check it's network anyway. If it's a studio subgraph we're dealing with.
-    const dataSourcesAndTemplates = await DataSourcesExtractor.fromFilePath(
-      path.join(directory, 'subgraph.yaml'),
-    );
-
-    for (const { network } of dataSourcesAndTemplates) {
-      validateStudioNetwork({ studio, product, network });
-    }
-  } catch (e) {
-    this.error(e.message, { exit: 1 });
   }
 
   const networkConf = await initNetworksConfig(directory, 'address');


### PR DESCRIPTION
### Summary

We don't need to know product or protocol information. The example comes with everything that is necessary. Even skipping the validation of networks since all the example that we have in this repo are maintained and should work.

[![asciicast](https://asciinema.org/a/sufNmPJKbMnlDDunOKcCZ1SWa.svg)](https://asciinema.org/a/sufNmPJKbMnlDDunOKcCZ1SWa)

closes https://github.com/graphprotocol/graph-tooling/issues/1375