### PR TITLE
fix: allow publishing without forcing network selection

### DIFF
--- a/.changeset/strong-camels-obey.md
+++ b/.changeset/strong-camels-obey.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Allow publishing without forcing network or subgraph id

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -31,7 +31,6 @@ export default class PublishCommand extends Command {
       options: ['arbitrum-one', 'arbitrum-sepolia'],
       default: 'arbitrum-one',
       required: false,
-      dependsOn: ['subgraph-id'],
     }),
     ipfs: Flags.string({
       summary: 'Upload build results to an IPFS node.',


### PR DESCRIPTION
Some weird reason `dependsOn` in OClif isn't working well it is messing things. So removing for now.

