### PR TITLE
Fix init for events with 2d arrays as params

### DIFF
--- a/.changeset/quick-zoos-brake.md
+++ b/.changeset/quick-zoos-brake.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+`graph init`: fix tests generation for events with [][] params #1878

--- a/packages/cli/src/scaffold/tests.ts
+++ b/packages/cli/src/scaffold/tests.ts
@@ -119,7 +119,13 @@ const isNativeType = (type: string) => {
   return natives.some(rx => rx.test(type));
 };
 
-const fetchArrayInnerType = (type: string) => type.match(/Array<(.*?)>/);
+// get inner type: Array<T> -> T, Array<Array<T>> -> T
+const fetchArrayInnerType = (type: string): RegExpMatchArray | null => {
+  const match = type.match(/Array<(.+)>/);
+  if (!match) return null;
+
+  return fetchArrayInnerType(match[1]) || match;
+};
 
 // Generates the example test.ts file
 const generateExampleTest = (


### PR DESCRIPTION
fixes #1878

Graph node still doesn't allow array of arrays (i.e. `[[[String!]!]!`) as entity fields in the schema, but at least it doesn't fail during scaffolding. It will be up to the developer to figure out how to properly transform such event params into entity fields according to their logic.