### PR TITLE
`graph init`: Show Sourcify fetch status

### DIFF
--- a/.changeset/nervous-garlics-cover.md
+++ b/.changeset/nervous-garlics-cover.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+show sourcify fetch status

--- a/packages/cli/src/command-helpers/spinner.ts
+++ b/packages/cli/src/command-helpers/spinner.ts
@@ -36,7 +36,7 @@ export const withSpinner = async (
   const spinner = print.spin(text);
   try {
     const result = await f(spinner);
-    if (typeof result === 'object') {
+    if (result && typeof result === 'object') {
       const hasError = Object.keys(result).includes('error');
       const hasWarning = Object.keys(result).includes('warning');
       const hasResult = Object.keys(result).includes('result');


### PR DESCRIPTION
- don't query Sourcify if protocol doesn't need ABI or if ABI is provided like with Etherscan
- show Sourcify fetch status in UI so if it takes too long at least we see the status