### PR TITLE
chore: fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           nodeVersion: 20
           packageManager: pnpm
-          packageManagerVersion: latest
+          packageManagerVersion: 9.3.0
 
       - name: Build Packages
         run: pnpm build # will also check types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           nodeVersion: 20
           packageManager: pnpm
-          packageManagerVersion: 9.1.0
+          packageManagerVersion: latest
 
       - name: Build Packages
         run: pnpm build # will also check types

--- a/examples/ethereum-basic-event-handlers/hardhat/Dockerfile
+++ b/examples/ethereum-basic-event-handlers/hardhat/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --update python3 make g++ && rm -rf /var/cache/apk/*
 
 RUN corepack enable
 
-RUN corepack prepare pnpm@latest --activate
+RUN corepack prepare pnpm@9.3.0 --activate
 
 RUN pnpm install
 

--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
       "groupName": null
     },
     {
-      "matchPackageNames": ["assemblyscript"],
+      "matchPackageNames": ["assemblyscript", "oclif"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Align pnpm versions to fix this CI error:
```
> [hardhat 7/9] RUN corepack prepare pnpm@latest --activate:
0.391 Preparing pnpm@latest for immediate activation...
1.015 Internal Error: Cannot find matching keyid: {"signatures":[{"sig":"MEQCIBfxS9RKPsi46jxBHnsGYQ03mg8um110415vE6KRCzY8AiBvik66sYxJ/NyCovwJSbDuuoaYCxc7EVdFhaaciIXjTw==","keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U"}],"keys":[{"expires":null,"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="}]}
1.015     at verifySignature (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21535:47)
1.015     at installVersion (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21882:7)
1.015     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
1.015     at async Engine.ensurePackageManager (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22310:32)
1.015     at async PrepareCommand.execute (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23019:27)
1.015     at async PrepareCommand.validateAndExecute (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:19835:22)
1.015     at async _Cli.run (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:20772:18)
1.015     at async Object.runMain (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23091:19)
```