### PR TITLE
fix: do not exit with 1 for substreams

### DIFF
--- a/.changeset/metal-fishes-drop.md
+++ b/.changeset/metal-fishes-drop.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+do not crash for codegen when it is substreams

--- a/packages/cli/src/type-generator.ts
+++ b/packages/cli/src/type-generator.ts
@@ -55,6 +55,7 @@ export default class TypeGenerator {
       toolbox.print.success(
         'Subgraph uses a substream datasource. Codegeneration is not required.',
       );
+      process.exit(0);
       return;
     }
 


### PR DESCRIPTION
this ensure that CLI does not return with status code `1` making it look like an error.

