### PR TITLE
Add support for Sourcify contract information lookup

### DIFF
--- a/.changeset/spotty-geckos-wonder.md
+++ b/.changeset/spotty-geckos-wonder.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': minor
+---
+
+Add support for Sourcify contract information lookup

--- a/packages/cli/src/command-helpers/contracts.test.ts
+++ b/packages/cli/src/command-helpers/contracts.test.ts
@@ -100,9 +100,15 @@ const TEST_SOURCIFY_CONTRACT_INFO = {
     },
   },
   wax: {
-    '': {
-      name: '',
-      startBlock: 0,
+    account: {
+      name: null,
+      startBlock: null,
+    },
+  },
+  'non-existing chain': {
+    '0x0000000000000000000000000000000000000000': {
+      name: null,
+      startBlock: null,
     },
   },
 };
@@ -129,23 +135,17 @@ describe('getFromSourcifyForContract', { sequential: true }, async () => {
   const registry = await loadRegistry();
   const contractService = new ContractService(registry);
   for (const [networkId, contractInfo] of Object.entries(TEST_SOURCIFY_CONTRACT_INFO)) {
-    for (const [contract, info] of Object.entries(contractInfo)) {
+    for (const [contract, t] of Object.entries(contractInfo)) {
       test(
-        `Returns contract information ${networkId} ${contract} ${info.name} ${info.startBlock}`,
+        `Returns contract information ${networkId} ${contract} ${t.name} ${t.startBlock}`,
         async () => {
-          if (networkId == 'wax') {
-            // Sourcify only supports EVM chains
-            expect(
-              await contractService.getFromSourcify(EthereumABI, networkId, contract),
-            ).toBeNull();
+          const result = await contractService.getFromSourcify(EthereumABI, networkId, contract);
+          if (t.name === null && t.startBlock === null) {
+            expect(result).toBeNull();
           } else {
             // Only check name and startBlock, omit API property from Sourcify results
-            const { name, startBlock } = (await contractService.getFromSourcify(
-              EthereumABI,
-              networkId,
-              contract,
-            ))!;
-            expect(info).toEqual({ name, startBlock: parseInt(startBlock) });
+            const { name, startBlock } = result!;
+            expect(t).toEqual({ name, startBlock: parseInt(startBlock) });
           }
         },
         { timeout: 10_000 },

--- a/packages/cli/src/command-helpers/contracts.test.ts
+++ b/packages/cli/src/command-helpers/contracts.test.ts
@@ -99,6 +99,12 @@ const TEST_SOURCIFY_CONTRACT_INFO = {
       startBlock: 7_019_815,
     },
   },
+  wax: {
+    '': {
+      name: '',
+      startBlock: 0,
+    },
+  },
 };
 
 describe('getStartBlockForContract', { sequential: true }, async () => {
@@ -127,13 +133,20 @@ describe('getFromSourcifyForContract', { sequential: true }, async () => {
       test(
         `Returns contract information ${networkId} ${contract} ${info.name} ${info.startBlock}`,
         async () => {
-          // Only check name and startBlock, omit API property from Sourcify results
-          const { name, startBlock } = (await contractService.getFromSourcify(
-            EthereumABI,
-            networkId,
-            contract,
-          ))!;
-          expect(info).toEqual({ name, startBlock: parseInt(startBlock) });
+          if (networkId == 'wax') {
+            // Sourcify only supports EVM chains
+            expect(
+              await contractService.getFromSourcify(EthereumABI, networkId, contract),
+            ).toBeNull();
+          } else {
+            // Only check name and startBlock, omit API property from Sourcify results
+            const { name, startBlock } = (await contractService.getFromSourcify(
+              EthereumABI,
+              networkId,
+              contract,
+            ))!;
+            expect(info).toEqual({ name, startBlock: parseInt(startBlock) });
+          }
         },
         { timeout: 10_000 },
       );

--- a/packages/cli/src/command-helpers/contracts.ts
+++ b/packages/cli/src/command-helpers/contracts.ts
@@ -151,6 +151,61 @@ export class ContractService {
     throw new Error(`Failed to fetch contract name for ${address}`);
   }
 
+  async getFromSourcify(
+    ABICtor: typeof ABI,
+    networkId: string,
+    address: string,
+  ): Promise<{ abi: ABI; startBlock: string; name: string } | null> {
+    try {
+      const network = this.registry.getNetworkById(networkId);
+      if (!network) throw new Error(`Invalid network ${networkId}`);
+
+      const chainId = network.caip2Id.split(':')[1];
+      if (!/^\d+$/.test(chainId))
+        throw new Error(`Invalid chainId, Sourcify API expects integer value, got '${chainId}'`);
+
+      const url = `https://sourcify.dev/server/files/any/${chainId}/${address}`;
+      const json:
+        | {
+            status: string;
+            files: { name: string; path: string; content: string }[];
+          }
+        | { error: string } = await (
+        await fetch(url).catch(error => {
+          throw new Error(`Sourcify API is unreachable: ${error}`);
+        })
+      ).json();
+
+      if (json) {
+        if ('error' in json) throw new Error(`Sourcify API error: ${json.error}`);
+
+        let metadata: any = json.files.find(e => e.name === 'metadata.json')?.content;
+        if (!metadata) throw new Error('Contract is missing metadata');
+
+        const tx_hash = json.files.find(e => e.name === 'creator-tx-hash.txt')?.content;
+        if (!tx_hash) throw new Error('Contract is missing tx creation hash');
+
+        const tx = await this.fetchTransactionByHash(networkId, tx_hash);
+        if (!tx?.blockNumber)
+          throw new Error(`Can't fetch blockNumber from tx: ${JSON.stringify(tx)}`);
+
+        metadata = JSON.parse(metadata);
+        const contractName = Object.values(metadata.settings.compilationTarget)[0] as string;
+        return {
+          abi: new ABICtor(contractName, undefined, immutable.fromJS(metadata.output.abi)) as ABI,
+          startBlock: Number(tx.blockNumber).toString(),
+          name: contractName,
+        };
+      }
+
+      throw new Error(`No result: ${JSON.stringify(json)}`);
+    } catch (error) {
+      logger(`Failed to fetch from Sourcify: ${error}`);
+    }
+
+    return null;
+  }
+
   private async fetchTransactionByHash(networkId: string, txHash: string) {
     const urls = this.getRpcUrls(networkId);
     if (!urls.length) {

--- a/packages/cli/src/command-helpers/contracts.ts
+++ b/packages/cli/src/command-helpers/contracts.ts
@@ -160,10 +160,10 @@ export class ContractService {
       const network = this.registry.getNetworkById(networkId);
       if (!network) throw new Error(`Invalid network ${networkId}`);
 
-      const chainId = network.caip2Id.split(':')[1];
-      if (!/^\d+$/.test(chainId))
-        throw new Error(`Invalid chainId, Sourcify API expects integer value, got '${chainId}'`);
+      if (!network.caip2Id.startsWith('eip155'))
+        throw new Error(`Invalid chainId, Sourcify API only supports EVM chains`);
 
+      const chainId = network.caip2Id.split(':')[1];
       const url = `https://sourcify.dev/server/files/any/${chainId}/${address}`;
       const json:
         | {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -80,12 +80,24 @@ export default class AddCommand extends Command {
     if (isLocalHost) this.warn('`localhost` network detected, prompting user for inputs');
     const registry = await loadRegistry();
     const contractService = new ContractService(registry);
+    const sourcifyContractInfo = await contractService.getFromSourcify(
+      EthereumABI,
+      network,
+      address,
+    );
 
     let startBlock = startBlockFlag ? parseInt(startBlockFlag).toString() : startBlockFlag;
     let contractName = contractNameFlag || DEFAULT_CONTRACT_NAME;
-
     let ethabi = null;
-    if (abi) {
+
+    if (sourcifyContractInfo) {
+      startBlock ??= sourcifyContractInfo.startBlock;
+      contractName =
+        contractName == DEFAULT_CONTRACT_NAME ? sourcifyContractInfo.name : contractName;
+      ethabi ??= sourcifyContractInfo.abi;
+    }
+
+    if (!ethabi && abi) {
       ethabi = EthereumABI.load(contractName, abi);
     } else {
       try {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { filesystem, print, prompt, system } from 'gluegun';
-import immutable from 'immutable';
 import { Args, Command, Flags } from '@oclif/core';
 import { Network } from '@pinax/graph-networks-registry';
 import { appendApiVersionForGraph } from '../command-helpers/compiler.js';
@@ -229,11 +228,7 @@ export default class InitCommand extends Command {
         } else {
           try {
             abi = sourcifyContractInfo
-              ? new EthereumABI(
-                  DEFAULT_CONTRACT_NAME,
-                  undefined,
-                  immutable.fromJS(sourcifyContractInfo.abi),
-                )
+              ? sourcifyContractInfo.abi
               : await contractService.getABI(ABI, network, fromContract!);
           } catch (e) {
             this.exit(1);
@@ -635,7 +630,7 @@ async function processInitForm(
           initDebugger.extend('processInitForm')(
             "infoFromSourcify: '%s'/'%s'",
             initStartBlock,
-            initContractName
+            initContractName,
           );
         }
 


### PR DESCRIPTION
Etherscan requires an API key for ABI lookup and other operations.
Sourcify (https://sourcify.dev/) is an open-source decentralized alternative.

## Features

- Contract name, ABI and creation transaction hash (start block) from [Sourcify API](https://docs.sourcify.dev/docs/api/).
- Runs before the registry lookup and replaces default values (not interactive) if not provided by the user.
This means priority for CLI parameters looks like:
user submitted (env/CLI args) > Sourcify API > Default values > Registry fetch

Closes #1001.

## Details

The `getFromSourcify` method returns all the information related to contracts that are normally fetch from registry URLs:
```js
{ abi: ABI; startBlock: string; name: string }
```
It internally makes the RPC call for the `startBlock` using the creation transaction hash.


