### PR TITLE
Fix bug in `graph auth`

### DIFF
--- a/.changeset/six-moles-appear.md
+++ b/.changeset/six-moles-appear.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+fix graph auth

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -57,9 +57,6 @@ export default class AuthCommand extends Command {
         required: true,
       }));
 
-    // Poor var naming will cleanup later
-    ({ node } = chooseNodeUrl({ product: node, studio: false }));
-
     // eslint-disable-next-line -- prettier has problems with ||=
     deployKey =
       deployKey ||


### PR DESCRIPTION
before:

```
    Error: Error storing deploy key: Invalid URL
```

after:

```
Deploy key set for https://api.studio.thegraph.com/deploy/
```