### PR TITLE
Improve ABI file path validation

### DIFF
--- a/.changeset/soft-scissors-help.md
+++ b/.changeset/soft-scissors-help.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Improve ABI file path validation

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -623,47 +623,34 @@ async function processInitForm(
         type: 'input',
         name: 'abi',
         message: 'ABI file (path)',
-        initial: initAbi,
+        initial: initAbiPath,
         skip: () =>
           !protocolInstance.hasABIs() ||
           initFromExample !== undefined ||
           abiFromEtherscan !== undefined ||
-          isSubstreams ||
-          !!initAbiPath,
+          isSubstreams,
         validate: async (value: string) => {
           if (initFromExample || abiFromEtherscan || !protocolInstance.hasABIs()) {
             return true;
           }
 
           const ABI = protocolInstance.getABI();
-          if (initAbiPath) {
-            try {
-              loadAbiFromFile(ABI, initAbiPath);
-              return true;
-            } catch (e) {
-              this.error(e.message);
-            }
-          }
+          if (initAbiPath) value = initAbiPath;
 
           try {
             loadAbiFromFile(ABI, value);
             return true;
           } catch (e) {
-            this.error(e.message);
+            return e.message;
           }
         },
         result: async (value: string) => {
           if (initFromExample || abiFromEtherscan || !protocolInstance.hasABIs()) {
             return null;
           }
+
           const ABI = protocolInstance.getABI();
-          if (initAbiPath) {
-            try {
-              return loadAbiFromFile(ABI, initAbiPath);
-            } catch (e) {
-              return e.message;
-            }
-          }
+          if (initAbiPath) value = initAbiPath;
 
           try {
             return loadAbiFromFile(ABI, value);

--- a/packages/cli/src/protocols/ethereum/abi.ts
+++ b/packages/cli/src/protocols/ethereum/abi.ts
@@ -141,7 +141,13 @@ export default class ABI {
   }
 
   static load(name: string, file: string) {
-    const data = JSON.parse(fs.readFileSync(file).toString());
+    let data;
+    try {
+      data = JSON.parse(fs.readFileSync(file).toString());
+    } catch (e) {
+      throw Error(`Could not parse ABI: ${e}`);
+    }
+
     const abi = ABI.normalized(data);
 
     if (abi === null || abi === undefined) {


### PR DESCRIPTION

![screenshot_2024-11-11_12-15-34](https://github.com/user-attachments/assets/c0f1487d-7651-4042-8d87-5c3790d62a66)

- Error message now shows within CLI interactive session instead of error crash
- Passing `--abi` will correctly pre-fill the interactive form
- Catch JSON parsing exception for `EthereumABI`.

Closes: #1765