### PR TITLE
`graph init`: handle non-standard Etherscan API responses

### DIFF
--- a/.changeset/sweet-spoons-accept.md
+++ b/.changeset/sweet-spoons-accept.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+handle non-standard Etherscan API responses, i.e. kaia

--- a/packages/cli/src/command-helpers/contracts.ts
+++ b/packages/cli/src/command-helpers/contracts.ts
@@ -164,10 +164,10 @@ export class ContractService {
           this.fetchFromEtherscan(
             `${url}?module=contract&action=getsourcecode&address=${address}`,
           ).then(json => {
-            if (!json?.result?.length) {
+            if (!json?.result) {
               throw new Error(`No result: ${JSON.stringify(json)}`);
             }
-            const { ContractName } = json.result[0];
+            const { ContractName } = json.result?.[0] ?? json.result ?? {};
             if (!ContractName) {
               throw new Error('Contract name is empty');
             }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -854,7 +854,7 @@ async function processInitForm(
       type: 'input',
       name: 'startBlock',
       message: 'Start block',
-      initial: () => initStartBlock || startBlock || '0',
+      initial: () => String(initStartBlock || startBlock || 0),
       skip: () => initFromExample !== undefined || isSubstreams,
       validate: value =>
         initFromExample !== undefined ||


### PR DESCRIPTION
Kaia returned non-standard Etherscan response, i.e. object instead of array of objects, number instead of string for start block. This resulted in unhandled `graph init` exception.
This PR fixes it.