### PR TITLE
Use Sourcify v2 endpoint for contract lookups

### DIFF
--- a/.changeset/giant-owls-accept.md
+++ b/.changeset/giant-owls-accept.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Use Sourcify v2 endpoint for contract lookups

--- a/packages/cli/src/command-helpers/contracts.test.ts
+++ b/packages/cli/src/command-helpers/contracts.test.ts
@@ -117,7 +117,7 @@ const TEST_SOURCIFY_CONTRACT_INFO = {
       name: null,
       startBlock: null,
     },
-  }
+  },
 };
 
 // Retry helper with configurable number of retries

--- a/packages/cli/src/command-helpers/contracts.test.ts
+++ b/packages/cli/src/command-helpers/contracts.test.ts
@@ -111,6 +111,13 @@ const TEST_SOURCIFY_CONTRACT_INFO = {
       startBlock: null,
     },
   },
+  // Invalid address (missing 0x)
+  matic: {
+    '0000000000000000000000000000000000000000': {
+      name: null,
+      startBlock: null,
+    },
+  }
 };
 
 // Retry helper with configurable number of retries

--- a/packages/cli/src/command-helpers/contracts.test.ts
+++ b/packages/cli/src/command-helpers/contracts.test.ts
@@ -93,6 +93,12 @@ const TEST_SOURCIFY_CONTRACT_INFO = {
       startBlock: 10_736_242,
     },
   },
+  'mainnet-non-verified': {
+    '0x4a183b7ED67B9E14b3f45Abfb2Cf44ed22c29E54': {
+      name: null,
+      startBlock: null,
+    },
+  },
   optimism: {
     '0xc35DADB65012eC5796536bD9864eD8773aBc74C4': {
       name: 'BentoBoxV1',

--- a/packages/cli/src/command-helpers/contracts.ts
+++ b/packages/cli/src/command-helpers/contracts.ts
@@ -174,14 +174,15 @@ export class ContractService {
             compilation: { name: string };
             deployment: { blockNumber: string };
           }
-        | { customCode: string; message: string; errorId: string; } = await (
+        | { customCode: string; message: string; errorId: string } = await (
         await fetch(url).catch(error => {
           throw new Error(`Sourcify API is unreachable: ${error}`);
         })
       ).json();
 
       if (json) {
-        if ('errorId' in json) throw new Error(`Sourcify API error: [${json.customCode}] ${json.message}`);
+        if ('errorId' in json)
+          throw new Error(`Sourcify API error: [${json.customCode}] ${json.message}`);
 
         const abi = json.abi;
         const contractName = json.compilation.name;

--- a/packages/cli/tests/cli/init.test.ts
+++ b/packages/cli/tests/cli/init.test.ts
@@ -8,7 +8,7 @@ describe(
   'Init',
   {
     sequential: true,
-    timeout: 100_000,
+    timeout: 500_000,
   },
   () => {
     const baseDir = path.join(__dirname, 'init');
@@ -31,7 +31,7 @@ describe(
         path.join('init', 'ethereum', 'from-example'),
         {
           exitCode: 0,
-          timeout: 100_000,
+          timeout: 200_000,
           cwd: ethereumBaseDir,
           deleteDir: true,
         },


### PR DESCRIPTION
This simplifies the lookup logic by not having to fetch RPC for the `startBlock`. Information returned by the lookup are still the same (abi, contract name, start block).

An additional check is added for the address format (must start with `0x` prefix).

v2 endpoints documentation: https://docs.sourcify.dev/docs/api/#/Contract%20Lookup/get-contract