### PR TITLE
Fix `_id` field clash

### DIFF
--- a/.changeset/short-keys-boil.md
+++ b/.changeset/short-keys-boil.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+fix bug with clashing \_id field name in schema

--- a/packages/cli/src/scaffold/ethereum.test.ts
+++ b/packages/cli/src/scaffold/ethereum.test.ts
@@ -26,6 +26,7 @@ const TEST_EVENT = {
       ],
     },
     { name: 'd', type: 'string', indexed: true },
+    { name: 'id', type: 'string' },
   ],
 };
 
@@ -106,7 +107,7 @@ dataSources:
         - name: Contract
           file: ./abis/Contract.json
       eventHandlers:
-        - event: ExampleEvent(indexed uint256,bytes[4],string,(uint256,bytes32,string,(uint96,string,bytes32)),indexed string)
+        - event: ExampleEvent(indexed uint256,bytes[4],string,(uint256,bytes32,string,(uint96,string,bytes32)),indexed string,string)
           handler: handleExampleEvent
         - event: ExampleEvent(bytes32)
           handler: handleExampleEvent1
@@ -139,6 +140,7 @@ type ExampleEvent @entity(immutable: true) {
   c_c3_value1: String! # string
   c_c3_value2: Bytes! # bytes32
   d: String! # string
+  internal_id: String! # string
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!
@@ -233,6 +235,7 @@ export function handleExampleEvent(event: ExampleEventEvent): void {
   entity.c_c3_value1 = event.params.c.c3.value1
   entity.c_c3_value2 = event.params.c.c3.value2
   entity.d = event.params.d
+  entity.internal_id = event.params.id
 
   entity.blockNumber = event.block.number
   entity.blockTimestamp = event.block.timestamp
@@ -285,7 +288,8 @@ describe("Describe entity assertions", () => {
     let param2 = "Example string value"
     let c = "ethereum.Tuple Not implemented"
     let d = "Example string value"
-    let newExampleEventEvent = createExampleEventEvent(a, b, param2, c, d)
+    let id = "Example string value"
+    let newExampleEventEvent = createExampleEventEvent(a, b, param2, c, d, id)
     handleExampleEvent(newExampleEventEvent)
   })
 
@@ -346,7 +350,8 @@ export function createExampleEventEvent(
   b: Array<Bytes>,
   param2: string,
   c: ethereum.Tuple,
-  d: string
+  d: string,
+  id: string
 ): ExampleEvent {
   let exampleEventEvent = changetype<ExampleEvent>(newMockEvent())
 
@@ -366,6 +371,9 @@ export function createExampleEventEvent(
   )
   exampleEventEvent.parameters.push(
     new ethereum.EventParam("d", ethereum.Value.fromString(d))
+  )
+  exampleEventEvent.parameters.push(
+    new ethereum.EventParam("id", ethereum.Value.fromString(id))
   )
 
   return exampleEventEvent
@@ -415,7 +423,8 @@ describe("Describe entity assertions", () => {
     let param2 = "Example string value"
     let c = "ethereum.Tuple Not implemented"
     let d = "Example string value"
-    let newExampleEventEvent = createExampleEventEvent(a, b, param2, c, d)
+    let id = "Example string value"
+    let newExampleEventEvent = createExampleEventEvent(a, b, param2, c, d, id)
     handleExampleEvent(newExampleEventEvent)
   })
 
@@ -476,7 +485,8 @@ export function createExampleEventEvent(
   b: Array<Bytes>,
   param2: string,
   c: ethereum.Tuple,
-  d: string
+  d: string,
+  id: string
 ): ExampleEvent {
   let exampleEventEvent = changetype<ExampleEvent>(newMockEvent())
 
@@ -496,6 +506,9 @@ export function createExampleEventEvent(
   )
   exampleEventEvent.parameters.push(
     new ethereum.EventParam("d", ethereum.Value.fromString(d))
+  )
+  exampleEventEvent.parameters.push(
+    new ethereum.EventParam("id", ethereum.Value.fromString(id))
   )
 
   return exampleEventEvent

--- a/packages/cli/src/scaffold/mapping.ts
+++ b/packages/cli/src/scaffold/mapping.ts
@@ -13,29 +13,23 @@ export const generateFieldAssignments = ({ index, input }: { index: number; inpu
         [input.name || `param${index}`],
       );
 
-type BlacklistDictionary = Record<string, string>;
-
 /**
  * Map of input names that are reserved so we do not use them as field names to avoid conflicts
+ * see https://github.com/graphprotocol/graph-tooling/issues/710
+ * name => mappedName
  */
-export const INPUT_NAMES_BLACKLIST = {
-  /** Related to https://github.com/graphprotocol/graph-tooling/issues/710 */
-  id: 'id',
+const NAMES_REMAP_DICTIONARY: Record<string, string> = {
+  id: 'internal_id',
+  _id: 'internal__id',
 } as const;
 
-export const renameInput = (name: string, subgraphName: string) => {
-  const inputMap: BlacklistDictionary = {
-    [INPUT_NAMES_BLACKLIST.id]: `${subgraphName}_id`,
-  };
-
-  return inputMap?.[name] ?? name;
+export const renameNameIfNeeded = (name: string) => {
+  return NAMES_REMAP_DICTIONARY[name] ?? name;
 };
 
-export const generateEventFieldAssignments = (event: any, contractName: string) =>
+export const generateEventFieldAssignments = (event: any, _contractName: string) =>
   event.inputs.reduce((acc: any[], input: any, index: number) => {
-    if (Object.values(INPUT_NAMES_BLACKLIST).includes(input.name)) {
-      input.mappedName = renameInput(input.name, contractName ?? 'contract');
-    }
+    input.mappedName = renameNameIfNeeded(input.name);
     return acc.concat(generateFieldAssignments({ input, index }));
   }, []);
 

--- a/packages/cli/src/scaffold/schema.ts
+++ b/packages/cli/src/scaffold/schema.ts
@@ -2,7 +2,7 @@ import immutable from 'immutable';
 import { ascTypeForProtocol, valueTypeForAsc } from '../codegen/types/index.js';
 import * as util from '../codegen/util.js';
 import Protocol from '../protocols/index.js';
-import { INPUT_NAMES_BLACKLIST, renameInput } from './mapping.js';
+import { renameNameIfNeeded } from './mapping.js';
 
 export function abiEvents(abi: { data: immutable.Collection<any, any> }) {
   return util.disambiguateNames({
@@ -73,9 +73,7 @@ export const generateEventType = (
         id: Bytes!
         ${event.inputs
           .reduce((acc: any[], input: any, index: number) => {
-            if (Object.values(INPUT_NAMES_BLACKLIST).includes(input.name)) {
-              input.name = renameInput(input.name, contractName ?? 'contract');
-            }
+            input.name = renameNameIfNeeded(input.name);
             return acc.concat(generateEventFields({ input, index, protocolName }));
           }, [])
           .join('\n')}


### PR DESCRIPTION
Fixes #1679 

- Added "_id" to the remap dictionary. 
- Simplified the remap logic since adding subgraph name to the field doesn't make much sense. Replacing `id` with `internal_id` is more logical and explicit
- Added `id` field to tests