### PR TITLE
`graph init`: Bump up api and spec versions

### DIFF
--- a/.changeset/brave-llamas-train.md
+++ b/.changeset/brave-llamas-train.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+`graph init`: get generated apiVersion and specVersion up to date

--- a/packages/cli/src/protocols/ethereum/scaffold/manifest.ts
+++ b/packages/cli/src/protocols/ethereum/scaffold/manifest.ts
@@ -22,7 +22,7 @@ export const source = ({
 
 export const mapping = ({ abi, contractName }: { abi: ABI; contractName: string }) => `
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         ${abiEvents(abi)

--- a/packages/cli/src/protocols/subgraph/scaffold/manifest.ts
+++ b/packages/cli/src/protocols/subgraph/scaffold/manifest.ts
@@ -20,7 +20,7 @@ export const mapping = ({
   contractName: string;
 }) => `
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
        - ExampleEntity

--- a/packages/cli/src/scaffold/__snapshots__/cosmos.test.ts.snap
+++ b/packages/cli/src/scaffold/__snapshots__/cosmos.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Cosmos subgraph scaffolding > Manifest 1`] = `
-"specVersion: 1.0.0
+"specVersion: 1.2.0
 indexerHints:
   prune: auto
 schema:

--- a/packages/cli/src/scaffold/__snapshots__/ethereum.test.ts.snap
+++ b/packages/cli/src/scaffold/__snapshots__/ethereum.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Ethereum subgraph scaffolding > Manifest 1`] = `
-"specVersion: 1.0.0
+"specVersion: 1.2.0
 indexerHints:
   prune: auto
 schema:
@@ -16,7 +16,7 @@ dataSources:
       startBlock: 12345
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - ExampleEvent

--- a/packages/cli/src/scaffold/__snapshots__/near.test.ts.snap
+++ b/packages/cli/src/scaffold/__snapshots__/near.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`NEAR subgraph scaffolding > Manifest 1`] = `
-"specVersion: 1.0.0
+"specVersion: 1.2.0
 indexerHints:
   prune: auto
 schema:

--- a/packages/cli/src/scaffold/index.ts
+++ b/packages/cli/src/scaffold/index.ts
@@ -20,7 +20,7 @@ const GRAPH_CLI_VERSION = process.env.GRAPH_CLI_TESTS
     undefined
   : // For scaffolding real subgraphs
     version;
-const GRAPH_TS_VERSION = '0.36.0';
+const GRAPH_TS_VERSION = '0.37.0';
 const GRAPH_MATCHSTICK_VERSION = '0.6.0';
 
 export interface ScaffoldOptions {
@@ -141,7 +141,7 @@ export default class Scaffold {
 
     return await prettier.format(
       `
-specVersion: 1.0.0
+specVersion: 1.2.0
 indexerHints:
   prune: auto
 schema:

--- a/packages/cli/tests/cli/add/expected/subgraph.yaml
+++ b/packages/cli/tests/cli/add/expected/subgraph.yaml
@@ -35,7 +35,7 @@ dataSources:
       startBlock: 6175244
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - GravatarNewGravatar


### PR DESCRIPTION
Fixes #1933 
`apiVersion: 0.0.9` and `specVersion: 1.2.0` released in v0.35.0 10 months ago