### PR TITLE
chore: upgrade to use node 20

### DIFF
--- a/.changeset/fluffy-rockets-tickle.md
+++ b/.changeset/fluffy-rockets-tickle.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': minor
+---
+
+upgrade to Node 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: the-guild-org/shared-config/setup@main
         name: Setup Env
         with:
-          nodeVersion: 18
+          nodeVersion: 20
           packageManager: pnpm
 
       - name: Lint
@@ -31,8 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # For some reason tests take forever on node 14 so will re-visit in future when we decide what versions to test on
-        node-version: [16, 18, 20]
+        node-version: [18, 20, 21]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -40,7 +39,7 @@ jobs:
       - uses: the-guild-org/shared-config/setup@main
         name: Setup Env
         with:
-          nodeVersion: 18
+          nodeVersion: 20
           packageManager: pnpm
 
       - name: Setup git user information
@@ -69,7 +68,7 @@ jobs:
       - uses: the-guild-org/shared-config/setup@main
         name: Setup Env
         with:
-          nodeVersion: 18
+          nodeVersion: 20
           packageManager: pnpm
 
       - name: Build Packages
@@ -96,7 +95,7 @@ jobs:
       - uses: the-guild-org/shared-config/setup@main
         name: Setup Env
         with:
-          nodeVersion: 18
+          nodeVersion: 20
           packageManager: pnpm
 
       - name: Build Packages

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       npmTag: alpha
       buildScript: build
-      nodeVersion: 16
+      nodeVersion: 20
       packageManager: pnpm
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -31,7 +31,7 @@ jobs:
     with:
       npmTag: rc
       buildScript: build
-      nodeVersion: 16
+      nodeVersion: 20
       packageManager: pnpm
       restoreDeletedChangesets: true
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup environment
         uses: the-guild-org/shared-config/setup@main
         with:
-          nodeVersion: 16
+          nodeVersion: 20
           packageManager: pnpm
       - name: Set variables
         id: vars

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "private": true,
   "packageManager": "pnpm@8.3.1",
   "engines": {
-    "pnpm": ">=8"
+    "pnpm": ">=8",
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "pnpm --filter=@graphprotocol/graph-* build",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   },
   "license": "(Apache-2.0 OR MIT)",
   "private": true,
-  "packageManager": "pnpm@8.3.1",
+  "packageManager": "pnpm@8.10.4",
   "engines": {
-    "pnpm": ">=8",
-    "node": ">=18.0.0"
+    "node": ">=18.0.0",
+    "pnpm": ">=8"
   },
   "scripts": {
     "build": "pnpm --filter=@graphprotocol/graph-* build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "description": "CLI for building for and deploying to The Graph",
   "license": "(Apache-2.0 OR MIT)",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "bin": {
     "graph": "bin/run"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 patchedDependencies:
   oclif@3.8.1:
     hash: rxmtqiusuyruv7tkwux5gvotbm
@@ -49,7 +53,7 @@ importers:
   examples/arweave-blocks-transactions:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.60.0
+        specifier: 0.61.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
         specifier: 0.31.0
@@ -65,7 +69,7 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.60.0
+        specifier: 0.61.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
         specifier: 0.31.0
@@ -84,7 +88,7 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.60.0
+        specifier: 0.61.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
         specifier: 0.31.0
@@ -103,7 +107,7 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.60.0
+        specifier: 0.61.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
         specifier: 0.31.0
@@ -122,7 +126,7 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.60.0
+        specifier: 0.61.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
         specifier: 0.31.0
@@ -174,7 +178,7 @@ importers:
         version: 5.0.4
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.60.0
+        specifier: 0.61.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
         specifier: 0.31.0
@@ -192,7 +196,7 @@ importers:
   examples/ethereum-gravatar:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.60.0
+        specifier: 0.61.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
         specifier: 0.31.0
@@ -213,7 +217,7 @@ importers:
   examples/matic-lens-protocol-posts-subgraph:
     dependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.60.0
+        specifier: 0.61.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
         specifier: 0.31.0
@@ -226,7 +230,7 @@ importers:
   examples/near-blocks:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.60.0
+        specifier: 0.61.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
         specifier: 0.31.0
@@ -235,7 +239,7 @@ importers:
   examples/near-receipts:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.60.0
+        specifier: 0.61.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
         specifier: 0.31.0
@@ -244,7 +248,7 @@ importers:
   examples/substreams-powered-subgraph:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.60.0
+        specifier: 0.61.0
         version: link:../../packages/cli
 
   packages/cli:
@@ -14831,7 +14835,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
- Drop node 16 from node test matrix
- include node 21 in node test matrix
- make node 20 the default env
- make node 20 the default dev env
- upgrade `pnpm` version
- CLI still will allow node 18+ just because it is still an active version from Node Releases WG


closes https://github.com/graphprotocol/graph-tooling/issues/1499
