### PR TITLE
Cleanup dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
   "pnpm": {
     "patchedDependencies": {
       "oclif@4.16.0": "patches/oclif@4.16.0.patch"
+    },
+    "overrides": {
+      "rimraf": "^6.0.0"
     }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
     "js-yaml": "4.1.0",
     "kubo-rpc-client": "^5.0.2",
     "open": "10.1.0",
+    "prettier": "3.4.2",
     "semver": "7.6.3",
     "tmp-promise": "3.0.3",
     "web3-eth-abi": "4.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  rimraf: ^6.0.0
+
 patchedDependencies:
   oclif@4.16.0:
     hash: ofxhflhoc4vkbbfnh6gtk4pfua
@@ -296,6 +299,9 @@ importers:
       open:
         specifier: 10.1.0
         version: 10.1.0
+      prettier:
+        specifier: 3.4.2
+        version: 3.4.2
       semver:
         specifier: 7.6.3
         version: 7.6.3
@@ -470,7 +476,7 @@ importers:
         specifier: ^8.4.49
         version: 8.4.49
       rimraf:
-        specifier: ^6.0.1
+        specifier: ^6.0.0
         version: 6.0.1
       tailwindcss:
         specifier: ^3.4.15
@@ -8363,16 +8369,6 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
-  rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   rimraf@6.0.1:
     resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
     engines: {node: 20 || >=22}
@@ -15371,7 +15367,7 @@ snapshots:
   binary-install-raw@0.0.13(debug@4.3.4):
     dependencies:
       axios: 0.21.4(debug@4.3.4)
-      rimraf: 3.0.2
+      rimraf: 6.0.1
       tar: 6.2.1
     transitivePeerDependencies:
       - debug
@@ -15379,7 +15375,7 @@ snapshots:
   binary-install@1.1.0(debug@4.3.7):
     dependencies:
       axios: 0.26.1(debug@4.3.7)
-      rimraf: 3.0.2
+      rimraf: 6.0.1
       tar: 6.2.1
     transitivePeerDependencies:
       - debug
@@ -17358,7 +17354,7 @@ snapshots:
   fs-jetpack@4.3.1:
     dependencies:
       minimatch: 3.1.2
-      rimraf: 2.7.1
+      rimraf: 6.0.1
 
   fs-minipass@2.1.0:
     dependencies:
@@ -20278,14 +20274,6 @@ snapshots:
   retry@0.13.1: {}
 
   reusify@1.0.4: {}
-
-  rimraf@2.7.1:
-    dependencies:
-      glob: 7.2.3
-
-  rimraf@3.0.2:
-    dependencies:
-      glob: 7.2.3
 
   rimraf@6.0.1:
     dependencies:


### PR DESCRIPTION
1. override deprecated rimraf version
2. add prettier back as a prod dependency