### PR TITLE
Revert "chore(release): update monorepo packages versions (#1822)" [no ci]

### DIFF
--- a/.changeset/green-islands-wink.md
+++ b/.changeset/green-islands-wink.md
@@ -1,0 +1,6 @@
+---
+'@graphprotocol/graph-cli': minor
+'@graphprotocol/graph-ts': minor
+---
+
+Update all dependencies

--- a/.changeset/heavy-socks-cross.md
+++ b/.changeset/heavy-socks-cross.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Fix `graph add` flag parameters parsing

--- a/.changeset/new-gorillas-scream.md
+++ b/.changeset/new-gorillas-scream.md
@@ -1,0 +1,11 @@
+---
+'@graphprotocol/graph-cli': minor
+---
+
+- add networks registry support
+- improve `graph init` flow
+  - filter through the networks as you type
+  - more information about the networks
+  - remove unnecessary options depending on the selection
+  - ESC key to go back
+- allow specifying ipfs/url for substreams package

--- a/.changeset/short-keys-boil.md
+++ b/.changeset/short-keys-boil.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+fix bug with clashing \_id field name in schema

--- a/.changeset/swift-jobs-count.md
+++ b/.changeset/swift-jobs-count.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+fix generated example entity id uniqueness

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,39 +1,5 @@
 # @graphprotocol/graph-cli
 
-## 0.92.0
-
-### Minor Changes
-
-- [#1775](https://github.com/graphprotocol/graph-tooling/pull/1775)
-  [`7faa309`](https://github.com/graphprotocol/graph-tooling/commit/7faa3098b2e6c61f09fc81b8b2d333e66b0080d1)
-  Thanks [@0237h](https://github.com/0237h)! - Update all dependencies
-
-- [#1788](https://github.com/graphprotocol/graph-tooling/pull/1788)
-  [`edb601d`](https://github.com/graphprotocol/graph-tooling/commit/edb601dbe29e3bab1ae356b4c94d4356f84929d6)
-  Thanks [@YaroShkvorets](https://github.com/YaroShkvorets)! - - add networks registry support
-  - improve `graph init` flow
-    - filter through the networks as you type
-    - more information about the networks
-    - remove unnecessary options depending on the selection
-    - ESC key to go back
-  - allow specifying ipfs/url for substreams package
-
-### Patch Changes
-
-- [#1778](https://github.com/graphprotocol/graph-tooling/pull/1778)
-  [`5900f09`](https://github.com/graphprotocol/graph-tooling/commit/5900f0948711285018b639219d1b33536c2ac69e)
-  Thanks [@briceyan](https://github.com/briceyan)! - Fix `graph add` flag parameters parsing
-
-- [#1810](https://github.com/graphprotocol/graph-tooling/pull/1810)
-  [`c301481`](https://github.com/graphprotocol/graph-tooling/commit/c301481d4350e3eb89074d3d0407520222bd810b)
-  Thanks [@YaroShkvorets](https://github.com/YaroShkvorets)! - fix bug with clashing \_id field name
-  in schema
-
-- [#1835](https://github.com/graphprotocol/graph-tooling/pull/1835)
-  [`299c75b`](https://github.com/graphprotocol/graph-tooling/commit/299c75b4649a452aabc8933460e04f21bf1c3058)
-  Thanks [@YaroShkvorets](https://github.com/YaroShkvorets)! - fix generated example entity id
-  uniqueness
-
 ## 0.91.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.92.0",
+  "version": "0.91.1",
   "type": "module",
   "description": "CLI for building for and deploying to The Graph",
   "license": "(Apache-2.0 OR MIT)",

--- a/packages/ts/CHANGELOG.md
+++ b/packages/ts/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @graphprotocol/graph-ts
 
-## 0.37.0
-
-### Minor Changes
-
-- [#1775](https://github.com/graphprotocol/graph-tooling/pull/1775)
-  [`7faa309`](https://github.com/graphprotocol/graph-tooling/commit/7faa3098b2e6c61f09fc81b8b2d333e66b0080d1)
-  Thanks [@0237h](https://github.com/0237h)! - Update all dependencies
-
 ## 0.36.0
 
 ### Minor Changes

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-ts",
-  "version": "0.37.0",
+  "version": "0.36.0",
   "description": "TypeScript/AssemblyScript library for writing subgraph mappings for The Graph",
   "main": "index.ts",
   "module": "index.ts",


### PR DESCRIPTION
This reverts commit b9d144154f1800935659d3b8e7e22ca8259cbca5.

To allow re-run failed release ci.