### PR TITLE
fix: init from example improvements

### DIFF
--- a/.changeset/five-suns-lie.md
+++ b/.changeset/five-suns-lie.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+ensure we use studio when loading from example

--- a/.changeset/kind-steaks-watch.md
+++ b/.changeset/kind-steaks-watch.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+skip validation for subgraph name when creating an example

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -129,7 +129,8 @@ export default class InitCommand extends Command {
 
     let { node, allowSimpleName } = chooseNodeUrl({
       product,
-      studio,
+      // if we are loading example, we want to ensure we are using studio
+      studio: studio || fromExample !== undefined,
       node: nodeFlag,
       allowSimpleName: allowSimpleNameFlag,
     });
@@ -256,6 +257,7 @@ export default class InitCommand extends Command {
 
       await initSubgraphFromExample.bind(this)(
         {
+          allowSimpleName,
           fromExample,
           subgraphName: answers.subgraphName,
           directory: answers.directory,


### PR DESCRIPTION
We want to ensure that user deploys to subgraph studio when loading `--from-example` and we don't need to validate subgraph name.
