### PR TITLE
Add new chains: `abstract-testnet`, `corn` and `corn-testnet`

### DIFF
--- a/.changeset/swift-bottles-trade.md
+++ b/.changeset/swift-bottles-trade.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Add new chains: `abstract-testnet`, `corn` and `corn-testnet`

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -346,6 +346,12 @@ const getEtherscanLikeAPIUrl = (network: string) => {
       return 'https://unichain-sepolia.blockscout.com/api';
     case 'lens-testnet':
       return 'https://block-explorer-api.testnet.lens.dev/api';
+    case 'abstract-testnet':
+      return 'https://block-explorer-api.testnet.abs.xyz/api';
+    case 'corn':
+      return 'https://maizenet-explorer.usecorn.com/api';
+    case 'corn-testnet':
+      return 'https://testnet-explorer.usecorn.com/api';
     default:
       return `https://api-${network}.etherscan.io/api`;
   }
@@ -504,6 +510,12 @@ const getPublicRPCEndpoint = (network: string) => {
       return 'https://sepolia.unichain.org';
     case 'lens-testnet':
       return 'https://api.staging.lens.zksync.dev';
+    case 'abstract-testnet':
+      return 'https://api.testnet.abs.xyz';
+    case 'corn':
+      return 'https://maizenet-rpc.usecorn.com';
+      case 'corn-testnet':
+        return 'https://testnet-rpc.usecorn.com';
     default:
       throw new Error(`Unknown network: ${network}`);
   }

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -514,8 +514,8 @@ const getPublicRPCEndpoint = (network: string) => {
       return 'https://api.testnet.abs.xyz';
     case 'corn':
       return 'https://maizenet-rpc.usecorn.com';
-      case 'corn-testnet':
-        return 'https://testnet-rpc.usecorn.com';
+    case 'corn-testnet':
+      return 'https://testnet-rpc.usecorn.com';
     default:
       throw new Error(`Unknown network: ${network}`);
   }

--- a/packages/cli/src/command-helpers/abi.ts
+++ b/packages/cli/src/command-helpers/abi.ts
@@ -346,11 +346,11 @@ const getEtherscanLikeAPIUrl = (network: string) => {
       return 'https://unichain-sepolia.blockscout.com/api';
     case 'lens-testnet':
       return 'https://block-explorer-api.testnet.lens.dev/api';
-    case 'abstract-testnet':
+    case 'abstract-sepolia':
       return 'https://block-explorer-api.testnet.abs.xyz/api';
     case 'corn':
       return 'https://maizenet-explorer.usecorn.com/api';
-    case 'corn-testnet':
+    case 'corn-sepolia':
       return 'https://testnet-explorer.usecorn.com/api';
     default:
       return `https://api-${network}.etherscan.io/api`;
@@ -510,11 +510,11 @@ const getPublicRPCEndpoint = (network: string) => {
       return 'https://sepolia.unichain.org';
     case 'lens-testnet':
       return 'https://api.staging.lens.zksync.dev';
-    case 'abstract-testnet':
+    case 'abstract-sepolia':
       return 'https://api.testnet.abs.xyz';
     case 'corn':
       return 'https://maizenet-rpc.usecorn.com';
-    case 'corn-testnet':
+    case 'corn-sepolia':
       return 'https://testnet-rpc.usecorn.com';
     default:
       throw new Error(`Unknown network: ${network}`);


### PR DESCRIPTION
Re-open from #1772, some discussions still ongoing regarding chain names.
CC @YaroShkvorets