### PR TITLE
`graph codegen`: fix bug with id field clash in example entity

### DIFF
--- a/.changeset/purple-files-think.md
+++ b/.changeset/purple-files-think.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+`graph codegen`: fix bug with id field clash in example entity

--- a/packages/cli/src/scaffold/schema.ts
+++ b/packages/cli/src/scaffold/schema.ts
@@ -89,11 +89,10 @@ export const generateExampleEntityType = (protocol: Protocol, events: any[]) => 
   id: Bytes!
   count: BigInt!
   ${events[0].inputs
-    .reduce(
-      (acc: any[], input: any, index: number) =>
-        acc.concat(generateEventFields({ input, index, protocolName: protocol.name })),
-      [],
-    )
+    .reduce((acc: any[], input: any, index: number) => {
+      input.name = renameNameIfNeeded(input.name);
+      return acc.concat(generateEventFields({ input, index, protocolName: protocol.name }));
+    }, [])
     .slice(0, 2)
     .join('\n')}
 }`;


### PR DESCRIPTION
#1810 fixed `id` field clash for event entities, but not for example entity

To reproduce, run `graph init` for `0xb89279DEd0AD7cD573D164b03424E1E2BbE1e2Be` on `moonbeam` and choose "N" when asked to index events.

This PR fixes it.