### PR TITLE
Allow declared calls in the manifest

### DIFF
--- a/.changeset/green-worms-rule.md
+++ b/.changeset/green-worms-rule.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Accept declared calls in subgraph manifests

--- a/packages/cli/src/protocols/ethereum/manifest.graphql
+++ b/packages/cli/src/protocols/ethereum/manifest.graphql
@@ -100,6 +100,8 @@ type ContractEventHandler {
   topic3: [String]
   handler: String!
   receipt: Boolean
+  # This should really be just a Map<String, String>
+  calls: JSON
 }
 
 type Graft {


### PR DESCRIPTION
This change is to enable the new 'declared calls' feature (PR [here](https://github.com/graphprotocol/graph-node/pull/5264)) The exact docs of what is needed are [here](https://github.com/graphprotocol/graph-node/pull/5264)