### PR TITLE
fix: Fixed incorrect usage of `toI32()` for i64 conversion

### DIFF
--- a/packages/ts/common/value.ts
+++ b/packages/ts/common/value.ts
@@ -158,7 +158,7 @@ export class Value {
     const values = this.toArray();
     const output = new Array<i64>(values.length);
     for (let i: i32 = 0; i < values.length; i++) {
-      output[i] = values[i].toI32();
+      output[i] = values[i].toI64();
     }
     return output;
   }


### PR DESCRIPTION
I’ve fixed an issue where `toI32()` was being used to convert values to `i64`.
This is incorrect, as `toI32()` returns an `i32`, not an `i64`, which could result in data loss or unexpected behavior.

The issue has been resolved by updating the conversion to the correct function.