### PR TITLE
Support parsing full path contract name from block explorers

### DIFF
--- a/.changeset/cyan-spoons-greet.md
+++ b/.changeset/cyan-spoons-greet.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Support parsing full path contract name from block explorers

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -151,7 +151,12 @@ export const getContractNameForAddress = async (
 ): Promise<string> => {
   try {
     const contractSourceCode = await fetchSourceCodeFromEtherscan(network, address);
-    const contractName = contractSourceCode.result[0].ContractName;
+    let contractName = contractSourceCode.result[0].ContractName;
+    // Some explorers will return the full path of the contract instead of just the name
+    const regex = /^contracts\/(?<contract>.+)\.sol:\1$/;
+
+    if (regex.test(contractName)) contractName = regex.exec(contractName)?.groups?.contract;
+
     logger('Successfully getContractNameForAddress. contractName: %s', contractName);
     return contractName;
   } catch (error) {

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -153,7 +153,7 @@ export const getContractNameForAddress = async (
     const contractSourceCode = await fetchSourceCodeFromEtherscan(network, address);
     let contractName = contractSourceCode.result[0].ContractName;
     // Some explorers will return the full path of the contract instead of just the name
-    const regex = /^contracts\/(?<contract>.+)\.sol:\1$/;
+    const regex = /(?<contract>.+)\.sol:\1$/;
 
     if (regex.test(contractName)) contractName = regex.exec(contractName)?.groups?.contract;
 

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -151,11 +151,12 @@ export const getContractNameForAddress = async (
 ): Promise<string> => {
   try {
     const contractSourceCode = await fetchSourceCodeFromEtherscan(network, address);
-    let contractName = contractSourceCode.result[0].ContractName;
-    // Some explorers will return the full path of the contract instead of just the name
-    const regex = /(?<contract>.+)\.sol:\1$/;
+    let contractName: string = contractSourceCode.result[0].ContractName;
 
-    if (regex.test(contractName)) contractName = regex.exec(contractName)?.groups?.contract;
+    // Some explorers will return the full path of the contract instead of just the name
+    // Example: contracts/SyncSwapRouter.sol:SyncSwapRouter
+    if (contractName.includes(':'))
+      contractName = contractName.substring(contractName.lastIndexOf(':') + 1);
 
     logger('Successfully getContractNameForAddress. contractName: %s', contractName);
     return contractName;


### PR DESCRIPTION
Some explorers like [ZkSync](https://block-explorer-api.mainnet.zksync.io/docs#/Contract%20API/ApiController_getContractSourceCode) will return the `ContractName` with a full path like so:
```json
{
  ...
  "ContractName": "contracts/SyncSwapRouter.sol:SyncSwapRouter",
  ...
}
```
This PR adds support for parsing the contract name for this format (e.g. `SyncSwapRouter`).