### PR TITLE
Refactor debug log for failed Etherscan ABI lookups

### DIFF
--- a/.changeset/nervous-grapes-mix.md
+++ b/.changeset/nervous-grapes-mix.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Refactor debug log for failed Etherscan ABI lookups


### PR DESCRIPTION
Help debugging when Etherscan ABI lookups fail.

## Before

```
DEBUG=* graph init
```

No useful message, even with `DEBUG` on.
![screenshot_2024-11-05_13-52-25](https://github.com/user-attachments/assets/f45476b0-729d-4def-a6a8-7983873b73cc)

## After

```
DEBUG=* graph init
```

Error shows what when wrong when fetching contract's ABI.
![screenshot_2024-11-05_15-09-16](https://github.com/user-attachments/assets/2da0e7e3-670b-4ca2-90a9-d0b6d007e7f3)
