### PR TITLE
Fix missing Graft type for substreams based subgraph

### DIFF
--- a/.changeset/purple-kids-talk.md
+++ b/.changeset/purple-kids-talk.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+fix bug with missing Graft type in SpS manifest definition

--- a/packages/cli/src/protocols/substreams/manifest.graphql
+++ b/packages/cli/src/protocols/substreams/manifest.graphql
@@ -24,6 +24,11 @@ type Schema {
   file: File!
 }
 
+type Graft {
+  base: String!
+  block: BigInt!
+}
+
 type IndexerHints {
   prune: StringOrBigInt
 }


### PR DESCRIPTION
Fixes
```
Error: Error in subgraph.yaml:

  Path: graft
  No validator for unsupported schema type: undefined
```