### PR TITLE
doc: LTS policy

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -68,6 +68,16 @@ If you are ready to dive into the details of building a subgraph from scratch, t
 well, along with API documentation for the
 [AssemblyScript API](https://thegraph.com/docs/en/developer/assemblyscript-api/).
 
+## Releases
+
+The Graph CLI is released on [npm](https://www.npmjs.com/package/@graphprotocol/graph-cli) and published as a Binary on [GitHub Releases](https://github.com/graphprotocol/graph-tooling/releases). We support all the version of CLI that support [Maintenance, LTS and Current Node.js releases](https://github.com/nodejs/Release#release-schedule). Additionally if there are `graph-node` specific features that are breaking and no-longer supported, we will drop support for older versions of CLI. After 90 days of a new `Node.js` release, we will drop support for the oldest `Node.js` version.
+
+End-of-life Releases
+
+| Release    | End-of-life       | Reason                                |
+| ---------- | ----------------- | ------------------------------------- |
+| `>=0.60.0` | December 31, 2023 | No longer supporting Node 16 or lower |
+
 ## License
 
 Copyright &copy; 2018-2019 Graph Protocol, Inc. and contributors.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -70,7 +70,13 @@ well, along with API documentation for the
 
 ## Releases
 
-The Graph CLI is released on [npm](https://www.npmjs.com/package/@graphprotocol/graph-cli) and published as a Binary on [GitHub Releases](https://github.com/graphprotocol/graph-tooling/releases). We support all the version of CLI that support [Maintenance, LTS and Current Node.js releases](https://github.com/nodejs/Release#release-schedule). Additionally if there are `graph-node` specific features that are breaking and no-longer supported, we will drop support for older versions of CLI. After 90 days of a new `Node.js` release, we will drop support for the oldest `Node.js` version.
+The Graph CLI is released on [npm](https://www.npmjs.com/package/@graphprotocol/graph-cli) and
+published as a Binary on [GitHub Releases](https://github.com/graphprotocol/graph-tooling/releases).
+We support all the version of CLI that support
+[Maintenance, LTS and Current Node.js releases](https://github.com/nodejs/Release#release-schedule).
+Additionally if there are `graph-node` specific features that are breaking and no-longer supported,
+we will drop support for older versions of CLI. After 90 days of a new `Node.js` release, we will
+drop support for the oldest `Node.js` version.
 
 End-of-life Releases
 


### PR DESCRIPTION
we should have an explicit policy for CLI cause today users are asking us support for CLI version which we can't simply support and it is recommended for users to upgrade. So starting in new year we will drop support for v0.60 or lower and recommendation for any of these users is to upgrade.

