### PR TITLE
feat(ts): add Starknet data types

### DIFF
--- a/.changeset/ninety-comics-joke.md
+++ b/.changeset/ninety-comics-joke.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-ts': minor
+---
+
+add starknet data types

--- a/packages/ts/chain/starknet.ts
+++ b/packages/ts/chain/starknet.ts
@@ -1,0 +1,39 @@
+import '../common/eager_offset';
+import { Bytes } from '../common/collections';
+import { BigInt } from '../common/numbers';
+
+export namespace starknet {
+  export class Block {
+    constructor(
+      public number: BigInt,
+      public hash: Bytes,
+      public prevHash: Bytes,
+      public timestamp: BigInt,
+    ) {}
+  }
+
+  export class Transaction {
+    constructor(
+      public type: TransactionType,
+      public hash: Bytes,
+    ) {}
+  }
+
+  export enum TransactionType {
+    DEPLOY = 0,
+    INVOKE_FUNCTION = 1,
+    DECLARE = 2,
+    L1_HANDLER = 3,
+    DEPLOY_ACCOUNT = 4,
+  }
+
+  export class Event {
+    constructor(
+      public fromAddr: Bytes,
+      public keys: Array<Bytes>,
+      public data: Array<Bytes>,
+      public block: Block,
+      public transaction: Transaction,
+    ) {}
+  }
+}

--- a/packages/ts/common/numbers.ts
+++ b/packages/ts/common/numbers.ts
@@ -438,3 +438,13 @@ export class BigDecimal {
     return diff.digits > BigInt.fromI32(0) ? 1 : -1;
   }
 }
+
+/** A type representing Starknet's field element type. */
+export class Felt extends Bytes {
+  /**
+   * Modifies and transforms the object IN-PLACE into `BigInt`.
+   */
+  intoBigInt(): BigInt {
+    return BigInt.fromUnsignedBytes(changetype<ByteArray>(this.reverse()));
+  }
+}

--- a/packages/ts/global/global.ts
+++ b/packages/ts/global/global.ts
@@ -2,6 +2,7 @@ import { arweave } from '../chain/arweave';
 import { cosmos } from '../chain/cosmos';
 import { ethereum } from '../chain/ethereum';
 import { near } from '../chain/near';
+import { starknet } from '../chain/starknet';
 import { Bytes, Entity, Result, TypedMap, TypedMapEntry, Wrapped } from '../common/collections';
 import { BigDecimal } from '../common/numbers';
 import { JSONValue, Value } from '../common/value';
@@ -230,7 +231,23 @@ export enum TypeId {
   ```
   */
 
-  // Reserved discriminant space for a future blockchain type IDs: [3,500, 4,499]
+  // Reserved discriminant space for Starknet type IDs: [3,500, 4,499]
+  StarknetBlock = 3500,
+  StarknetTransaction = 3501,
+  StarknetTransactionTypeEnum = 3502,
+  StarknetEvent = 3503,
+  StarknetArrayBytes = 3504,
+  /*
+  Continue to add more Starknet type IDs here. e.g.:
+  ```
+  NextStarknetType = 3505,
+  AnotherStarknetType = 3506,
+  ...
+  LastStarknetType = 4499,
+  ```
+  */
+
+  // Reserved discriminant space for a future blockchain type IDs: [4,500, 5,499]
 }
 
 export function id_of_type(typeId: TypeId): usize {
@@ -563,6 +580,19 @@ export function id_of_type(typeId: TypeId): usize {
       return idof<Array<arweave.Transaction>>();
     case TypeId.ArweaveTransactionWithBlockPtr:
       return idof<arweave.TransactionWithBlockPtr>();
+    /**
+     * Starknet type ids
+     */
+    case TypeId.StarknetBlock:
+      return idof<starknet.Block>();
+    case TypeId.StarknetTransaction:
+      return idof<starknet.Transaction>();
+    case TypeId.StarknetTransactionTypeEnum:
+      return idof<Array<starknet.TransactionType>>();
+    case TypeId.StarknetEvent:
+      return idof<starknet.Event>();
+    case TypeId.StarknetArrayBytes:
+      return idof<Array<Bytes>>();
     default:
       return 0;
   }

--- a/packages/ts/index.ts
+++ b/packages/ts/index.ts
@@ -11,6 +11,8 @@ export * from './chain/ethereum';
 export * from './chain/near';
 // Cosmos support
 export * from './chain/cosmos';
+// Starknet support
+export * from './chain/starknet';
 // Regular re-exports
 export * from './common/collections';
 export * from './common/conversion';

--- a/packages/ts/test/test.js
+++ b/packages/ts/test/test.js
@@ -36,6 +36,7 @@ async function main() {
   fs.copyFileSync('chain/ethereum.ts', 'test/temp_lib/chain/ethereum.ts');
   fs.copyFileSync('chain/near.ts', 'test/temp_lib/chain/near.ts');
   fs.copyFileSync('chain/cosmos.ts', 'test/temp_lib/chain/cosmos.ts');
+  fs.copyFileSync('chain/starknet.ts', 'test/temp_lib/chain/starknet.ts');
   fs.copyFileSync('index.ts', 'test/temp_lib/index.ts');
 
   try {
@@ -70,6 +71,7 @@ async function main() {
     fs.unlinkSync('test/temp_lib/chain/ethereum.ts');
     fs.unlinkSync('test/temp_lib/chain/near.ts');
     fs.unlinkSync('test/temp_lib/chain/cosmos.ts');
+    fs.unlinkSync('test/temp_lib/chain/starknet.ts');
     fs.rmdirSync('test/temp_lib/chain');
     fs.unlinkSync('test/temp_lib/index.ts');
     fs.rmdirSync('test/temp_lib');


### PR DESCRIPTION
This is the first of a series of PRs for adding Starknet support into `graph-tooling`, following the [addition of Starknet support in `graph-node`](https://github.com/graphprotocol/graph-node/pull/4895). This first PR adds support on the `ts` side, which is essentially mapped from the corresponding parts in `graph-node`.

This PR also adds a type `Felt`. This type is added because unlike in Ethereum where bytes and integers and distinct types (and hence have different representations in ABI), in Starknet the type `felt252` (or `felt` in Cairo Zero) is often used to represent both addresses and numbers. If we simply use `Bytes` for it, users might find it difficult to convert them into `BigInt`, as `BigInt` only takes little-endian arrays.

Once this gets merged, I will submit follow-up PRs that add Starknet subgraph initialization, codegen, and compilation support on the `cli` side. I figured following the "`ts` first then `cli`" approach should be easier.