### PR TITLE
updating readme to proper deploy command

### DIFF
--- a/examples/substreams-powered-subgraph/README.md
+++ b/examples/substreams-powered-subgraph/README.md
@@ -15,5 +15,5 @@ This
 yarn install # install graph-cli
 yarn substreams:prepare # build and package the substreams module
 yarn subgraph:build # build the subgraph
-yarn subgraph:deploy # deploy the subgraph
+yarn deploy # deploy the subgraph
 ```


### PR DESCRIPTION
yarn command changed to `yarn deploy` fixing readme.