### PR TITLE
chore: Add oclif to renovate exceptions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
       "groupSlug": "all-minor-patch"
     },
     {
-      "matchPackageNames": ["typescript", "@theguild/**", "@pinax/**"],
+      "matchPackageNames": ["oclif", "@theguild/**", "@pinax/**"],
       "groupName": null
     },
     {


### PR DESCRIPTION
It needs to be patched, so can't be bundled in minor updates