### PR TITLE
cli: fix ABI api endpoint zksync mainnet

### DIFF
--- a/.changeset/fast-experts-play.md
+++ b/.changeset/fast-experts-play.md
@@ -1,0 +1,5 @@
+---
+"@graphprotocol/graph-cli": patch
+---
+
+fix ABI api endpoint zksync mainnet

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -193,7 +193,7 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'fantom-testnet':
       return `https://api-testnet.ftmscan.com/api`;
     case 'zksync-era':
-      return `https://explorer.zksync.io/api`;
+      return `https://block-explorer-api.mainnet.zksync.io/api`;
     case 'polygon-zkevm-testnet':
       return `https://testnet-zkevm.polygonscan.com/api`;
     case 'polygon-zkevm':


### PR DESCRIPTION
Currently the CLI fails to scaffold projects on zkSync Era cause the API endpoint to retrieve the contract ABI is incorrect. This PR fixes it using the new explorer API we've just released.