### PR TITLE
etherscan api & public rpc url added for amoy,chiado,mode networks

### DIFF
--- a/.changeset/friendly-lamps-help.md
+++ b/.changeset/friendly-lamps-help.md
@@ -1,0 +1,6 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Added Etherscan like API url and Public RPC endpoints for Polygon Amoy,Gnosis Chiado,Mode Mainnet,
+Mode Sepolia chains for fetching startBlock and ABI

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -237,6 +237,14 @@ const getEtherscanLikeAPIUrl = (network: string) => {
       return `https://api.routescan.io/v2/network/mainnet/evm/81457/etherscan/api`;
     case 'etherlink-testnet':
       return `https://testnet-explorer.etherlink.com/api`;
+    case 'polygon-amoy':
+      return `https://api-amoy.polygonscan.com/api`
+    case 'gnosis-chiado':
+      return `https://gnosis-chiado.blockscout.com/api`
+    case 'mode-mainnet':
+      return `https://explorer.mode.network/api`
+    case 'mode-sepolia':
+      return `https://sepolia.explorer.mode.network/api`
     default:
       return `https://api-${network}.etherscan.io/api`;
   }
@@ -333,6 +341,14 @@ const getPublicRPCEndpoint = (network: string) => {
       return 'https://sepolia.optimism.io';
     case 'etherlink-testnet':
       return `https://node.ghostnet.etherlink.com`;
+    case 'polygon-amoy':
+      return `https://rpc-amoy.polygon.technology`;
+    case 'gnosis-chiado':
+      return `https://rpc.chiadochain.net`
+    case 'mode-mainnet':
+      return `https://mainnet.mode.network`
+    case 'mode-sepolia':
+      return `https://sepolia.mode.network`
     default:
       throw new Error(`Unknown network: ${network}`);
   }

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -238,13 +238,13 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'etherlink-testnet':
       return `https://testnet-explorer.etherlink.com/api`;
     case 'polygon-amoy':
-      return `https://api-amoy.polygonscan.com/api`
+      return `https://api-amoy.polygonscan.com/api`;
     case 'gnosis-chiado':
-      return `https://gnosis-chiado.blockscout.com/api`
+      return `https://gnosis-chiado.blockscout.com/api`;
     case 'mode-mainnet':
-      return `https://explorer.mode.network/api`
+      return `https://explorer.mode.network/api`;
     case 'mode-sepolia':
-      return `https://sepolia.explorer.mode.network/api`
+      return `https://sepolia.explorer.mode.network/api`;
     default:
       return `https://api-${network}.etherscan.io/api`;
   }
@@ -344,11 +344,11 @@ const getPublicRPCEndpoint = (network: string) => {
     case 'polygon-amoy':
       return `https://rpc-amoy.polygon.technology`;
     case 'gnosis-chiado':
-      return `https://rpc.chiadochain.net`
+      return `https://rpc.chiadochain.net`;
     case 'mode-mainnet':
-      return `https://mainnet.mode.network`
+      return `https://mainnet.mode.network`;
     case 'mode-sepolia':
-      return `https://sepolia.mode.network`
+      return `https://sepolia.mode.network`;
     default:
       throw new Error(`Unknown network: ${network}`);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,10 +47,10 @@ importers:
   examples/arweave-blocks-transactions:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.69.2
+        specifier: 0.70.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: 0.34.0
+        specifier: 0.35.0
         version: link:../../packages/ts
 
   examples/cosmos-block-filtering:
@@ -63,10 +63,10 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.69.2
+        specifier: 0.70.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: 0.34.0
+        specifier: 0.35.0
         version: link:../../packages/ts
       mustache:
         specifier: ^4.2.0
@@ -82,10 +82,10 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.69.2
+        specifier: 0.70.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: 0.34.0
+        specifier: 0.35.0
         version: link:../../packages/ts
 
   examples/cosmos-validator-delegations:
@@ -101,10 +101,10 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.69.2
+        specifier: 0.70.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: 0.34.0
+        specifier: 0.35.0
         version: link:../../packages/ts
       mustache:
         specifier: ^4.2.0
@@ -120,10 +120,10 @@ importers:
         version: 6.26.0
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.69.2
+        specifier: 0.70.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: 0.34.0
+        specifier: 0.35.0
         version: link:../../packages/ts
       mustache:
         specifier: ^4.2.0
@@ -172,10 +172,10 @@ importers:
         version: 5.0.4
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.69.2
+        specifier: 0.70.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: 0.34.0
+        specifier: 0.35.0
         version: link:../../packages/ts
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^2.0.2
@@ -190,10 +190,10 @@ importers:
   examples/ethereum-gravatar:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.69.2
+        specifier: 0.70.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: 0.34.0
+        specifier: 0.35.0
         version: link:../../packages/ts
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^2.0.2
@@ -205,16 +205,16 @@ importers:
   examples/example-subgraph:
     devDependencies:
       '@graphprotocol/graph-ts':
-        specifier: 0.34.0
+        specifier: 0.35.0
         version: link:../../packages/ts
 
   examples/matic-lens-protocol-posts-subgraph:
     dependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.69.2
+        specifier: 0.70.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: 0.34.0
+        specifier: 0.35.0
         version: link:../../packages/ts
     devDependencies:
       matchstick-as:
@@ -224,25 +224,25 @@ importers:
   examples/near-blocks:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.69.2
+        specifier: 0.70.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: 0.34.0
+        specifier: 0.35.0
         version: link:../../packages/ts
 
   examples/near-receipts:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.69.2
+        specifier: 0.70.0
         version: link:../../packages/cli
       '@graphprotocol/graph-ts':
-        specifier: 0.34.0
+        specifier: 0.35.0
         version: link:../../packages/ts
 
   examples/substreams-powered-subgraph:
     devDependencies:
       '@graphprotocol/graph-cli':
-        specifier: 0.69.2
+        specifier: 0.70.0
         version: link:../../packages/cli
 
   packages/cli:


### PR DESCRIPTION
Added Etherscan like API url and Public RPC endpoints for the following chains for fetching `startBlock` and `ABI`

- Polygon Amoy
- Gnosis Chiado
- Mode Mainnet
- Mode Sepolia