### PR TITLE
feat: validation for handlers from manifest file

### DIFF
--- a/.changeset/@graphprotocol_graph-cli-1535-dependencies.md
+++ b/.changeset/@graphprotocol_graph-cli-1535-dependencies.md
@@ -1,0 +1,7 @@
+---
+"@graphprotocol/graph-cli": patch
+---
+dependencies updates:
+  - Added dependency [`@babel/core@^7.20.5` ↗︎](https://www.npmjs.com/package/@babel/core/v/7.20.5) (to `dependencies`)
+  - Added dependency [`@babel/preset-typescript@^7.18.6` ↗︎](https://www.npmjs.com/package/@babel/preset-typescript/v/7.18.6) (to `dependencies`)
+  - Added dependency [`memoizee@^0.4.15` ↗︎](https://www.npmjs.com/package/memoizee/v/0.4.15) (to `dependencies`)

--- a/.changeset/six-crabs-crash.md
+++ b/.changeset/six-crabs-crash.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': minor
+---
+
+add validation for handlers from subgraph manifest

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@babel/core": "^7.20.5",
+    "@babel/preset-typescript": "^7.18.6",
     "@float-capital/float-subgraph-uncrashable": "^0.0.0-alpha.4",
     "@oclif/core": "2.8.6",
     "@oclif/plugin-autocomplete": "^2.3.6",
@@ -48,6 +50,7 @@
     "ipfs-http-client": "55.0.0",
     "jayson": "4.0.0",
     "js-yaml": "3.14.1",
+    "memoizee": "^0.4.15",
     "prettier": "1.19.1",
     "request": "2.88.2",
     "semver": "7.4.0",
@@ -58,10 +61,12 @@
     "yaml": "1.10.2"
   },
   "devDependencies": {
+    "@types/babel__core": "^7.20.5",
     "@types/debug": "^4.1.7",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^29.0.0",
     "@types/js-yaml": "^3.12.7",
+    "@types/memoizee": "^0.4.11",
     "@types/semver": "^7.3.13",
     "@types/which": "^2.0.1",
     "copyfiles": "^2.4.1",

--- a/packages/cli/src/compiler/index.ts
+++ b/packages/cli/src/compiler/index.ts
@@ -283,10 +283,10 @@ export default class Compiler {
           templates === undefined
             ? templates
             : templates.map((template: any) =>
-              template.updateIn(['mapping', 'file'], (mappingPath: string) =>
-                this._compileTemplateMapping(template, mappingPath, compiledFiles, spinner),
+                template.updateIn(['mapping', 'file'], (mappingPath: string) =>
+                  this._compileTemplateMapping(template, mappingPath, compiledFiles, spinner),
+                ),
               ),
-            ),
         );
 
         return subgraph;
@@ -649,37 +649,37 @@ export default class Compiler {
           templates === undefined
             ? templates
             : templates.map((template: any) => {
-              let updatedTemplate = template;
+                let updatedTemplate = template;
 
-              if (this.protocol.hasABIs()) {
-                updatedTemplate = updatedTemplate
-                  // Write template ABIs to the output directory
-                  .updateIn(['mapping', 'abis'], (abis: any[]) =>
-                    abis.map(abi =>
-                      abi.update('file', (abiFile: string) => {
-                        abiFile = path.resolve(this.sourceDir, abiFile);
-                        const abiData = this.ABI.load(abi.get('name'), abiFile);
-                        return path.relative(
-                          this.options.outputDir,
-                          this._writeSubgraphFile(
-                            abiFile,
-                            JSON.stringify(abiData.data.toJS(), null, 2),
-                            this.sourceDir,
-                            this.subgraphDir(this.options.outputDir, template),
-                            spinner,
-                          ),
-                        );
-                      }),
-                    ),
-                  );
-              }
+                if (this.protocol.hasABIs()) {
+                  updatedTemplate = updatedTemplate
+                    // Write template ABIs to the output directory
+                    .updateIn(['mapping', 'abis'], (abis: any[]) =>
+                      abis.map(abi =>
+                        abi.update('file', (abiFile: string) => {
+                          abiFile = path.resolve(this.sourceDir, abiFile);
+                          const abiData = this.ABI.load(abi.get('name'), abiFile);
+                          return path.relative(
+                            this.options.outputDir,
+                            this._writeSubgraphFile(
+                              abiFile,
+                              JSON.stringify(abiData.data.toJS(), null, 2),
+                              this.sourceDir,
+                              this.subgraphDir(this.options.outputDir, template),
+                              spinner,
+                            ),
+                          );
+                        }),
+                      ),
+                    );
+                }
 
-              // The mapping file is already being written to the output
-              // directory by the AssemblyScript compiler
-              return updatedTemplate.updateIn(['mapping', 'file'], (mappingFile: string) =>
-                path.relative(this.options.outputDir, path.resolve(this.sourceDir, mappingFile)),
-              );
-            }),
+                // The mapping file is already being written to the output
+                // directory by the AssemblyScript compiler
+                return updatedTemplate.updateIn(['mapping', 'file'], (mappingFile: string) =>
+                  path.relative(this.options.outputDir, path.resolve(this.sourceDir, mappingFile)),
+                );
+              }),
         );
 
         // Write the subgraph manifest itself

--- a/packages/cli/src/compiler/index.ts
+++ b/packages/cli/src/compiler/index.ts
@@ -6,6 +6,8 @@ import * as toolbox from 'gluegun';
 import immutable from 'immutable';
 import type { IPFSHTTPClient } from 'ipfs-http-client';
 import yaml from 'js-yaml';
+import memo from 'memoizee';
+import { parseSync } from '@babel/core';
 import { Spinner, step, withSpinner } from '../command-helpers/spinner';
 import debug from '../debug';
 import { applyMigrations } from '../migrations';
@@ -15,6 +17,18 @@ import Watcher from '../watcher';
 import * as asc from './asc';
 
 const compilerDebug = debug('graph-cli:compiler');
+
+/** memoize the reading of the file so we don't have to read it every time */
+const readFile = memo((filename: string) => fs.readFileSync(filename, 'utf-8'));
+
+/** Memoized parser for Babel, so we can simply just read from cache  */
+const babelAst = memo((filename: string) => {
+  const data = readFile(filename);
+  return parseSync(data, {
+    presets: ['@babel/preset-typescript'],
+    filename,
+  });
+});
 
 interface CompilerOptions {
   ipfs: any;
@@ -269,10 +283,10 @@ export default class Compiler {
           templates === undefined
             ? templates
             : templates.map((template: any) =>
-                template.updateIn(['mapping', 'file'], (mappingPath: string) =>
-                  this._compileTemplateMapping(template, mappingPath, compiledFiles, spinner),
-                ),
+              template.updateIn(['mapping', 'file'], (mappingPath: string) =>
+                this._compileTemplateMapping(template, mappingPath, compiledFiles, spinner),
               ),
+            ),
         );
 
         return subgraph;
@@ -350,11 +364,18 @@ export default class Compiler {
 
     try {
       const dataSourceName = dataSource.getIn(['name']);
-
       const baseDir = this.sourceDir;
       const absoluteMappingPath = path.resolve(baseDir, mappingPath);
       const inputFile = path.relative(baseDir, absoluteMappingPath);
+
       this._validateMappingContent(absoluteMappingPath);
+
+      const eventHandlers = dataSource.getIn(['mapping', 'eventHandlers']);
+      // TODO: improve the types
+      for (const eventHandler of (eventHandlers as any).toJS()) {
+        compilerDebug('Validating Event Handler %s', eventHandler.handler);
+        this._validateHandler(absoluteMappingPath, eventHandler.handler);
+      }
 
       // If the file has already been compiled elsewhere, just use that output
       // file and return early
@@ -431,6 +452,13 @@ export default class Compiler {
       const inputFile = path.relative(baseDir, absoluteMappingPath);
       this._validateMappingContent(absoluteMappingPath);
 
+      const eventHandlers = templateName.getIn(['mapping', 'eventHandlers']);
+      // TODO: improve the types
+      for (const eventHandler of (eventHandlers as any).toJS()) {
+        compilerDebug('Validating Template handler %s', eventHandler.handler);
+        this._validateHandler(absoluteMappingPath, eventHandler.handler);
+      }
+
       // If the file has already been compiled elsewhere, just use that output
       // file and return early
       const inputCacheKey = this.cacheKeyForFile(absoluteMappingPath);
@@ -489,13 +517,38 @@ export default class Compiler {
   }
 
   _validateMappingContent(filePath: string) {
-    const data = fs.readFileSync(filePath);
+    const data = readFile(filePath);
     if (this.blockIpfsMethods && (data.includes('ipfs.cat') || data.includes('ipfs.map'))) {
       throw Error(`
       Subgraph Studio does not support mappings with ipfs methods.
       Please remove all instances of ipfs.cat and ipfs.map from
       ${filePath}
       `);
+    }
+  }
+
+  _validateHandler(filePath: string, handlerName: string) {
+    const baselAst = babelAst(filePath);
+
+    const body = baselAst?.program.body;
+
+    if (!body) {
+      throw Error(`Could not parse ${filePath}`);
+    }
+
+    const exportedFunctionNames = body
+      .map(statement => {
+        if (
+          statement.type === 'ExportNamedDeclaration' &&
+          statement?.declaration?.type === 'FunctionDeclaration'
+        ) {
+          return statement.declaration.id?.name;
+        }
+      })
+      .filter(Boolean);
+
+    if (!exportedFunctionNames.includes(handlerName)) {
+      throw Error(`Could not find handler '${handlerName}' in ${filePath}`);
     }
   }
 
@@ -596,37 +649,37 @@ export default class Compiler {
           templates === undefined
             ? templates
             : templates.map((template: any) => {
-                let updatedTemplate = template;
+              let updatedTemplate = template;
 
-                if (this.protocol.hasABIs()) {
-                  updatedTemplate = updatedTemplate
-                    // Write template ABIs to the output directory
-                    .updateIn(['mapping', 'abis'], (abis: any[]) =>
-                      abis.map(abi =>
-                        abi.update('file', (abiFile: string) => {
-                          abiFile = path.resolve(this.sourceDir, abiFile);
-                          const abiData = this.ABI.load(abi.get('name'), abiFile);
-                          return path.relative(
-                            this.options.outputDir,
-                            this._writeSubgraphFile(
-                              abiFile,
-                              JSON.stringify(abiData.data.toJS(), null, 2),
-                              this.sourceDir,
-                              this.subgraphDir(this.options.outputDir, template),
-                              spinner,
-                            ),
-                          );
-                        }),
-                      ),
-                    );
-                }
+              if (this.protocol.hasABIs()) {
+                updatedTemplate = updatedTemplate
+                  // Write template ABIs to the output directory
+                  .updateIn(['mapping', 'abis'], (abis: any[]) =>
+                    abis.map(abi =>
+                      abi.update('file', (abiFile: string) => {
+                        abiFile = path.resolve(this.sourceDir, abiFile);
+                        const abiData = this.ABI.load(abi.get('name'), abiFile);
+                        return path.relative(
+                          this.options.outputDir,
+                          this._writeSubgraphFile(
+                            abiFile,
+                            JSON.stringify(abiData.data.toJS(), null, 2),
+                            this.sourceDir,
+                            this.subgraphDir(this.options.outputDir, template),
+                            spinner,
+                          ),
+                        );
+                      }),
+                    ),
+                  );
+              }
 
-                // The mapping file is already being written to the output
-                // directory by the AssemblyScript compiler
-                return updatedTemplate.updateIn(['mapping', 'file'], (mappingFile: string) =>
-                  path.relative(this.options.outputDir, path.resolve(this.sourceDir, mappingFile)),
-                );
-              }),
+              // The mapping file is already being written to the output
+              // directory by the AssemblyScript compiler
+              return updatedTemplate.updateIn(['mapping', 'file'], (mappingFile: string) =>
+                path.relative(this.options.outputDir, path.resolve(this.sourceDir, mappingFile)),
+              );
+            }),
         );
 
         // Write the subgraph manifest itself

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,12 @@ importers:
 
   packages/cli:
     dependencies:
+      '@babel/core':
+        specifier: ^7.20.5
+        version: 7.22.11
+      '@babel/preset-typescript':
+        specifier: ^7.18.6
+        version: 7.18.6(@babel/core@7.22.11)
       '@float-capital/float-subgraph-uncrashable':
         specifier: ^0.0.0-alpha.4
         version: 0.0.0-alpha.6
@@ -313,6 +319,9 @@ importers:
       js-yaml:
         specifier: 3.14.1
         version: 3.14.1
+      memoizee:
+        specifier: ^0.4.15
+        version: 0.4.15
       prettier:
         specifier: 1.19.1
         version: 1.19.1
@@ -338,6 +347,9 @@ importers:
         specifier: 1.10.2
         version: 1.10.2
     devDependencies:
+      '@types/babel__core':
+        specifier: ^7.20.5
+        version: 7.20.5
       '@types/debug':
         specifier: ^4.1.7
         version: 4.1.7
@@ -350,6 +362,9 @@ importers:
       '@types/js-yaml':
         specifier: ^3.12.7
         version: 3.12.7
+      '@types/memoizee':
+        specifier: ^0.4.11
+        version: 0.4.11
       '@types/semver':
         specifier: ^7.3.13
         version: 7.3.13
@@ -489,7 +504,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.0
-    dev: true
 
   /@babel/helper-builder-binary-assignment-operator-visitor@7.18.9:
     resolution: {integrity: sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==}
@@ -539,6 +553,24 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@babel/helper-create-class-features-plugin@7.20.5(@babel/core@7.22.11):
+    resolution: {integrity: sha512-3RCdA/EmEaikrhayahwToF0fpweU/8o2p8vhc1c/1kftHOdTKuC65kik/TLc+qfbS8JKw4qqJbne4ovICDhmww==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.11
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-member-expression-to-functions': 7.18.9
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-replace-supers': 7.19.1
+      '@babel/helper-split-export-declaration': 7.22.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.20.5):
     resolution: {integrity: sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==}
@@ -596,7 +628,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.0
-    dev: true
 
   /@babel/helper-module-imports@7.22.5:
     resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
@@ -652,7 +683,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.0
-    dev: true
 
   /@babel/helper-plugin-utils@7.20.2:
     resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
@@ -684,7 +714,6 @@ packages:
       '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-simple-access@7.22.5:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
@@ -1611,6 +1640,20 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/plugin-transform-typescript@7.20.2(@babel/core@7.22.11):
+    resolution: {integrity: sha512-jvS+ngBfrnTUBfOQq8NfGnSbF9BrqlR6hjJ2yVxMkmO5nL/cdifNbI30EfjRlN4g5wYWNnMPyj5Sa6R1pbLeag==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.11
+      '@babel/helper-create-class-features-plugin': 7.20.5(@babel/core@7.22.11)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.22.11)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-transform-unicode-escapes@7.18.10(@babel/core@7.20.5):
     resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
     engines: {node: '>=6.9.0'}
@@ -1744,6 +1787,20 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@babel/preset-typescript@7.18.6(@babel/core@7.22.11):
+    resolution: {integrity: sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.11
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.22.5
+      '@babel/plugin-transform-typescript': 7.20.2(@babel/core@7.22.11)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@babel/runtime@7.20.6:
     resolution: {integrity: sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==}
@@ -3927,6 +3984,15 @@ packages:
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.3
 
+  /@types/babel__core@7.20.5:
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+    dependencies:
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
+      '@types/babel__generator': 7.6.4
+      '@types/babel__template': 7.4.1
+      '@types/babel__traverse': 7.18.3
+
   /@types/babel__generator@7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
@@ -4103,6 +4169,10 @@ packages:
     resolution: {integrity: sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==}
     dependencies:
       '@types/unist': 2.0.6
+    dev: true
+
+  /@types/memoizee@0.4.11:
+    resolution: {integrity: sha512-2gyorIBZu8GoDr9pYjROkxWWcFtHCquF7TVbN2I+/OvgZhnIGQS0vX5KJz4lXNKb8XOSfxFOSG5OLru1ESqLUg==}
     dev: true
 
   /@types/minimatch@3.0.5:
@@ -4979,7 +5049,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.11
       '@jest/transform': 29.7.0
-      '@types/babel__core': 7.1.20
+      '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 29.6.3(@babel/core@7.22.11)
       chalk: 4.1.2
@@ -6166,6 +6236,13 @@ packages:
       stream-transform: 2.1.3
     dev: true
 
+  /d@1.0.1:
+    resolution: {integrity: sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==}
+    dependencies:
+      es5-ext: 0.10.62
+      type: 1.2.0
+    dev: false
+
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
     dev: true
@@ -6775,6 +6852,24 @@ packages:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
+  /es5-ext@0.10.62:
+    resolution: {integrity: sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==}
+    engines: {node: '>=0.10'}
+    requiresBuild: true
+    dependencies:
+      es6-iterator: 2.0.3
+      es6-symbol: 3.1.3
+      next-tick: 1.1.0
+    dev: false
+
+  /es6-iterator@2.0.3:
+    resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
+    dependencies:
+      d: 1.0.1
+      es5-ext: 0.10.62
+      es6-symbol: 3.1.3
+    dev: false
+
   /es6-promise@4.2.8:
     resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
     dev: false
@@ -6783,6 +6878,22 @@ packages:
     resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
     dependencies:
       es6-promise: 4.2.8
+    dev: false
+
+  /es6-symbol@3.1.3:
+    resolution: {integrity: sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==}
+    dependencies:
+      d: 1.0.1
+      ext: 1.7.0
+    dev: false
+
+  /es6-weak-map@2.0.3:
+    resolution: {integrity: sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==}
+    dependencies:
+      d: 1.0.1
+      es5-ext: 0.10.62
+      es6-iterator: 2.0.3
+      es6-symbol: 3.1.3
     dev: false
 
   /escalade@3.1.1:
@@ -7446,6 +7557,13 @@ packages:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
 
+  /event-emitter@0.3.5:
+    resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
+    dependencies:
+      d: 1.0.1
+      es5-ext: 0.10.62
+    dev: false
+
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -7503,6 +7621,12 @@ packages:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+
+  /ext@1.7.0:
+    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
+    dependencies:
+      type: 2.7.2
+    dev: false
 
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -9044,6 +9168,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /is-promise@2.2.2:
+    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
+    dev: false
+
   /is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
@@ -10214,6 +10342,12 @@ packages:
     resolution: {integrity: sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==}
     engines: {node: '>=12'}
 
+  /lru-queue@0.1.0:
+    resolution: {integrity: sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==}
+    dependencies:
+      es5-ext: 0.10.62
+    dev: false
+
   /lru_map@0.3.3:
     resolution: {integrity: sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==}
 
@@ -10450,6 +10584,19 @@ packages:
       vinyl: 2.2.1
       vinyl-file: 3.0.0
     dev: true
+
+  /memoizee@0.4.15:
+    resolution: {integrity: sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==}
+    dependencies:
+      d: 1.0.1
+      es5-ext: 0.10.62
+      es6-weak-map: 2.0.3
+      event-emitter: 0.3.5
+      is-promise: 2.2.2
+      lru-queue: 0.1.0
+      next-tick: 1.1.0
+      timers-ext: 0.1.7
+    dev: false
 
   /memory-fs@0.3.0:
     resolution: {integrity: sha512-QTNXnl79X97kZ9jJk/meJrtDuvgvRakX5LU7HZW1L7MsXHuSTwoMIzN9tOLLH3Xfsj/gbsSqX/ovnsqz246zKQ==}
@@ -11178,6 +11325,10 @@ packages:
 
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  /next-tick@1.1.0:
+    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
+    dev: false
 
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -13560,6 +13711,13 @@ packages:
       retimer: 3.0.0
     dev: false
 
+  /timers-ext@0.1.7:
+    resolution: {integrity: sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==}
+    dependencies:
+      es5-ext: 0.10.62
+      next-tick: 1.1.0
+    dev: false
+
   /tiny-glob@0.2.9:
     resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
     dependencies:
@@ -13836,6 +13994,14 @@ packages:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
     dev: true
+
+  /type@1.2.0:
+    resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==}
+    dev: false
+
+  /type@2.7.2:
+    resolution: {integrity: sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==}
+    dev: false
 
   /typechain@8.1.1(jest@29.7.0)(typescript@5.0.4):
     resolution: {integrity: sha512-uF/sUvnXTOVF2FHKhQYnxHk4su4JjZR8vr4mA2mBaRwHTbwh0jIlqARz9XJr1tA0l7afJGvEa1dTSi4zt039LQ==}


### PR DESCRIPTION
Uses `Babel` to load the file's AST then finds all the exported functions and then matches them against the `eventHandler` we have. We `memoize` the calls to generate the Babel AST and even reading the `file` using the `filename` since for a file at a given path contents and AST will stay the same during execution of `build` which keeps this validation not very expensive on compute.


Example when the handler does not exist:

![CleanShot 2023-12-07 at 17 16 45](https://github.com/graphprotocol/graph-tooling/assets/44710980/efcea66d-de8f-4353-956c-97e7530738d4)


closes https://github.com/graphprotocol/graph-tooling/issues/1475
closes https://github.com/graphprotocol/graph-tooling/issues/1469
