### PR TITLE
Add prompt for existing directory in `init` flow

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -634,12 +634,17 @@ async function processInitForm(
         name: 'directory',
         message: 'Directory to create the subgraph in',
         initial: () => initDirectory || getSubgraphBasename(subgraphName),
-        validate: value =>
-          filesystem.exists(value || initDirectory || getSubgraphBasename(subgraphName))
-            ? 'Directory already exists'
-            : true,
       },
     ]);
+
+    if (
+      filesystem.exists(directory) &&
+      !(await prompt.confirm(
+        'Directory already exists, do you want to initialize the subgraph here ?',
+        false,
+      ))
+    )
+      return;
 
     let choices = (await AVAILABLE_NETWORKS())?.[
       product === 'subgraph-studio' ? 'studio' : 'hostedService'


### PR DESCRIPTION
If the user is choosing an existing directory for creating a new subgraph, ask for confirmation.
If the answer is negative, abort the process.

Closes #1370