### PR TITLE
chore: bump spec version on graph init

### DIFF
--- a/packages/cli/src/scaffold/__snapshots__/cosmos.test.ts.snap
+++ b/packages/cli/src/scaffold/__snapshots__/cosmos.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Cosmos subgraph scaffolding > Manifest 1`] = `
-"specVersion: 1.2.0
+"specVersion: 1.3.0
 indexerHints:
   prune: auto
 schema:

--- a/packages/cli/src/scaffold/__snapshots__/ethereum.test.ts.snap
+++ b/packages/cli/src/scaffold/__snapshots__/ethereum.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Ethereum subgraph scaffolding > Manifest 1`] = `
-"specVersion: 1.2.0
+"specVersion: 1.3.0
 indexerHints:
   prune: auto
 schema:

--- a/packages/cli/src/scaffold/__snapshots__/near.test.ts.snap
+++ b/packages/cli/src/scaffold/__snapshots__/near.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`NEAR subgraph scaffolding > Manifest 1`] = `
-"specVersion: 1.2.0
+"specVersion: 1.3.0
 indexerHints:
   prune: auto
 schema:

--- a/packages/cli/src/scaffold/index.ts
+++ b/packages/cli/src/scaffold/index.ts
@@ -141,7 +141,7 @@ export default class Scaffold {
 
     return await prettier.format(
       `
-specVersion: 1.2.0
+specVersion: 1.3.0
 indexerHints:
   prune: auto
 schema:


### PR DESCRIPTION
With the release of graph-node version `0.37.0`, the latest spec version is `1.3.0`