### PR TITLE
fix: dedupe module imports in codegen

### DIFF
--- a/.changeset/stupid-clouds-remain.md
+++ b/.changeset/stupid-clouds-remain.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+dedupe imports in codegen


### PR DESCRIPTION
we were only generating imports once, but we want to aggregate all the imports across all templates and then dedupe the imports.


| Before | After | 
| -------| -----|
|![CleanShot 2023-11-14 at 19 49 03](https://github.com/graphprotocol/graph-tooling/assets/44710980/147c6a37-f494-49bc-83a2-49d497ff93d9) |![CleanShot 2023-11-14 at 19 48 38](https://github.com/graphprotocol/graph-tooling/assets/44710980/3e9f3a0f-dc02-4a62-807b-d20531be1867) |


closes #1453 



