### PR TITLE
fix: broken AssemblyScript migration link

### DIFF
--- a/packages/cli/src/command-helpers/version.test.ts
+++ b/packages/cli/src/command-helpers/version.test.ts
@@ -222,7 +222,7 @@ describe('Version Command Helpers', { concurrent: true }, () => {
       await expect(assertGraphTsVersion(fakeNodeModulesDir, minimumGraphTsVersion)).rejects.toThrow(
         new Error(
           `To use this version of the graph-cli you must upgrade the graph-ts dependency to a version greater than or equal to ${minimumGraphTsVersion}
-Also, you'll probably need to take a look at our AssemblyScript migration guide because of language breaking changes: https://thegraph.com/docs/developer/assemblyscript-migration-guide`,
+Also, you'll probably need to take a look at our AssemblyScript migration guide because of language breaking changes: https://thegraph.com/docs/en/resources/migration-guides/assemblyscript-migration-guide/`,
         ),
       );
     });

--- a/packages/cli/src/command-helpers/version.ts
+++ b/packages/cli/src/command-helpers/version.ts
@@ -47,7 +47,7 @@ export const assertGraphTsVersion = async (sourceDir: string, minimumGraphTsVers
   if (graphTsVersion && semver.lt(semver.coerce(graphTsVersion)!, minimumGraphTsVersion)) {
     throw new Error(
       `To use this version of the graph-cli you must upgrade the graph-ts dependency to a version greater than or equal to ${minimumGraphTsVersion}
-Also, you'll probably need to take a look at our AssemblyScript migration guide because of language breaking changes: https://thegraph.com/docs/developer/assemblyscript-migration-guide`,
+Also, you'll probably need to take a look at our AssemblyScript migration guide because of language breaking changes: https://thegraph.com/docs/en/resources/migration-guides/assemblyscript-migration-guide/`,
     );
   }
 };


### PR DESCRIPTION
Hi! I noticed that the link to the AssemblyScript migration guide in the CLI error messages is broken. The old URL (`https://thegraph.com/docs/developer/assemblyscript-migration-guide`) no longer works and just leads to a 404 page.  