### PR TITLE
revert log.critical() never return

### DIFF
--- a/.changeset/old-times-double.md
+++ b/.changeset/old-times-double.md
@@ -1,5 +1,0 @@
----
-'@graphprotocol/graph-ts': patch
----
-
-changed log(CRITICAL) return type to `never` for compiler flow analysis

--- a/packages/ts/index.ts
+++ b/packages/ts/index.ts
@@ -101,10 +101,8 @@ export namespace log {
    * @param msg Format string a la "Value = {}, other = {}".
    * @param args Format string arguments.
    */
-  export function critical(msg: string, args: Array<string>): never {
-    const message = format(msg, args);
-    log(Level.CRITICAL, message);
-    throw new Error(message);
+  export function critical(msg: string, args: Array<string>): void {
+    log(Level.CRITICAL, format(msg, args));
   }
 
   /**


### PR DESCRIPTION
Reverts #2015
AssemblyScript doesn't support `never` type
Need to make "example" subgraph test catch these: https://github.com/graphprotocol/graph-tooling/blob/2cb827a79643654ebcdd05693d282970321bc270/examples/example-subgraph/src/mapping.ts#L271