### PR TITLE
replace Etherscan endpoints with proxies

### DIFF
--- a/.changeset/mean-eyes-report.md
+++ b/.changeset/mean-eyes-report.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': minor
+---
+
+replace etherscan endpoints

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ oclif.manifest.json
 tmp
 
 *.wasm
+
+.idea

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -317,7 +317,7 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'neox-testnet':
       return 'https://xt4scan.ngd.network/api/ngd/api';
     case 'arbitrum-nova':
-      return 'https://arbitrum-nova.pinax.network/api';
+      return 'https://arbitrum-nova.abi.pinax.network/api';
     case 'soneium-testnet':
       return 'https://explorer-testnet.soneium.org/api';
     case 'chiliz':

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -243,9 +243,9 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'fuji':
       return `https://api-testnet.snowtrace.io/api`;
     case 'celo':
-      return `https://api.celoscan.io/api`;
+      return `https://celo.abi.pinax.network/api`;
     case 'celo-alfajores':
-      return `https://api-alfajores.celoscan.io/api`;
+      return `https://celo-alfajores.abi.pinax.network/api`;
     case 'gnosis':
       return `https://api.gnosisscan.io/api`;
     case 'fantom':

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -221,9 +221,9 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'chapel':
       return `https://api-testnet.bscscan.com/api`;
     case 'matic':
-      return `https://api.polygonscan.com/api`;
+      return `https://polygon.abi.pinax.network/api`;
     case 'mumbai':
-      return `https://api-testnet.polygonscan.com/api`;
+      return `https://polygon-mumbai.abi.pinax.network/api`;
     case 'aurora':
       return `https://explorer.mainnet.aurora.dev/api`;
     case 'aurora-testnet':
@@ -259,9 +259,9 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'zksync-era-sepolia':
       return 'https://block-explorer-api.sepolia.zksync.dev/api';
     case 'polygon-zkevm-testnet':
-      return `https://testnet-zkevm.polygonscan.com/api`;
+      return `https://polygon-zkevm-testnet.abi.pinax.network/api`;
     case 'polygon-zkevm':
-      return `https://api-zkevm.polygonscan.com/api`;
+      return `https://polygon-zkevm.abi.pinax.network/api`;
     case 'sepolia':
       return `https://sepolia.abi.pinax.network/api`;
     case 'scroll-sepolia':
@@ -283,7 +283,7 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'etherlink-testnet':
       return `https://testnet-explorer.etherlink.com/api`;
     case 'polygon-amoy':
-      return `https://api-amoy.polygonscan.com/api`;
+      return `https://polygon-amoy.abi.pinax.network/api`;
     case 'gnosis-chiado':
       return `https://gnosis-chiado.blockscout.com/api`;
     case 'mode-mainnet':
@@ -295,7 +295,7 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'astar-zkevm-mainnet':
       return `https://astar-zkevm.explorer.startale.com/api`;
     case 'polygon-zkevm-cardona':
-      return `https://api-cardona-zkevm.polygonscan.com/api`;
+      return `https://polygon-zkevm-cardona.abi.pinax.network/api`;
     case 'sei-mainnet':
       return `https://seitrace.com/pacific-1/api`;
     case 'sei-atlantic':

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -211,7 +211,7 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'arbitrum-sepolia':
       return `https://arbitrum-sepolia.pinax.network/api`;
     case 'bsc':
-      return `https://api.bscscan.com/api`;
+      return `https://bsc.abi.pinax.network/api`;
     case 'base-testnet':
       return `https://api-goerli.basescan.org/api`;
     case 'base-sepolia':
@@ -219,7 +219,7 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'base':
       return `https://api.basescan.org/api`;
     case 'chapel':
-      return `https://api-testnet.bscscan.com/api`;
+      return `https://bsc-testnet.abi.pinax.network/api`;
     case 'matic':
       return `https://polygon.abi.pinax.network/api`;
     case 'mumbai':
@@ -277,9 +277,9 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'linea-goerli':
       return `https://api.linea-goerli.build/api`;
     case 'blast-testnet':
-      return `https://api-sepolia.blastscan.io/api`;
+      return `https://blast-testnet.abi.pinax.network/api`;
     case 'blast-mainnet':
-      return `https://api.blastscan.io/api`;
+      return `https://blast.abi.pinax.network/api`;
     case 'etherlink-testnet':
       return `https://testnet-explorer.etherlink.com/api`;
     case 'polygon-amoy':

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -203,7 +203,7 @@ export const loadAbiFromBlockScout = async (
 const getEtherscanLikeAPIUrl = (network: string) => {
   switch (network) {
     case 'mainnet':
-      return `https://api.etherscan.io/api`;
+      return `https://mainnet.abi.pinax.network/api`;
     case 'arbitrum-one':
       return `https://api.arbiscan.io/api`;
     case 'arbitrum-goerli':
@@ -231,7 +231,7 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'optimism-goerli':
       return `https://api-goerli-optimistic.etherscan.io/api`;
     case 'optimism':
-      return `https://api-optimistic.etherscan.io/api`;
+      return `https://optimism.abi.pinax.network/api`;
     case 'moonbeam':
       return `https://api-moonbeam.moonscan.io/api`;
     case 'moonriver':
@@ -263,11 +263,11 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'polygon-zkevm':
       return `https://api-zkevm.polygonscan.com/api`;
     case 'sepolia':
-      return `https://api-sepolia.etherscan.io/api`;
+      return `https://sepolia.abi.pinax.network/api`;
     case 'scroll-sepolia':
       return `https://api-sepolia.scrollscan.dev/api`;
     case 'optimism-sepolia':
-      return `https://api-sepolia-optimistic.etherscan.io/api`;
+      return `https://optimism-sepolia.abi.pinax.network/api`;
     case 'scroll':
       return `https://api.scrollscan.com/api`;
     case 'linea':

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -259,7 +259,7 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'zksync-era-sepolia':
       return 'https://block-explorer-api.sepolia.zksync.dev/api';
     case 'polygon-zkevm-testnet':
-      return `https://polygon-zkevm-testnet.abi.pinax.network/api`;
+      return `https://testnet-zkevm.polygonscan.com/api`;
     case 'polygon-zkevm':
       return `https://polygon-zkevm.abi.pinax.network/api`;
     case 'sepolia':

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -205,19 +205,19 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'mainnet':
       return `https://mainnet.abi.pinax.network/api`;
     case 'arbitrum-one':
-      return `https://arbitrum-one.pinax.network/api`;
+      return `https://arbitrum-one.abi.pinax.network/api`;
     case 'arbitrum-goerli':
       return `https://api-goerli.arbiscan.io/api`;
     case 'arbitrum-sepolia':
-      return `https://arbitrum-sepolia.pinax.network/api`;
+      return `https://arbitrum-sepolia.abi.pinax.network/api`;
     case 'bsc':
       return `https://bsc.abi.pinax.network/api`;
     case 'base-testnet':
       return `https://api-goerli.basescan.org/api`;
     case 'base-sepolia':
-      return `https://api-sepolia.basescan.org/api`;
+      return `https://base-sepolia.abi.pinax.network/api`;
     case 'base':
-      return `https://api.basescan.org/api`;
+      return `https://base.abi.pinax.network/api`;
     case 'chapel':
       return `https://bsc-testnet.abi.pinax.network/api`;
     case 'matic':

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -247,7 +247,7 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'celo-alfajores':
       return `https://celo-alfajores.abi.pinax.network/api`;
     case 'gnosis':
-      return `https://api.gnosisscan.io/api`;
+      return `https://gnosis.abi.pinax.network/api`;
     case 'fantom':
       return `https://api.ftmscan.com/api`;
     case 'fantom-testnet':

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -235,7 +235,7 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'moonbeam':
       return `https://moonbeam.abi.pinax.network/api`;
     case 'moonriver':
-      return `https://moonriver.abi.pinax.network/api`;
+      return `https://api-moonriver.moonscan.io/api`;
     case 'mbase':
       return `https://moonbase.abi.pinax.network/api`;
     case 'avalanche':
@@ -249,9 +249,9 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'gnosis':
       return `https://gnosis.abi.pinax.network/api`;
     case 'fantom':
-      return `https://api.ftmscan.com/api`;
+      return `https://fantom.abi.pinax.network/api`;
     case 'fantom-testnet':
-      return `https://api-testnet.ftmscan.com/api`;
+      return `https://fantom-testnet.abi.pinax.network/api`;
     case 'zksync-era':
       return `https://block-explorer-api.mainnet.zksync.io/api`;
     case 'zksync-era-testnet':

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -271,9 +271,9 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'scroll':
       return `https://api.scrollscan.com/api`;
     case 'linea':
-      return `https://api.lineascan.build/api`;
+      return `https://linea.abi.pinax.network/api`;
     case 'linea-sepolia':
-      return 'https://api-sepolia.lineascan.build/api';
+      return 'https://linea-sepolia.abi.pinax.network/api';
     case 'linea-goerli':
       return `https://api.linea-goerli.build/api`;
     case 'blast-testnet':

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -233,11 +233,11 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'optimism':
       return `https://optimism.abi.pinax.network/api`;
     case 'moonbeam':
-      return `https://api-moonbeam.moonscan.io/api`;
+      return `https://moonbeam.abi.pinax.network/api`;
     case 'moonriver':
-      return `https://api-moonriver.moonscan.io/api`;
+      return `https://moonriver.abi.pinax.network/api`;
     case 'mbase':
-      return `https://api-moonbase.moonscan.io/api`;
+      return `https://moonbase.abi.pinax.network/api`;
     case 'avalanche':
       return `https://api.snowtrace.io/api`;
     case 'fuji':

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -205,11 +205,11 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'mainnet':
       return `https://mainnet.abi.pinax.network/api`;
     case 'arbitrum-one':
-      return `https://api.arbiscan.io/api`;
+      return `https://arbitrum-one.pinax.network/api`;
     case 'arbitrum-goerli':
       return `https://api-goerli.arbiscan.io/api`;
     case 'arbitrum-sepolia':
-      return `https://api-sepolia.arbiscan.io/api`;
+      return `https://arbitrum-sepolia.pinax.network/api`;
     case 'bsc':
       return `https://api.bscscan.com/api`;
     case 'base-testnet':
@@ -317,7 +317,7 @@ const getEtherscanLikeAPIUrl = (network: string) => {
     case 'neox-testnet':
       return 'https://xt4scan.ngd.network/api/ngd/api';
     case 'arbitrum-nova':
-      return 'https://api-nova.arbiscan.io/api';
+      return 'https://arbitrum-nova.pinax.network/api';
     case 'soneium-testnet':
       return 'https://explorer-testnet.soneium.org/api';
     case 'chiliz':


### PR DESCRIPTION
This replaces the Etherscan endpoints with a Pinax proxies until a new logic is implemented to fetch ABIs from another source. 