### PR TITLE
Disable renovate bot for `assemblyscript` package

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,10 @@
     {
       "matchPackageNames": ["typescript", "@theguild/**", "@pinax/**"],
       "groupName": null
+    },
+    {
+      "matchPackageNames": ["assemblyscript"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Compiler update should be done manually and coordinated with graph-node