### PR TITLE
Add retries to etherscan calls

### DIFF
--- a/.changeset/honest-shoes-rhyme.md
+++ b/.changeset/honest-shoes-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': minor
+---
+
+add etherscan api retries to `graph init` wizard

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -72,8 +72,7 @@ export const fetchContractCreationHashWithRetry = async (
       /* empty */
     }
   }
-  throw new Error(`Failed to fetch contract creation transaction hash
-  `);
+  throw new Error(`Failed to fetch contract creation transaction hash`);
 };
 
 export const fetchTransactionByHashFromRPC = async (

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -19,6 +19,7 @@ import EthereumABI from '../protocols/ethereum/abi';
 import { abiEvents } from '../scaffold/schema';
 import { validateContract } from '../validation';
 import AddCommand from './add';
+import * as toolbox from 'gluegun';
 
 const protocolChoices = Array.from(Protocol.availableProtocols().keys());
 const availableNetworks = Protocol.availableNetworks();
@@ -395,6 +396,26 @@ async function processFromExampleInitForm(
   }
 }
 
+async function retryWithPrompt<T>(func: () => Promise<T>): Promise<T | undefined> {
+  for(;;) {
+    try {
+      return await func();
+    } catch (_) {
+      const { retry } = await toolbox.prompt.ask({
+        type: 'confirm',
+        name: 'retry',
+        message: 'Do you want to retry?',
+        initial: true,
+      });
+
+      if (!retry) {
+        break;
+      }
+    }
+  }
+  return undefined;
+}
+
 async function processInitForm(
   this: InitCommand,
   {
@@ -585,24 +606,19 @@ async function processInitForm(
 
           // Try loading the ABI from Etherscan, if none was provided
           if (protocolInstance.hasABIs() && !initAbi) {
-            try {
-              if (network === 'poa-core') {
-                // TODO: this variable is never used anywhere, what happens?
-                // abiFromBlockScout = await loadAbiFromBlockScout(ABI, network, value)
-              } else {
-                abiFromEtherscan = await loadAbiFromEtherscan(ABI, network, value);
-              }
-            } catch (e) {
-              // noop
+            if (network === 'poa-core') {
+              abiFromEtherscan = await retryWithPrompt(() => loadAbiFromBlockScout(ABI, network, value));
+            } else {
+              abiFromEtherscan = await retryWithPrompt(() => loadAbiFromEtherscan(ABI, network, value));
             }
+
           }
           // If startBlock is not set, try to load it.
           if (!initStartBlock) {
-            try {
-              // Load startBlock for this contract
-              initStartBlock = Number(await loadStartBlockForContract(network, value)).toString();
-            } catch (error) {
-              // noop
+            // Load startBlock for this contract
+            const startBlock = await retryWithPrompt(() => loadStartBlockForContract(network, value));
+            if (startBlock) {
+              initStartBlock = Number(startBlock).toString();
             }
           }
           return value;

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { filesystem, prompt, system } from 'gluegun';
+import * as toolbox from 'gluegun';
 import { Args, Command, Flags, ux } from '@oclif/core';
 import {
   loadAbiFromBlockScout,
@@ -19,7 +20,6 @@ import EthereumABI from '../protocols/ethereum/abi';
 import { abiEvents } from '../scaffold/schema';
 import { validateContract } from '../validation';
 import AddCommand from './add';
-import * as toolbox from 'gluegun';
 
 const protocolChoices = Array.from(Protocol.availableProtocols().keys());
 const availableNetworks = Protocol.availableNetworks();
@@ -397,7 +397,7 @@ async function processFromExampleInitForm(
 }
 
 async function retryWithPrompt<T>(func: () => Promise<T>): Promise<T | undefined> {
-  for(;;) {
+  for (;;) {
     try {
       return await func();
     } catch (_) {
@@ -607,16 +607,21 @@ async function processInitForm(
           // Try loading the ABI from Etherscan, if none was provided
           if (protocolInstance.hasABIs() && !initAbi) {
             if (network === 'poa-core') {
-              abiFromEtherscan = await retryWithPrompt(() => loadAbiFromBlockScout(ABI, network, value));
+              abiFromEtherscan = await retryWithPrompt(() =>
+                loadAbiFromBlockScout(ABI, network, value),
+              );
             } else {
-              abiFromEtherscan = await retryWithPrompt(() => loadAbiFromEtherscan(ABI, network, value));
+              abiFromEtherscan = await retryWithPrompt(() =>
+                loadAbiFromEtherscan(ABI, network, value),
+              );
             }
-
           }
           // If startBlock is not set, try to load it.
           if (!initStartBlock) {
             // Load startBlock for this contract
-            const startBlock = await retryWithPrompt(() => loadStartBlockForContract(network, value));
+            const startBlock = await retryWithPrompt(() =>
+              loadStartBlockForContract(network, value),
+            );
             if (startBlock) {
               initStartBlock = Number(startBlock).toString();
             }


### PR DESCRIPTION
Adds "Do you want to retry?" prompt when API calls fail during `graph init` wizard.
Fixes #1447