### PR TITLE
install: Allow installing to a user-specified directory

### DIFF
--- a/cf-pages/install.sh
+++ b/cf-pages/install.sh
@@ -1,88 +1,103 @@
 #!/bin/bash
-{
-  set -e
-  SUDO=''
-  if [ "$(id -u)" != "0" ]; then
-    SUDO='sudo'
-    echo "This script requires superuser access."
-    echo "You will be prompted for your password by sudo."
-    # clear any previous sudo permission
-    sudo -k
-  fi
 
-  # run inside sudo
-  $SUDO bash << SCRIPT
-      set -e
+if [ -n "$1" ]
+then
+    INSTALL_DIR=${1%%/}
+    BIN_DIR=
+else
+    INSTALL_DIR=/usr/local/lib
+    BIN_DIR=/usr/local/bin
+fi
 
-      OS=""
-      ARCH=""
-      OS_ARCH=""
+if [ ! -w "$INSTALL_DIR" ]
+then
+    cat <<EOF
+usage: install.sh [DIR]
 
-      echoerr() { echo "\$@" 1>&2; }
+Install graph-cli to DIR. DIR defaults to /usr/local/lib.
 
-      unsupported_arch() {
-        local os=$1
-        local arch=$2
-        echoerr "The Graph CLI does not support $os / $arch at this time."
-        exit 1
-      }
+The directory $INSTALL_DIR is not writable by the current user.
 
-      set_os_arch() {
-        if [ "\$(uname)" == "Darwin" ]; then
-          OS=darwin
-        elif [ "\$(expr substr \$(uname -s) 1 5)" == "Linux" ]; then
-          OS=linux
-        else
-          OS=win32
-        fi
+Try running this script as root for a system-wide install which will also
+put 'graph' into /usr/local/bin or pass an installation directory that is
+writable by the current user as DIR
+EOF
+    exit 1
+fi
 
-        ARCH="\$(uname -m)"
-        if [ "\$ARCH" == "x86_64" ]; then
-          ARCH=x64
-        elif [ "\$ARCH" == "amd64" ]; then
-          ARCH=x64
-        elif [ "\$ARCH" == "arm64" ]; then
-          if [ "\$OS" == "darwin" ]; then
-            ARCH=arm64
-          else
-            ARCH=arm
-          fi
-        elif [[ "\$ARCH" == aarch* ]]; then
-          ARCH=arm
-        else
-          unsupported_arch $OS $ARCH
-        fi
-      }
+set -e
 
-      download() {
-        DOWNLOAD_DIR=$(mktemp -d)
+OS=""
+ARCH=""
 
-        TARGET="\$OS-\$ARCH"
-        URL="https://github.com/graphprotocol/graph-tooling/releases/latest/download/graph-\$TARGET.tar.gz"
-        echo "Downloading \$URL"
+echoerr() { echo "$@" 1>&2; }
 
-        if ! curl --progress-bar --fail -L "\$URL" -o "\$DOWNLOAD_DIR/graph.tar.gz"; then
-          echo "Download failed."
-          exit 1
-        fi
-
-        echo "Downloaded to \$DOWNLOAD_DIR"
-
-        rm -rf "/usr/local/lib/graph"
-        tar xzf "\$DOWNLOAD_DIR/graph.tar.gz" -C /usr/local/lib
-        rm -rf "\$DOWNLOAD_DIR"
-        echo "Unpacked to /usr/local/lib/graph"
-
-        echo "Installing to /usr/local/bin/graph"
-        rm -f /usr/local/bin/graph
-        ln -s /usr/local/lib/graph/bin/graph /usr/local/bin/graph
-      }
-
-      set_os_arch
-      download
-
-SCRIPT
-  LOCATION=$(command -v graph)
-  echo "The Graph CLI installed to $LOCATION"
-  graph --version
+unsupported_arch() {
+    local os=$1
+    local arch=$2
+    echoerr "The Graph CLI does not support $os / $arch at this time."
+    exit 1
 }
+
+set_os_arch() {
+    if [ "$(uname)" == "Darwin" ]; then
+        OS=darwin
+    elif [ "$(uname -s)" == "Linux" ]; then
+        OS=linux
+    else
+        OS=win32
+    fi
+
+    ARCH="$(uname -m)"
+    if [ "$ARCH" == "x86_64" ]; then
+        ARCH=x64
+    elif [ "$ARCH" == "amd64" ]; then
+        ARCH=x64
+    elif [ "$ARCH" == "arm64" ]; then
+        if [ "$OS" == "darwin" ]; then
+            ARCH=arm64
+        else
+            ARCH=arm
+        fi
+    elif [[ "$ARCH" == aarch* ]]; then
+        ARCH=arm
+    else
+        unsupported_arch $OS $ARCH
+    fi
+}
+
+download() {
+    DOWNLOAD_DIR=$(mktemp -d)
+
+    TARGET="$OS-$ARCH"
+    URL="https://github.com/graphprotocol/graph-tooling/releases/latest/download/graph-$TARGET.tar.gz"
+    echo "Downloading $URL"
+
+    if ! curl --progress-bar --fail -L "$URL" -o "$DOWNLOAD_DIR/graph.tar.gz"; then
+        echo "Download failed."
+        exit 1
+    fi
+
+    echo "Downloaded to $DOWNLOAD_DIR"
+
+    rm -rf "${INSTALL_DIR}/graph"
+    tar xzf "$DOWNLOAD_DIR/graph.tar.gz" -C "$INSTALL_DIR"
+    rm -rf "$DOWNLOAD_DIR"
+    echo "Unpacked to $INSTALL_DIR"
+
+    if [ -n "$BIN_DIR" ]
+    then
+        echo "Installing to ${BIN_DIR}/graph"
+        rm -f "$BIN_DIR/graph"
+        ln -s "$INSTALL_DIR/graph/bin/graph" "$BIN_DIR/graph"
+        LOCATION="$BIN_DIR/graph"
+    else
+        LOCATION="$INSTALL_DIR/graph/bin/graph"
+    fi
+}
+
+set_os_arch
+download
+
+echo "The Graph CLI installed to $LOCATION"
+$LOCATION --version


### PR DESCRIPTION
Also, do not run sudo from the script. Users instead should do `curl -sSL http://cli.thegraph.com/install.sh | sudo sh` if they want one-shot execution