### PR TITLE
feat: skip install flag for init

### DIFF
--- a/.changeset/pretty-cows-end.md
+++ b/.changeset/pretty-cows-end.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': minor
+---
+
+add skipInstall flag for init

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -79,6 +79,10 @@ export default class InitCommand extends Command {
       description: 'Index contract events as entities.',
       dependsOn: ['from-contract'],
     }),
+    'skip-install': Flags.boolean({
+      summary: 'Skip installing dependencies.',
+      default: false,
+    }),
     'start-block': Flags.string({
       helpGroup: 'Scaffold from contract',
       description: 'Block number to start indexing from.',
@@ -120,6 +124,7 @@ export default class InitCommand extends Command {
         'contract-name': contractName,
         'from-example': fromExample,
         'index-events': indexEvents,
+        'skip-install': skipInstall,
         network,
         abi: abiPath,
         'start-block': startBlock,
@@ -174,6 +179,7 @@ export default class InitCommand extends Command {
           allowSimpleName,
           directory,
           subgraphName,
+          skipInstall,
         },
         { commands },
       );
@@ -236,6 +242,7 @@ export default class InitCommand extends Command {
           product,
           startBlock,
           spkgPath,
+          skipInstall,
         },
         { commands, addContract: false },
       );
@@ -261,6 +268,7 @@ export default class InitCommand extends Command {
           fromExample,
           subgraphName: answers.subgraphName,
           directory: answers.directory,
+          skipInstall,
         },
         { commands },
       );
@@ -311,6 +319,7 @@ export default class InitCommand extends Command {
           product: answers.product,
           startBlock: answers.startBlock,
           spkgPath: answers.spkgPath,
+          skipInstall,
         },
         { commands, addContract: true },
       );
@@ -851,11 +860,13 @@ async function initSubgraphFromExample(
     allowSimpleName,
     subgraphName,
     directory,
+    skipInstall,
   }: {
     fromExample: string | boolean;
     allowSimpleName?: boolean;
     subgraphName: string;
     directory: string;
+    skipInstall: boolean;
   },
   {
     commands,
@@ -969,10 +980,12 @@ async function initSubgraphFromExample(
   }
 
   // Install dependencies
-  const installed = await installDependencies(directory, commands);
-  if (installed !== true) {
-    this.exit(1);
-    return;
+  if (!skipInstall) {
+    const installed = await installDependencies(directory, commands);
+    if (installed !== true) {
+      this.exit(1);
+      return;
+    }
   }
 
   // Run code-generation
@@ -1002,6 +1015,7 @@ async function initSubgraphFromContract(
     product,
     startBlock,
     spkgPath,
+    skipInstall,
   }: {
     protocolInstance: Protocol;
     allowSimpleName: boolean | undefined;
@@ -1017,6 +1031,7 @@ async function initSubgraphFromContract(
     product?: string;
     startBlock?: string;
     spkgPath?: string;
+    skipInstall: boolean;
   },
   {
     commands,
@@ -1109,12 +1124,15 @@ async function initSubgraphFromContract(
     return;
   }
 
-  // Install dependencies
-  const installed = await installDependencies(directory, commands);
-  if (installed !== true) {
-    this.exit(1);
-    return;
+  if (!skipInstall) {
+    // Install dependencies
+    const installed = await installDependencies(directory, commands);
+    if (installed !== true) {
+      this.exit(1);
+      return;
+    }
   }
+
   // Substreams we have nothing to install or generate
   if (!isSubstreams) {
     // Run code-generation


### PR DESCRIPTION
I find it useful to have a flag like this when testing and debugging flows cause I don't need to download all deps, I just want to bootstrap a project.

[![asciicast](https://asciinema.org/a/QGhJSBh3liUSV9yMBYFvmhLyG.svg)](https://asciinema.org/a/QGhJSBh3liUSV9yMBYFvmhLyG)

