### PR TITLE
Fix `import.meta.url` not being parsed as path properly

### DIFF
--- a/.changeset/flat-spiders-grin.md
+++ b/.changeset/flat-spiders-grin.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Fix `import.meta.url` not being parsed as path properly

--- a/packages/cli/src/command-helpers/network.test.ts
+++ b/packages/cli/src/command-helpers/network.test.ts
@@ -6,7 +6,7 @@ import yaml from 'yaml';
 import { initNetworksConfig, updateSubgraphNetwork } from './network.js';
 
 const SUBGRAPH_PATH_BASE = path.join(
-  `${process.platform === 'win32' ? '' : '/'}${fileURLToPath(import.meta.url)}`,
+  fileURLToPath(import.meta.url),
   '..',
   '..',
   '..',

--- a/packages/cli/src/command-helpers/network.test.ts
+++ b/packages/cli/src/command-helpers/network.test.ts
@@ -6,7 +6,8 @@ import yaml from 'yaml';
 import { initNetworksConfig, updateSubgraphNetwork } from './network.js';
 
 const SUBGRAPH_PATH_BASE = path.join(
-  `${process.platform === 'win32' ? '' : '/'}${/file:\/{2,3}(.+)\/[^/]/.exec(fileURLToPath(import.meta.url))![1]}`,
+  `${process.platform === 'win32' ? '' : '/'}${fileURLToPath(import.meta.url)}`,
+  '..',
   '..',
   '..',
   '..',

--- a/packages/cli/src/command-helpers/network.test.ts
+++ b/packages/cli/src/command-helpers/network.test.ts
@@ -1,11 +1,12 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import * as toolbox from 'gluegun';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import yaml from 'yaml';
 import { initNetworksConfig, updateSubgraphNetwork } from './network.js';
 
 const SUBGRAPH_PATH_BASE = path.join(
-  `${process.platform === 'win32' ? '' : '/'}${/file:\/{2,3}(.+)\/[^/]/.exec(import.meta.url)![1]}`,
+  `${process.platform === 'win32' ? '' : '/'}${/file:\/{2,3}(.+)\/[^/]/.exec(fileURLToPath(import.meta.url))![1]}`,
   '..',
   '..',
   '..',

--- a/packages/cli/src/commands/local.ts
+++ b/packages/cli/src/commands/local.ts
@@ -94,9 +94,8 @@ export default class LocalCommand extends Command {
     const composeFile =
       composeFileFlag ||
       path.join(
-        `${process.platform === 'win32' ? '' : '/'}${
-          /file:\/{2,3}(.+)\/[^/]/.exec(fileURLToPath(import.meta.url))![1]
-        }`,
+        `${process.platform === 'win32' ? '' : '/'}${fileURLToPath(import.meta.url)}`,
+        '..',
         '..',
         '..',
         'resources',

--- a/packages/cli/src/commands/local.ts
+++ b/packages/cli/src/commands/local.ts
@@ -2,6 +2,7 @@ import { ChildProcess, spawn } from 'node:child_process';
 import http from 'node:http';
 import net from 'node:net';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import compose from 'docker-compose';
 import { filesystem, patching } from 'gluegun';
 import stripAnsi from 'strip-ansi';
@@ -94,7 +95,7 @@ export default class LocalCommand extends Command {
       composeFileFlag ||
       path.join(
         `${process.platform === 'win32' ? '' : '/'}${
-          /file:\/{2,3}(.+)\/[^/]/.exec(import.meta.url)![1]
+          /file:\/{2,3}(.+)\/[^/]/.exec(fileURLToPath(import.meta.url))![1]
         }`,
         '..',
         '..',

--- a/packages/cli/src/commands/local.ts
+++ b/packages/cli/src/commands/local.ts
@@ -94,7 +94,7 @@ export default class LocalCommand extends Command {
     const composeFile =
       composeFileFlag ||
       path.join(
-        `${process.platform === 'win32' ? '' : '/'}${fileURLToPath(import.meta.url)}`,
+        fileURLToPath(import.meta.url),
         '..',
         '..',
         '..',

--- a/packages/cli/src/subgraph.ts
+++ b/packages/cli/src/subgraph.ts
@@ -54,7 +54,8 @@ export default class Subgraph {
     const schema = graphql.parse(
       await fs.readFile(
         path.join(
-          `${process.platform === 'win32' ? '' : '/'}${/file:\/{2,3}(.+)\/[^/]/.exec(fileURLToPath(import.meta.url))![1]}`,
+          `${process.platform === 'win32' ? '' : '/'}${fileURLToPath(import.meta.url)}`,
+          '..',
           'protocols',
           // TODO: substreams/triggers is a special case, should be handled better
           protocol.name === 'substreams/triggers' ? 'substreams' : protocol.name,

--- a/packages/cli/src/subgraph.ts
+++ b/packages/cli/src/subgraph.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import fs from 'fs-extra';
 import * as graphql from 'graphql/language/index.js';
 import immutable from 'immutable';
@@ -53,7 +54,7 @@ export default class Subgraph {
     const schema = graphql.parse(
       await fs.readFile(
         path.join(
-          `${process.platform === 'win32' ? '' : '/'}${/file:\/{2,3}(.+)\/[^/]/.exec(import.meta.url)![1]}`,
+          `${process.platform === 'win32' ? '' : '/'}${/file:\/{2,3}(.+)\/[^/]/.exec(fileURLToPath(import.meta.url))![1]}`,
           'protocols',
           // TODO: substreams/triggers is a special case, should be handled better
           protocol.name === 'substreams/triggers' ? 'substreams' : protocol.name,

--- a/packages/cli/src/subgraph.ts
+++ b/packages/cli/src/subgraph.ts
@@ -54,7 +54,7 @@ export default class Subgraph {
     const schema = graphql.parse(
       await fs.readFile(
         path.join(
-          `${process.platform === 'win32' ? '' : '/'}${fileURLToPath(import.meta.url)}`,
+          fileURLToPath(import.meta.url),
           '..',
           'protocols',
           // TODO: substreams/triggers is a special case, should be handled better

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -7,7 +7,8 @@ const packageJson = JSON.parse(
     .readFileSync(
       // works even when bundled/built because the path to package.json is the same
       path.join(
-        `${process.platform === 'win32' ? '' : '/'}${/file:\/{2,3}(.+)\/[^/]/.exec(fileURLToPath(import.meta.url))![1]}`,
+        `${process.platform === 'win32' ? '' : '/'}${fileURLToPath(import.meta.url)}`,
+        '..',
         '..',
         'package.json',
       ),

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -6,12 +6,7 @@ const packageJson = JSON.parse(
   fs
     .readFileSync(
       // works even when bundled/built because the path to package.json is the same
-      path.join(
-        `${process.platform === 'win32' ? '' : '/'}${fileURLToPath(import.meta.url)}`,
-        '..',
-        '..',
-        'package.json',
-      ),
+      path.join(fileURLToPath(import.meta.url), '..', '..', 'package.json'),
     )
     .toString(),
 );

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,12 +1,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const packageJson = JSON.parse(
   fs
     .readFileSync(
       // works even when bundled/built because the path to package.json is the same
       path.join(
-        `${process.platform === 'win32' ? '' : '/'}${/file:\/{2,3}(.+)\/[^/]/.exec(import.meta.url)![1]}`,
+        `${process.platform === 'win32' ? '' : '/'}${/file:\/{2,3}(.+)\/[^/]/.exec(fileURLToPath(import.meta.url))![1]}`,
         '..',
         'package.json',
       ),


### PR DESCRIPTION
Using `import.meta.url` to resolve local file path and directories can lead to issues when special characters are percent-encoded in the url.

This fix uses the `fileURLToPath` native method to properly parse local urls to file paths.

Closes #1881 