### PR TITLE
fix: returned string of BigInt.toHexString

### DIFF
--- a/packages/ts/common/numbers.ts
+++ b/packages/ts/common/numbers.ts
@@ -114,8 +114,15 @@ export class BigInt extends Uint8Array {
     return typeConversion.bigIntToHex(this);
   }
 
-  toHexString(): string {
-    return "0x" + typeConversion.bigIntToHex(this);
+  /**
+   * Converts `BigInt` to a hexadecimal string representation, with an optional
+   * prefix (for example, '0x').
+   */
+  toHexString(prefix: string = ''): string {
+    if (prefix !== '') {
+    return prefix + typeConversion.bigIntToHex(this)
+    }
+    return typeConversion.bigIntToHex(this);
   }
 
   toString(): string {

--- a/packages/ts/common/numbers.ts
+++ b/packages/ts/common/numbers.ts
@@ -120,7 +120,7 @@ export class BigInt extends Uint8Array {
    */
   toHexString(prefix: string = ''): string {
     if (prefix !== '') {
-    return prefix + typeConversion.bigIntToHex(this)
+      return prefix + typeConversion.bigIntToHex(this)
     }
     return typeConversion.bigIntToHex(this);
   }

--- a/packages/ts/common/numbers.ts
+++ b/packages/ts/common/numbers.ts
@@ -115,7 +115,7 @@ export class BigInt extends Uint8Array {
   }
 
   toHexString(): string {
-    return typeConversion.bigIntToHex(this);
+    return "0x" + typeConversion.bigIntToHex(this);
   }
 
   toString(): string {


### PR DESCRIPTION
For The Graph's graph-ts [implementation](https://github.com/graphprotocol/graph-tooling/blob/main/packages/ts/common/numbers.ts#L113C1-L119C4), `BigInt.toHex()` and `BigInt.toHexString()` behaves the same. 

```js
toHex(): string {
  return typeConversion.bigIntToHex(this);
}

toHexString(): string {
  return typeConversion.bigIntToHex(this);
}
```

However, in my thoughts `toHex()` should return a string that looks like `deadbeef` while `toHexString()` should return a string that looks like `0xdeadbeef`.

So the implementation should be updated into:

```js
toHex(): string {
  return typeConversion.bigIntToHex(this);
}

toHexString(): string {
  return "0x" + typeConversion.bigIntToHex(this);
}
```

Additionally, `toHexString()` is not tracked by [The Graph's AssemblyScript API docs](https://thegraph.com/docs/en/developing/assemblyscript-api/#bigint).