### PR TITLE
Add Darwinia chains support

### DIFF
--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -280,6 +280,14 @@ const getPublicRPCEndpoint = (network: string) => {
       return 'https://rpc.ankr.com/eth_sepolia';
     case 'scroll-sepolia':
       return 'https://rpc.ankr.com/scroll_sepolia_testnet';
+    case 'darwinia':
+      return 'https://rpc.darwinia.network';
+    case 'crab':
+      return 'https://crab-rpc.darwinia.network';
+    case 'pangolin':
+      return 'https://pangolin-rpc.darwinia.network';
+    case 'pangoro':
+      return 'https://pangoro-rpc.darwinia.network';
     default:
       throw new Error(`Unknown network: ${network}`);
   }

--- a/packages/cli/src/protocols/index.ts
+++ b/packages/cli/src/protocols/index.ts
@@ -112,6 +112,10 @@ export default class Protocol {
         'polygon-zkevm-testnet',
         'polygon-zkevm',
         'scroll-sepolia',
+        'darwinia',
+        'crab',
+        'pangolin',
+        'pangoro',
       ],
       near: ['near-mainnet', 'near-testnet'],
       cosmos: [


### PR DESCRIPTION
Add Darwinia chains into cli, Help users quickly create indexes in Darwinia
Darwinia is mainnet
Crab is canary net
Pangolin and Pangoro  are testnets
