### PR TITLE
cli: fix ABI api endpoint aurora networks

### DIFF
--- a/.changeset/grumpy-carrots-relate.md
+++ b/.changeset/grumpy-carrots-relate.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+fix ABI api endpoint aurora networks

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -165,9 +165,9 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'mumbai':
       return `https://api-testnet.polygonscan.com/api`;
     case 'aurora':
-      return `https://api.aurorascan.dev/api`;
+      return `https://explorer.mainnet.aurora.dev/api`;
     case 'aurora-testnet':
-      return `https://api-testnet.aurorascan.dev/api`;
+      return `https://explorer.testnet.aurora.dev/api`;
     case 'optimism-goerli':
       return `https://api-goerli-optimistic.etherscan.io/api`;
     case 'optimism':


### PR DESCRIPTION
Before:

```
$ graph init aurora-graph-test --allow-simple-name
✔ Protocol · ethereum
✔ Product for which to initialize · hosted-service
✔ Subgraph name · aurora-graph-test
✔ Directory to create the subgraph in · aurora-graph-test
✔ Ethereum network · aurora
✔ Contract address · 0xccc2b1aD21666A5847A804a73a41F904C4a4A0Ec
✖ Failed to fetch ABI from Etherscan: write EPROTO 802033DE01000000:error:0A000438:SSL routines:ssl3_read_bytes:tlsv1 alert internal error:../deps/openssl/openssl/ssl/record/rec_layer_s3.c:1586:SSL alert number 80

✖ Failed to fetch Start Block: Failed to fetch contract creation transaction hash

? ABI file (path) ›
```

After:

```
$ graph init aurora-graph-test --allow-simple-name
✔ Protocol · ethereum
✔ Product for which to initialize · hosted-service
✔ Subgraph name · aurora-graph-test
✔ Directory to create the subgraph in · aurora-graph-test
✔ Ethereum network · aurora
✔ Contract address · 0xccc2b1aD21666A5847A804a73a41F904C4a4A0Ec
✔ Fetching ABI from Etherscan
```