### PR TITLE
Update IPFS endpoints

### DIFF
--- a/.changeset/moody-cars-rule.md
+++ b/.changeset/moody-cars-rule.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+updated IPFS endpoints, added deprecation notice when using old ones

--- a/examples/aggregations/package.json
+++ b/examples/aggregations/package.json
@@ -12,7 +12,7 @@
     "codegen": "graph codegen",
     "create": "graph create example --node https://api.studio.thegraph.com/deploy/",
     "create-local": "graph create example --node http://127.0.0.1:8020",
-    "deploy": "graph deploy example --ipfs https://api.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
+    "deploy": "graph deploy example --ipfs https://ipfs.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
     "deploy-local": "graph deploy example --ipfs http://127.0.0.1:5001 --node http://127.0.0.1:8020",
     "test": "graph test"
   },

--- a/examples/arweave-blocks-transactions/package.json
+++ b/examples/arweave-blocks-transactions/package.json
@@ -14,7 +14,7 @@
     "codegen": "graph codegen",
     "create": "graph create arweave-example --node https://api.studio.thegraph.com/deploy/",
     "create-local": "graph create arweave-example --node http://localhost:8020",
-    "deploy": "graph deploy arweave-example --ipfs https://api.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
+    "deploy": "graph deploy arweave-example --ipfs https://ipfs.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
     "deploy-local": "graph deploy arweave-example -l v0.1.0 --ipfs http://localhost:5001 --node http://localhost:8020",
     "remove-local": "graph remove arweave-example --node http://localhost:8020"
   },

--- a/examples/cosmos-block-filtering/package.json
+++ b/examples/cosmos-block-filtering/package.json
@@ -13,7 +13,7 @@
     "codegen": "graph codegen",
     "create": "graph create cosmos-block-filtering --node https://api.studio.thegraph.com/deploy/",
     "create-local": "graph create cosmos-block-filtering --node http://127.0.0.1:8020",
-    "deploy": "graph deploy cosmos-block-filtering --ipfs https://api.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
+    "deploy": "graph deploy cosmos-block-filtering --ipfs https://ipfs.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
     "deploy-local": "graph deploy cosmos-block-filtering -l v0.1.0 --ipfs http://127.0.0.1:5001 --node http://127.0.0.1:8020",
     "prepare:cosmoshub": "mustache config/cosmoshub.json subgraph.template.yaml > subgraph.yaml",
     "prepare:osmosis": "mustache config/osmosis.json subgraph.template.yaml > subgraph.yaml",

--- a/examples/cosmos-osmosis-token-swaps/package.json
+++ b/examples/cosmos-osmosis-token-swaps/package.json
@@ -13,7 +13,7 @@
     "codegen": "graph codegen",
     "create": "graph create osmosis-token-swaps --node https://api.studio.thegraph.com/deploy/",
     "create-local": "graph create osmosis-token-swaps --node http://0.0.0.0:8020",
-    "deploy": "graph deploy osmosis-token-swaps --ipfs https://api.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
+    "deploy": "graph deploy osmosis-token-swaps --ipfs https://ipfs.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
     "deploy-local": "graph deploy osmosis-token-swaps -l v0.1.0 --ipfs http://0.0.0.0:5001 --node http://0.0.0.0:8020",
     "remove-local": "graph remove osmosis-token-swaps --node http://0.0.0.0:8020"
   },

--- a/examples/cosmos-validator-delegations/package.json
+++ b/examples/cosmos-validator-delegations/package.json
@@ -13,7 +13,7 @@
     "codegen": "graph codegen",
     "create": "graph create cosmos-validator-delegations --node https://api.studio.thegraph.com/deploy/",
     "create-local": "graph create cosmos-validator-delegations --node http://127.0.0.1:8020",
-    "deploy": "graph deploy cosmos-validator-delegations --ipfs https://api.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
+    "deploy": "graph deploy cosmos-validator-delegations --ipfs https://ipfs.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
     "deploy-local": "graph deploy cosmos-validator-delegations -l v0.1.0 --ipfs http://127.0.0.1:5001 --node http://127.0.0.1:8020",
     "prepare:cosmoshub": "mustache config/cosmoshub.json subgraph.template.yaml > subgraph.yaml",
     "prepare:osmosis": "mustache config/osmosis.json subgraph.template.yaml > subgraph.yaml",

--- a/examples/cosmos-validator-rewards/package.json
+++ b/examples/cosmos-validator-rewards/package.json
@@ -13,7 +13,7 @@
     "codegen": "graph codegen",
     "create": "graph create cosmos-validator-rewards --node https://api.studio.thegraph.com/deploy/",
     "create-local": "graph create cosmos-validator-rewards --node http://127.0.0.1:8020",
-    "deploy": "graph deploy cosmos-validator-rewards --ipfs https://api.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
+    "deploy": "graph deploy cosmos-validator-rewards --ipfs https://ipfs.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
     "deploy-local": "graph deploy cosmos-validator-rewards -l v0.1.0 --ipfs http://127.0.0.1:5001 --node http://127.0.0.1:8020",
     "prepare:cosmoshub": "mustache config/cosmoshub.json subgraph.template.yaml > subgraph.yaml",
     "prepare:osmosis": "mustache config/osmosis.json subgraph.template.yaml > subgraph.yaml",

--- a/examples/ethereum-gravatar/package.json
+++ b/examples/ethereum-gravatar/package.json
@@ -14,7 +14,7 @@
     "codegen": "graph codegen",
     "create": "graph create example --node https://api.studio.thegraph.com/deploy/",
     "create-local": "graph create example --node http://127.0.0.1:8020",
-    "deploy": "graph deploy example --ipfs https://api.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
+    "deploy": "graph deploy example --ipfs https://ipfs.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
     "deploy-local": "graph deploy example --ipfs http://127.0.0.1:5001 --node http://127.0.0.1:8020"
   },
   "devDependencies": {

--- a/examples/near-blocks/package.json
+++ b/examples/near-blocks/package.json
@@ -13,7 +13,7 @@
     "codegen": "graph codegen",
     "create": "graph create example --node https://api.studio.thegraph.com/deploy/",
     "create-local": "graph create example --node http://127.0.0.1:8020",
-    "deploy": "graph deploy example --ipfs https://api.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
+    "deploy": "graph deploy example --ipfs https://ipfs.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
     "deploy-local": "graph deploy example --ipfs http://localhost:5001 --node http://127.0.0.1:8020"
   },
   "devDependencies": {

--- a/examples/near-receipts/package.json
+++ b/examples/near-receipts/package.json
@@ -13,7 +13,7 @@
     "codegen": "graph codegen",
     "create": "graph create example --node https://api.studio.thegraph.com/deploy/",
     "create-local": "graph create example --node http://127.0.0.1:8020",
-    "deploy": "graph deploy example --ipfs https://api.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
+    "deploy": "graph deploy example --ipfs https://ipfs.thegraph.com/ipfs/ --node https://api.studio.thegraph.com/deploy/",
     "deploy-local": "graph deploy example --ipfs http://localhost:5001 --node http://127.0.0.1:8020"
   },
   "devDependencies": {

--- a/packages/cli/src/command-helpers/compiler.test.ts
+++ b/packages/cli/src/command-helpers/compiler.test.ts
@@ -1,42 +1,70 @@
 import { describe, expect, it } from 'vitest';
-import { appendApiVersionForGraph } from './compiler.js';
+import { getGraphIpfsUrl } from './ipfs.js';
 
-describe('appendApiVersionForGraph', { concurrent: true }, () => {
-  it('append /api/v0 to Prod URL with trailing slash', () => {
-    expect(appendApiVersionForGraph('https://api.thegraph.com/ipfs/')).toBe(
-      'https://api.thegraph.com/ipfs/api/v0',
-    );
+const DEFAULT_IPFS_URL = 'https://ipfs.thegraph.com/ipfs';
+
+describe('getGraphIpfsUrl', { concurrent: true }, () => {
+  it('returns default URL when input is undefined', () => {
+    expect(getGraphIpfsUrl(undefined)).toEqual({
+      ipfsUrl: DEFAULT_IPFS_URL,
+    });
   });
 
-  it('append /api/v0 to Prod URL without trailing slash', () => {
-    expect(appendApiVersionForGraph('https://api.thegraph.com/ipfs')).toBe(
-      'https://api.thegraph.com/ipfs/api/v0',
-    );
+  it('returns default URL when input is empty string', () => {
+    expect(getGraphIpfsUrl('')).toEqual({
+      ipfsUrl: DEFAULT_IPFS_URL,
+    });
   });
 
-  it('append /api/v0 to Staging URL without trailing slash', () => {
-    expect(appendApiVersionForGraph('https://staging.api.thegraph.com/ipfs')).toBe(
-      'https://staging.api.thegraph.com/ipfs/api/v0',
-    );
+  it('returns input URL when valid and not deprecated', () => {
+    const validUrl = 'https://ipfs.network.example.com';
+    expect(getGraphIpfsUrl(validUrl)).toEqual({
+      ipfsUrl: validUrl,
+    });
   });
 
-  it('do nothing if Prod URL has /api/v0', () => {
-    expect(appendApiVersionForGraph('https://api.thegraph.com/ipfs/api/v0')).toBe(
-      'https://api.thegraph.com/ipfs/api/v0',
-    );
+  it('trim trailing slash from valid url', () => {
+    const validUrl = 'https://ipfs.network.example.com/ipfs/';
+    expect(getGraphIpfsUrl(validUrl)).toEqual({
+      ipfsUrl: 'https://ipfs.network.example.com/ipfs',
+    });
   });
 
-  it('do nothing if Prod URL has no /ipfs', () => {
-    expect(appendApiVersionForGraph('https://api.thegraph.com')).toBe('https://api.thegraph.com');
+  it('returns default URL with warning for deprecated api.thegraph.com URL', () => {
+    const result = getGraphIpfsUrl('https://api.thegraph.com/ipfs/api/v0');
+    expect(result.ipfsUrl).toEqual(DEFAULT_IPFS_URL);
+    expect(result.warning).toContain('deprecated');
   });
 
-  it('do nothing for non-graph endpoint', () => {
-    expect(appendApiVersionForGraph('https://ipfs.saihaj.dev/')).toBe('https://ipfs.saihaj.dev/');
+  it('returns default URL with warning for deprecated ipfs.testnet.thegraph.com URL', () => {
+    const result = getGraphIpfsUrl('https://ipfs.testnet.thegraph.com/abc');
+    expect(result.ipfsUrl).toEqual(DEFAULT_IPFS_URL);
+    expect(result.warning).toContain('deprecated');
   });
 
-  it('do nothing for non-graph endpoint ending with /ipfs', () => {
-    expect(appendApiVersionForGraph('https://ipfs.saihaj.dev/ipfs/')).toBe(
-      'https://ipfs.saihaj.dev/ipfs/',
-    );
+  it('returns default URL with warning for deprecated ipfs.network.thegraph.com URL', () => {
+    const result = getGraphIpfsUrl('https://ipfs.network.thegraph.com/xyz');
+    expect(result.ipfsUrl).toEqual(DEFAULT_IPFS_URL);
+    expect(result.warning).toContain('deprecated');
+  });
+
+  it('returns default URL with warning for invalid URL', () => {
+    const result = getGraphIpfsUrl('not-a-valid-url');
+    expect(result.ipfsUrl).toEqual(DEFAULT_IPFS_URL);
+    expect(result.warning).toContain('Invalid IPFS URL');
+  });
+
+  it('preserves non-deprecated graph endpoints', () => {
+    const url = 'https://ipfs.thegraph.com/ipfs';
+    expect(getGraphIpfsUrl(url)).toEqual({
+      ipfsUrl: url,
+    });
+  });
+
+  it('preserves third-party IPFS endpoints', () => {
+    const url = 'https://ipfs.example.com/api';
+    expect(getGraphIpfsUrl(url)).toEqual({
+      ipfsUrl: url,
+    });
   });
 });

--- a/packages/cli/src/command-helpers/compiler.test.ts
+++ b/packages/cli/src/command-helpers/compiler.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { getGraphIpfsUrl } from './ipfs.js';
 
-const DEFAULT_IPFS_URL = 'https://ipfs.thegraph.com/ipfs';
+const DEFAULT_IPFS_URL = 'https://ipfs.thegraph.com/ipfs/api/v0';
 
 describe('getGraphIpfsUrl', { concurrent: true }, () => {
   it('returns default URL when input is undefined', () => {
@@ -57,7 +57,7 @@ describe('getGraphIpfsUrl', { concurrent: true }, () => {
   it('preserves non-deprecated graph endpoints', () => {
     const url = 'https://ipfs.thegraph.com/ipfs';
     expect(getGraphIpfsUrl(url)).toEqual({
-      ipfsUrl: url,
+      ipfsUrl: DEFAULT_IPFS_URL,
     });
   });
 

--- a/packages/cli/src/command-helpers/compiler.ts
+++ b/packages/cli/src/command-helpers/compiler.ts
@@ -4,6 +4,7 @@ import Compiler from '../compiler/index.js';
 import { GRAPH_CLI_SHARED_HEADERS } from '../constants.js';
 import Protocol from '../protocols/index.js';
 import { createIpfsClient } from '../utils.js';
+import { getGraphIpfsUrl } from './ipfs.js';
 
 interface CreateCompilerOptions {
   ipfs: string | URL | undefined;
@@ -14,22 +15,6 @@ interface CreateCompilerOptions {
   // TODO: Remove this is unused
   blockIpfsMethods?: RegExpMatchArray;
   protocol: Protocol;
-}
-
-/**
- * Appends /api/v0 to the end of a The Graph IPFS URL
- */
-export function appendApiVersionForGraph(inputString: string) {
-  // Check if the input string is a valid The Graph IPFS URL
-  const pattern = /^(https?:\/\/)?([\w-]+\.)+thegraph\.com\/ipfs\/?$/;
-  if (pattern.test(inputString)) {
-    // account for trailing slash
-    if (inputString.endsWith('/')) {
-      return inputString.slice(0, -1) + '/api/v0';
-    }
-    return inputString + '/api/v0';
-  }
-  return inputString;
 }
 
 // Helper function to construct a subgraph compiler
@@ -57,7 +42,7 @@ The IPFS URL must be of the following format: http(s)://host[:port]/[path]`);
   // Connect to the IPFS node (if a node address was provided)
   const ipfsClient = ipfs
     ? createIpfsClient({
-        url: appendApiVersionForGraph(ipfs.toString()),
+        url: getGraphIpfsUrl(ipfs.toString()).ipfsUrl,
         headers: {
           ...headers,
           ...GRAPH_CLI_SHARED_HEADERS,

--- a/packages/cli/src/command-helpers/file-resolver.ts
+++ b/packages/cli/src/command-helpers/file-resolver.ts
@@ -1,7 +1,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'fs-extra';
-import { DEFAULT_IPFS_URL } from './ipfs.js';
+import { getGraphIpfsUrl } from './ipfs.js';
 
 export interface FileSource {
   path: string;
@@ -39,7 +39,7 @@ export async function resolveFile(
     try {
       // If it's an IPFS hash (Qm...)
       if (source.startsWith('Qm')) {
-        const response = await fetch(`${DEFAULT_IPFS_URL}/cat?arg=${source}`);
+        const response = await fetch(`${getGraphIpfsUrl().ipfsUrl}/${source}`);
         if (!response.ok) {
           throw new Error(`failed to fetch from IPFS: ${response.statusText}`);
         }

--- a/packages/cli/src/command-helpers/file-resolver.ts
+++ b/packages/cli/src/command-helpers/file-resolver.ts
@@ -39,7 +39,7 @@ export async function resolveFile(
     try {
       // If it's an IPFS hash (Qm...)
       if (source.startsWith('Qm')) {
-        const response = await fetch(`${getGraphIpfsUrl().ipfsUrl}/${source}`);
+        const response = await fetch(`${getGraphIpfsUrl().ipfsUrl}/cat?arg=${source}`);
         if (!response.ok) {
           throw new Error(`failed to fetch from IPFS: ${response.statusText}`);
         }

--- a/packages/cli/src/command-helpers/ipfs.ts
+++ b/packages/cli/src/command-helpers/ipfs.ts
@@ -1,3 +1,37 @@
-const DEFAULT_IPFS_URL = 'https://api.thegraph.com/ipfs/api/v0' as const;
+const DEFAULT_IPFS_URL = 'https://ipfs.thegraph.com/ipfs' as const;
 
-export { DEFAULT_IPFS_URL };
+/**
+ * Validates supplied IPFS URL and provides warnings for deprecated/invalid URLs
+ * @param ipfsUrl - The IPFS URL to validate, can be undefined
+ * @returns An object with the validated URL and optional warning message
+ */
+export function getGraphIpfsUrl(ipfsUrl?: string): { ipfsUrl: string; warning?: string } {
+  if (!ipfsUrl) {
+    return { ipfsUrl: DEFAULT_IPFS_URL };
+  }
+
+  try {
+    new URL(ipfsUrl);
+
+    const deprecatedPatterns = [
+      /^https?:\/\/ipfs\.testnet\.thegraph\.com.*/,
+      /^https?:\/\/ipfs\.network\.thegraph\.com.*/,
+      /^https?:\/\/api\.thegraph\.com\/ipfs.*/,
+    ];
+
+    const isDeprecated = deprecatedPatterns.some(pattern => pattern.test(ipfsUrl));
+    if (isDeprecated) {
+      return {
+        ipfsUrl: DEFAULT_IPFS_URL,
+        warning: `IPFS URL ${ipfsUrl} is deprecated. Using ${DEFAULT_IPFS_URL}`,
+      };
+    }
+
+    return { ipfsUrl: ipfsUrl.replace(/\/+$/, '') };
+  } catch (e) {
+    return {
+      ipfsUrl: DEFAULT_IPFS_URL,
+      warning: `Invalid IPFS URL: ${ipfsUrl}. Using default URL: ${DEFAULT_IPFS_URL}`,
+    };
+  }
+}

--- a/packages/cli/src/command-helpers/ipfs.ts
+++ b/packages/cli/src/command-helpers/ipfs.ts
@@ -1,4 +1,4 @@
-const DEFAULT_IPFS_URL = 'https://ipfs.thegraph.com/ipfs' as const;
+const DEFAULT_IPFS_URL = 'https://ipfs.thegraph.com/ipfs/api/v0' as const;
 
 /**
  * Validates supplied IPFS URL and provides warnings for deprecated/invalid URLs
@@ -9,6 +9,9 @@ export function getGraphIpfsUrl(ipfsUrl?: string): { ipfsUrl: string; warning?: 
   if (!ipfsUrl) {
     return { ipfsUrl: DEFAULT_IPFS_URL };
   }
+
+  // trim trailing slash
+  ipfsUrl = ipfsUrl.replace(/\/+$/, '');
 
   try {
     new URL(ipfsUrl);
@@ -27,7 +30,14 @@ export function getGraphIpfsUrl(ipfsUrl?: string): { ipfsUrl: string; warning?: 
       };
     }
 
-    return { ipfsUrl: ipfsUrl.replace(/\/+$/, '') };
+    // if default URL - make sure it ends with /api/v0
+    if (DEFAULT_IPFS_URL.startsWith(ipfsUrl)) {
+      return {
+        ipfsUrl: DEFAULT_IPFS_URL,
+      };
+    }
+
+    return { ipfsUrl };
   } catch (e) {
     return {
       ipfsUrl: DEFAULT_IPFS_URL,

--- a/packages/cli/src/command-helpers/ipfs.ts
+++ b/packages/cli/src/command-helpers/ipfs.ts
@@ -23,7 +23,7 @@ export function getGraphIpfsUrl(ipfsUrl?: string): { ipfsUrl: string; warning?: 
     if (isDeprecated) {
       return {
         ipfsUrl: DEFAULT_IPFS_URL,
-        warning: `IPFS URL ${ipfsUrl} is deprecated. Using ${DEFAULT_IPFS_URL}`,
+        warning: `IPFS URL ${ipfsUrl} is deprecated. Using default URL instead: ${DEFAULT_IPFS_URL}`,
       };
     }
 
@@ -31,7 +31,7 @@ export function getGraphIpfsUrl(ipfsUrl?: string): { ipfsUrl: string; warning?: 
   } catch (e) {
     return {
       ipfsUrl: DEFAULT_IPFS_URL,
-      warning: `Invalid IPFS URL: ${ipfsUrl}. Using default URL: ${DEFAULT_IPFS_URL}`,
+      warning: `Invalid IPFS URL: ${ipfsUrl}. Using default URL instead: ${DEFAULT_IPFS_URL}`,
     };
   }
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -2,6 +2,7 @@ import { filesystem } from 'gluegun';
 import { Args, Command, Flags } from '@oclif/core';
 import { createCompiler } from '../command-helpers/compiler.js';
 import * as DataSourcesExtractor from '../command-helpers/data-sources.js';
+import { getGraphIpfsUrl } from '../command-helpers/ipfs.js';
 import { updateSubgraphNetwork } from '../command-helpers/network.js';
 import debug from '../debug.js';
 import Protocol from '../protocols/index.js';
@@ -86,9 +87,13 @@ export default class BuildCommand extends Command {
       const identifierName = protocol.getContract()!.identifierName();
       await updateSubgraphNetwork(manifest, network, networkFile, identifierName);
     }
+    const { ipfsUrl, warning } = getGraphIpfsUrl(ipfs);
+    if (warning) {
+      this.warn(warning);
+    }
 
     const compiler = createCompiler(manifest, {
-      ipfs,
+      ipfs: ipfsUrl,
       outputDir,
       outputFormat,
       skipMigrations,

--- a/packages/cli/src/commands/codegen.ts
+++ b/packages/cli/src/commands/codegen.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { Args, Command, Flags } from '@oclif/core';
 import * as DataSourcesExtractor from '../command-helpers/data-sources.js';
-import { DEFAULT_IPFS_URL } from '../command-helpers/ipfs.js';
+import { getGraphIpfsUrl } from '../command-helpers/ipfs.js';
 import { assertGraphTsVersion, assertManifestApiVersion } from '../command-helpers/version.js';
 import debug from '../debug.js';
 import Protocol from '../protocols/index.js';
@@ -42,7 +42,7 @@ export default class CodegenCommand extends Command {
     ipfs: Flags.string({
       summary: 'IPFS node to use for fetching subgraph data.',
       char: 'i',
-      default: DEFAULT_IPFS_URL,
+      default: getGraphIpfsUrl().ipfsUrl,
     }),
     'uncrashable-config': Flags.file({
       summary: 'Directory for uncrashable config.',
@@ -89,6 +89,11 @@ export default class CodegenCommand extends Command {
       this.error(e, { exit: 1 });
     }
 
+    const { ipfsUrl, warning } = getGraphIpfsUrl(ipfs);
+    if (warning) {
+      this.warn(warning);
+    }
+
     const generator = new TypeGenerator({
       subgraphManifest: manifest,
       outputDir,
@@ -97,7 +102,7 @@ export default class CodegenCommand extends Command {
       uncrashable,
       subgraphSources,
       uncrashableConfig: uncrashableConfig || 'uncrashable-config.yaml',
-      ipfsUrl: ipfs,
+      ipfsUrl,
     });
 
     // Watch working directory for file updates or additions, trigger

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -5,7 +5,7 @@ import { Args, Command, Flags, ux } from '@oclif/core';
 import { URL, URLSearchParams } from '@whatwg-node/fetch';
 import { createCompiler } from '../command-helpers/compiler.js';
 import * as DataSourcesExtractor from '../command-helpers/data-sources.js';
-import { DEFAULT_IPFS_URL } from '../command-helpers/ipfs.js';
+import { getGraphIpfsUrl } from '../command-helpers/ipfs.js';
 import Protocol from '../protocols/index.js';
 
 export default class PublishCommand extends Command {
@@ -34,7 +34,7 @@ export default class PublishCommand extends Command {
     ipfs: Flags.string({
       summary: 'Upload build results to an IPFS node.',
       char: 'i',
-      default: DEFAULT_IPFS_URL,
+      default: getGraphIpfsUrl().ipfsUrl,
     }),
     'ipfs-hash': Flags.string({
       summary: 'IPFS hash of the subgraph manifest to deploy.',
@@ -128,6 +128,11 @@ export default class PublishCommand extends Command {
       );
     }
 
+    const { ipfsUrl, warning } = getGraphIpfsUrl(ipfs);
+    if (warning) {
+      this.warn(warning);
+    }
+
     if (ipfsHash) {
       await this.publishWithBrowser({
         ipfsHash,
@@ -148,7 +153,7 @@ export default class PublishCommand extends Command {
     }
 
     const compiler = createCompiler(manifest, {
-      ipfs,
+      ipfs: ipfsUrl,
       outputDir: 'build/',
       outputFormat: 'wasm',
       skipMigrations: false,

--- a/packages/cli/src/type-generator.ts
+++ b/packages/cli/src/type-generator.ts
@@ -8,8 +8,8 @@ import prettier from 'prettier';
 import uncrashable from '@float-capital/float-subgraph-uncrashable/src/Index.bs.js';
 import DataSourceTemplateCodeGenerator from './codegen/template.js';
 import { GENERATED_FILE_NOTE, ModuleImports } from './codegen/typescript.js';
-import { appendApiVersionForGraph } from './command-helpers/compiler.js';
 import { displayPath } from './command-helpers/fs.js';
+import { getGraphIpfsUrl } from './command-helpers/ipfs.js';
 import { Spinner, step, withSpinner } from './command-helpers/spinner.js';
 import { GRAPH_CLI_SHARED_HEADERS } from './constants.js';
 import debug from './debug.js';
@@ -112,7 +112,7 @@ export default class TypeGenerator {
 
       if (this.options.subgraphSources.length > 0) {
         const ipfsClient = createIpfsClient({
-          url: appendApiVersionForGraph(this.options.ipfsUrl.toString()),
+          url: getGraphIpfsUrl(this.options.ipfsUrl.toString()).ipfsUrl,
           headers: {
             ...GRAPH_CLI_SHARED_HEADERS,
           },

--- a/website/src/components/dropzone.tsx
+++ b/website/src/components/dropzone.tsx
@@ -114,7 +114,7 @@ export function SubgraphImageDropZone(props: React.InputHTMLAttributes<HTMLInput
                 ...a,
                 target: {
                   ...a.target,
-                  value: `https://api.thegraph.com/ipfs/api/v0/cat?arg=${ipfsHash}`,
+                  value: `https://ipfs.thegraph.com/ipfs/${ipfsHash}`,
                 },
               });
             },

--- a/website/src/lib/ipfs.ts
+++ b/website/src/lib/ipfs.ts
@@ -1,7 +1,7 @@
 import { create } from 'kubo-rpc-client';
 
 const ipfsClient = create({
-  url: 'https://api.thegraph.com/ipfs/api/v0',
+  url: 'https://ipfs.thegraph.com/ipfs',
 });
 
 export async function uploadFileToIpfs(file: { path: string; content: Buffer }) {

--- a/website/src/lib/ipfs.ts
+++ b/website/src/lib/ipfs.ts
@@ -1,7 +1,7 @@
 import { create } from 'kubo-rpc-client';
 
 const ipfsClient = create({
-  url: 'https://ipfs.thegraph.com/ipfs',
+  url: 'https://ipfs.thegraph.com/ipfs/api/v0',
 });
 
 export async function uploadFileToIpfs(file: { path: string; content: Buffer }) {

--- a/website/src/routes/publish.lazy.tsx
+++ b/website/src/routes/publish.lazy.tsx
@@ -205,7 +205,7 @@ function DeploySubgraph({
     defaultValues: {
       description: subgraphManifest?.parsed.description,
       subgraphImage:
-        'https://api.thegraph.com/ipfs/api/v0/cat?arg=QmdSeSQ3APFjLktQY3aNVu3M5QXPfE9ZRK5LqgghRgB7L9',
+        'https://ipfs.thegraph.com/ipfs/QmdSeSQ3APFjLktQY3aNVu3M5QXPfE9ZRK5LqgghRgB7L9',
       codeRepository: subgraphManifest?.parsed.repository,
       website: undefined,
       categories: undefined,


### PR DESCRIPTION
- update default IPFS endpoint to `https://ipfs.thegraph.com/ipfs/api/v0`
- add deprecation warning when using old endpoints