### PR TITLE
cli: Skip validations for aggregations

### DIFF
--- a/.changeset/spotty-clocks-agree.md
+++ b/.changeset/spotty-clocks-agree.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': minor
+---
+
+Make validations more lenient to allow aggregations and Int8 ids

--- a/packages/cli/src/validation/schema.ts
+++ b/packages/cli/src/validation/schema.ts
@@ -83,13 +83,15 @@ const parseSchema = (doc: string) => {
 
 const validateEntityDirective = (def: any) => {
   validateDebugger('Validating entity directive for %s', def?.name?.value);
-  return def.directives.find((directive: any) => directive.name.value === 'entity')
+  return def.directives.find(
+    (directive: any) => directive.name.value === 'entity' || directive.name.value === 'aggregation',
+  )
     ? List()
     : immutable.fromJS([
         {
           loc: def.loc,
           entity: def.name.value,
-          message: `Defined without @entity directive`,
+          message: `Defined without @entity or @aggregation directive`,
         },
       ]);
 };
@@ -114,7 +116,8 @@ const validateEntityID = (def: any) => {
     idField.type.type.kind === 'NamedType' &&
     (idField.type.type.name.value === 'ID' ||
       idField.type.type.name.value === 'Bytes' ||
-      idField.type.type.name.value === 'String')
+      idField.type.type.name.value === 'String' ||
+      idField.type.type.name.value === 'Int8')
   ) {
     validateDebugger('Entity %s has valid id field', def?.name?.value);
     return List();
@@ -125,7 +128,7 @@ const validateEntityID = (def: any) => {
     {
       loc: idField.loc,
       entity: def.name.value,
-      message: `Field 'id': Entity ids must be of type Bytes! or String!`,
+      message: `Field 'id': Entity ids must be of type Int8!, Bytes! or String!`,
     },
   ]);
 };


### PR DESCRIPTION
This is a placeholder that simply allows `@aggregation` annotation. The real change should come from using `graph-node`'s validation functionality.