### PR TITLE
Fix `graph add` Etherscan lookups when using `localhost` network

### DIFF
--- a/.changeset/cold-snails-bake.md
+++ b/.changeset/cold-snails-bake.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Using `graph add` with `localhost` network now prompts the user for input


### PR DESCRIPTION
The command will now skip Etherscan lookups if detecting the network as `localhost`. User will be prompted to enter all relevant information.

### Before

![screenshot_2024-10-30_17-21-50](https://github.com/user-attachments/assets/f6bb4931-280a-45b9-8c83-f59e137fd213)

### After

![screenshot_2024-10-30_17-20-54](https://github.com/user-attachments/assets/ef2f7114-fb70-4515-aae4-aa9f2c01445e)

Closes #1748