### PR TITLE
feat(cli): add --publish-network flag to graph cli deploy

### DIFF
--- a/.changeset/deploy-publish-network.md
+++ b/.changeset/deploy-publish-network.md
@@ -1,0 +1,8 @@
+---
+'@graphprotocol/graph-cli': minor
+---
+
+Add `--publish-network` flag to `graph deploy`. When provided, its value is sent
+to the deployment router as the `publish_to_graph_network` param of the
+`subgraph_deploy` JSON-RPC request. When the flag is omitted, the param is left
+out of the request entirely.

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -57,6 +57,9 @@ export default class DeployCommand extends Command {
       summary: 'Version label used for the deployment.',
       char: 'l',
     }),
+    'publish-network': Flags.string({
+      summary: 'Graph network to publish the subgraph to.',
+    }),
     ipfs: Flags.string({
       summary: 'Upload build results to an IPFS node.',
       char: 'i',
@@ -98,6 +101,7 @@ export default class DeployCommand extends Command {
         'deploy-key': deployKeyFlag,
         'access-token': accessToken,
         'version-label': versionLabelFlag,
+        'publish-network': publishNetwork,
         ipfs,
         headers,
         node: nodeFlag,
@@ -177,6 +181,7 @@ export default class DeployCommand extends Command {
           ipfs_hash: ipfsHash,
           version_label: versionLabel,
           debug_fork: debugFork,
+          publish_to_graph_network: publishNetwork,
         },
         async (
           // @ts-expect-error TODO: why are the arguments not typed?


### PR DESCRIPTION
## Summary
Adds a `--publish-network` flag to `graph deploy`. When set, its value is forwarded to Studio's deployment router as the `publish_to_graph_network` param of the `subgraph_deploy` JSON-RPC request. When the flag is omitted, the param is not included so existing deploy behavior is unchanged.

## Background
To support testing of indexing agreements on `arbitrum-sepolia` (testnet for protocol), Studio's deployment-router needs to discern which protocol network to create the on-chain indexing agreement for once the subgraph deployment is created in Studio. Passing the flag will allow studio to identify if a subgraph deployment is targeting testnet if `--publish-network arbitrum-sepolia` is added to `graph deploy` command, while defaulting to `arbitrum-one` if the param is not added or passed with `--publish-network arbitrum-one` 

## Changes
- `packages/cli/src/commands/deploy.ts` -- new `--publish-network` string flag (no default); its value is threaded into the `subgraph_deploy` params as `publish_to_graph_network`. When undefined, `JSON.stringify` drops the key, matching how the existing `debug_fork` param behaves.
- `.changeset/deploy-publish-network.md` -- minor version bump.

## Testing
This was tested by executing deploy command manually against local IPFS node and deployment-router, capturing the exact request body from the deployment router logs

Scenario 1: `--publish-network arbitrum-sepolia` -> param present
Scenario 2: flag omitted -> param absent

Also confirmed: `graph deploy --help` lists the flag, and `pnpm build` completes successfully with no error.

<img width="841" height="201" alt="cli-deploy-scenario1-run" src="https://github.com/user-attachments/assets/8fb2f8d6-7d93-4e5a-b94f-9e1ed81faff6" />
<img width="1129" height="77" alt="cli-deploy-scenario1-log-OK" src="https://github.com/user-attachments/assets/db78806c-e702-48fc-abee-81466da826f1" />

<img width="838" height="183" alt="cli-deploy-scenario2-run" src="https://github.com/user-attachments/assets/b7544bef-43f3-41bc-854c-6252a011741d" />
<img width="1133" height="68" alt="cli-deploy-scenario2-log-OK" src="https://github.com/user-attachments/assets/79b9d08d-8a19-435a-bc67-c1594dbe6485" />

<img width="1112" height="434" alt="cli-deploy--help-OK" src="https://github.com/user-attachments/assets/4d57c415-ba8b-4263-8f6f-05cf615d61f7" />
