### PR TITLE
cli: Fix build files being placed outside the build directory

### DIFF
--- a/.changeset/proud-zebras-report.md
+++ b/.changeset/proud-zebras-report.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Fix build files being placed outside the build directory

--- a/packages/cli/src/compiler/index.ts
+++ b/packages/cli/src/compiler/index.ts
@@ -231,8 +231,8 @@ export default class Compiler {
     spinner: Spinner,
   ) {
     const absoluteSourceFile = path.resolve(sourceDir, maybeRelativeFile);
-    const relativeSourceFile = path.relative(sourceDir, absoluteSourceFile);
-    const targetFile = path.join(targetDir, relativeSourceFile);
+    const baseName = path.basename(absoluteSourceFile);
+    const targetFile = path.join(targetDir, baseName);
     step(spinner, 'Write subgraph file', this.displayPath(targetFile));
     fs.mkdirsSync(path.dirname(targetFile));
     fs.writeFileSync(targetFile, data);


### PR DESCRIPTION
## Problem

When running `build`, output files can be generated outside of the build folder if the relative paths in the manifest file are prefixed by two or more parent paths (i.e. `../`). For example, if the manifest file contains this:
```
abis:
  - name: ERC20
  file: ../../subgraph-core/abis/ERC20.json
```

The file creation during the `build` process will end up like this (incorrect!):
```
project/
├── build/
│   └── DataSource/
│       └── DataSource.wasm
└── subgraph-core/
    └── abis/
        └── ERC20.json
```

Note that even when a single parent path is used, the copied files will still appear outside of their respective data sources (though still within the `build` folder).

## Proposed Solution

When copying abi files into the build folder, use only the base file name. This will prevent the above effect of using relative paths and ensure all build files stay inside the build folder.

With this change, the new output structure for the same scenario would be:
```
project/
├── build/
│   └── DataSource/
│       ├── DataSource.wasm/
│       └── ERC20.json

```