### PR TITLE
Feature | Order list of EVM chains in `graph init` command

### DIFF
--- a/.changeset/early-walls-talk.md
+++ b/.changeset/early-walls-talk.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Order list of evm chains in graph init command

--- a/packages/cli/src/command-helpers/sort.test.ts
+++ b/packages/cli/src/command-helpers/sort.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { sortWithPriority } from './sort';  // adjust the import based on your file structure
+
+describe('sortWithPriority', () => {
+  it('should sort numbers with specific priority elements', () => {
+    const numbers = [5, 3, 9, 1, 4];
+    const priorityNumbers = [9, 1];
+    const result = sortWithPriority(numbers, priorityNumbers);
+    expect(result).toEqual([1, 9, 3, 4, 5]);
+  });
+
+  it('should default sort numbers if no priority specifier', () => {
+    const numbers = [5, 3, 9, 1, 4];
+    const result = sortWithPriority(numbers);
+    expect(result).toEqual([1, 3, 4, 5, 9]);
+  });
+
+  it('should sort strings with priority determined by a function', () => {
+    const fruits = ['apple', 'orange', 'banana', 'mango', 'kiwi', 'melon'];
+    const sortedFruits = sortWithPriority(fruits, fruit => fruit.startsWith('m'));
+    expect(sortedFruits).toEqual(['mango', 'melon', 'apple', 'banana', 'kiwi', 'orange']);
+  });
+
+  it('should handle an empty array', () => {
+    const emptyArray: never[] = [];
+    const result = sortWithPriority(emptyArray, (x) => x > 3);
+    expect(result).toEqual([]);
+  });
+
+  it('should sort using a custom compare function', () => {
+    const numbers = [5, 3, 9, 1, 4];
+    const priorityNumbers = [9, 1];
+    const result = sortWithPriority(numbers, priorityNumbers, (a, b) => a - b);
+    expect(result).toEqual([1, 9, 3, 4, 5]);
+  });
+});

--- a/packages/cli/src/command-helpers/sort.ts
+++ b/packages/cli/src/command-helpers/sort.ts
@@ -1,7 +1,7 @@
 /**
  * Sorts an array with specified elements given priority.
- * Elements can be prioritized through a predicate function or by explicitly specifying them as an array.
- * If no compare function is provided, default JS sorting behaviour prevails (ascending order).
+ * Use a predicate function, or provide an array to prioritise elements.
+ * If no compare function is provided, default JS sorting (ascending) behaviour prevails.
  *
  * @param {T[]} array - The array to be sorted.
  * @param {((element: T) => boolean) | T[]} prioritySpecifier - A function that returns true if an element should be prioritized, or an array of elements to be prioritized.

--- a/packages/cli/src/command-helpers/sort.ts
+++ b/packages/cli/src/command-helpers/sort.ts
@@ -3,7 +3,6 @@
  * Elements can be prioritized through a predicate function or by explicitly specifying them as an array.
  * If no compare function is provided, default JS sorting behaviour prevails (ascending order).
  *
- * @template T The type of elements in the array.
  * @param {T[]} array - The array to be sorted.
  * @param {((element: T) => boolean) | T[]} prioritySpecifier - A function that returns true if an element should be prioritized, or an array of elements to be prioritized.
  * @param {(a: T, b: T) => number} [compareFunction] - An optional comparison function to sort the elements of the array. If omitted, the array is sorted in default order.

--- a/packages/cli/src/command-helpers/sort.ts
+++ b/packages/cli/src/command-helpers/sort.ts
@@ -1,0 +1,46 @@
+/**
+ * Sorts an array with specified elements given priority.
+ * Elements can be prioritized through a predicate function or by explicitly specifying them as an array.
+ * If no compare function is provided, default JS sorting behaviour prevails (ascending order).
+ *
+ * @template T The type of elements in the array.
+ * @param {T[]} array - The array to be sorted.
+ * @param {((element: T) => boolean) | T[]} prioritySpecifier - A function that returns true if an element should be prioritized, or an array of elements to be prioritized.
+ * @param {(a: T, b: T) => number} [compareFunction] - An optional comparison function to sort the elements of the array. If omitted, the array is sorted in default order.
+ * @returns {T[]} The sorted array with priority elements first.
+ *
+ * @example
+ * const numbers = [5, 3, 9, 1, 4];
+ * sortWithPriority(numbers, x => x > 5); // [9, 1, 3, 4, 5]
+ * sortWithPriority(numbers, [9, 1]); // [1, 9, 3, 4, 5]
+ */
+function sortWithPriority<T>(
+  array: T[],
+  prioritySpecifier?: ((element: T) => boolean) | T[],
+  compareFunction?: (a: T, b: T) => number
+): T[] {
+  // prioritySpecifier can be an array or a function so handle each case
+  let isPriorityElement: (element: T) => boolean;
+
+  if (Array.isArray(prioritySpecifier) || !prioritySpecifier) {
+    const prioritySet = new Set(prioritySpecifier ?? []);
+    isPriorityElement = (element: T) => prioritySet.has(element);
+  } else {
+    isPriorityElement = prioritySpecifier;
+  }
+
+  const priorityArray = array.filter(isPriorityElement);
+  const regularArray = array.filter(item => !isPriorityElement(item));
+
+  if (compareFunction) {
+    priorityArray.sort(compareFunction);
+    regularArray.sort(compareFunction);
+  } else {
+    priorityArray.sort();
+    regularArray.sort();
+  }
+
+  return priorityArray.concat(regularArray);
+}
+
+export { sortWithPriority }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,17 +1,18 @@
+import { Args, Command, Flags, ux } from '@oclif/core';
 import fs from 'fs';
+import * as toolbox from 'gluegun';
+import { filesystem, prompt, system } from 'gluegun';
 import os from 'os';
 import path from 'path';
-import { filesystem, prompt, system } from 'gluegun';
-import * as toolbox from 'gluegun';
-import { Args, Command, Flags, ux } from '@oclif/core';
 import {
   loadAbiFromBlockScout,
   loadAbiFromEtherscan,
   loadStartBlockForContract,
 } from '../command-helpers/abi';
 import { initNetworksConfig } from '../command-helpers/network';
-import { chooseNodeUrl, SUBGRAPH_STUDIO_URL } from '../command-helpers/node';
+import { SUBGRAPH_STUDIO_URL, chooseNodeUrl } from '../command-helpers/node';
 import { generateScaffold, writeScaffold } from '../command-helpers/scaffold';
+import { sortWithPriority } from '../command-helpers/sort';
 import { withSpinner } from '../command-helpers/spinner';
 import { getSubgraphBasename, validateSubgraphName } from '../command-helpers/subgraph';
 import { GRAPH_CLI_SHARED_HEADERS } from '../constants';

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -631,7 +631,7 @@ async function processInitForm(
       },
     ]);
 
-    const choices = (await AVAILABLE_NETWORKS())?.[
+    let choices = (await AVAILABLE_NETWORKS())?.[
       product === 'subgraph-studio' ? 'studio' : 'hostedService'
     ];
 
@@ -641,6 +641,8 @@ async function processInitForm(
         { exit: 1 },
       );
     }
+
+    choices = sortWithPriority(choices, ['mainnet'])
 
     const { network } = await prompt.ask<{ network: string }>([
       {


### PR DESCRIPTION
## Change Description
When running `graph init ` to initialise an EVM subgraph, sort the list of possible networks as follows:
1. Ethereum mainnet
2. Rest, alphabetically ordered

## Related Issue / Discussion
https://github.com/graphprotocol/graph-tooling/issues/1618
https://github.com/graphprotocol/graph-tooling/discussions/1616

## Screenshot of change
![image](https://github.com/graphprotocol/graph-tooling/assets/31418899/1e42dccf-d5e3-4868-b12f-2ec9e995070f)
