### PR TITLE
fix: sanitize special characters from codegen

### DIFF
--- a/.changeset/slow-carpets-smell.md
+++ b/.changeset/slow-carpets-smell.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+sanitize special characters in codegeneration

--- a/packages/cli/src/protocols/ethereum/codegen/abi.ts
+++ b/packages/cli/src/protocols/ethereum/codegen/abi.ts
@@ -14,6 +14,8 @@ const doFixtureCodegen = fs.existsSync('./fixtures.yaml');
 export default class AbiCodeGenerator {
   constructor(private abi: ABI) {
     this.abi = abi;
+    // Sanitize the name of the ABI to make it a valid class name
+    this.abi.name = abi.name.replace(/[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]+/g, '_');
   }
 
   generateModuleImports() {


### PR DESCRIPTION
| Before | After | 
| -----|--------|
|[![asciicast](https://asciinema.org/a/9MI99SWMpyh150GX8gF3GesUa.svg)](https://asciinema.org/a/9MI99SWMpyh150GX8gF3GesUa) |[![asciicast](https://asciinema.org/a/1frZk7oUNADIkzChiI7fitDr7.svg)](https://asciinema.org/a/1frZk7oUNADIkzChiI7fitDr7)|

closes https://github.com/graphprotocol/graph-tooling/issues/1390





