### PR TITLE
chore(rpcs): update gnosis chain RPC endpoint

### DIFF
--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -387,7 +387,7 @@ const getPublicRPCEndpoint = (network: string) => {
     case 'goerli':
       return 'https://rpc.ankr.com/eth_goerli';
     case 'gnosis':
-      return 'https://safe-transaction.gnosis.io';
+      return 'https://rpc.gnosischain.com';
     case 'mainnet':
       return 'https://rpc.ankr.com/eth';
     case 'matic':


### PR DESCRIPTION
https://safe-transaction.gnosis.io is not working. I suspect that's the issue which prevents `graph add` and `graph deploy`  