### PR TITLE
feat(ts): add ethereum.decodeParams host binding

### DIFF
--- a/.changeset/ethereum-decode-params.md
+++ b/.changeset/ethereum-decode-params.md
@@ -1,0 +1,14 @@
+---
+'@graphprotocol/graph-ts': minor
+---
+
+Add `ethereum.decodeParams` for decoding ABI function-parameter data
+
+`ethereum.decode` decodes its input as a single ABI value, which fails for
+data whose top-level type is a tuple with a dynamic field (e.g. Gnosis Safe
+`execTransaction`): transaction calldata and event data are encoded as ABI
+function parameters and have no leading offset word. `ethereum.decodeParams`
+decodes that parameter layout correctly. Use it for calldata/event data and
+keep `ethereum.decode` for round-tripping `ethereum.encode` output.
+
+Requires a graph-node that supports mapping apiVersion `0.0.10`.

--- a/packages/ts/chain/ethereum.ts
+++ b/packages/ts/chain/ethereum.ts
@@ -9,6 +9,7 @@ export declare namespace ethereum {
   function hasCode(address: Address): Wrapped<bool>;
   function encode(token: Value): Bytes | null;
   function decode(types: string, data: Bytes): Value | null;
+  function decodeParams(types: string, data: Bytes): Value | null;
 }
 
 export namespace ethereum {


### PR DESCRIPTION
Declares the `ethereum.decodeParams` host function. Implementation + rationale:
graphprotocol/graph-node#6649.

Use it for calldata/event data; keep `ethereum.decode` for `ethereum.encode`
round-trips. Needs a graph-node with apiVersion 0.0.10.

Refs graphprotocol/graph-node#5432
