### PR TITLE
fix(graph-ts): catch i32/i64 overflow when the sign bit is the widest bit

### DIFF
--- a/.changeset/bytearray-toi32-overflow.md
+++ b/.changeset/bytearray-toi32-overflow.md
@@ -1,0 +1,10 @@
+---
+'@graphprotocol/graph-ts': patch
+---
+
+`ByteArray.toI32` and `ByteArray.toI64` now report an overflow for a positive value
+that needs the sign bit of the widest byte, instead of returning it as a negative
+number. The overflow check only compared the bytes above the target width against the
+sign padding, so `0x80000000` carried in five bytes - exactly what
+`BigInt.fromUnsignedBytes` produces for a `u32` at or above `2^31` - passed the check
+and came back as `-2147483648`.

--- a/packages/ts/common/collections.ts
+++ b/packages/ts/common/collections.ts
@@ -150,6 +150,14 @@ export class ByteArray extends Uint8Array {
         assert(false, 'overflow converting ' + this.toHexString() + ' to i32');
       }
     }
+    // Matching sign padding above the window is not enough on its own: the sign bit of the
+    // last byte inside the window has to agree with it too. Without this check a positive
+    // value one bit too wide - 0x80000000 carried in five bytes, exactly what
+    // BigInt.fromUnsignedBytes produces for a u32 >= 2^31 - passes the loop above and is
+    // returned as a negative i32 instead of throwing.
+    if (this.length > 4 && this[3] >> 7 != (isNeg ? 1 : 0)) {
+      assert(false, 'overflow converting ' + this.toHexString() + ' to i32');
+    }
     const paddedBytes = new Bytes(4);
     paddedBytes[0] = padding;
     paddedBytes[1] = padding;
@@ -194,6 +202,11 @@ export class ByteArray extends Uint8Array {
       if (this[i] != padding) {
         assert(false, 'overflow converting ' + this.toHexString() + ' to i64');
       }
+    }
+    // Same as in toI32: the sign bit of the last byte inside the window has to agree with
+    // the padding, otherwise a positive value that needs the 64th bit is returned negative.
+    if (this.length > 8 && this[7] >> 7 != (isNeg ? 1 : 0)) {
+      assert(false, 'overflow converting ' + this.toHexString() + ' to i64');
     }
     const paddedBytes = new Bytes(8);
     paddedBytes[0] = padding;

--- a/packages/ts/test/bigInt.ts
+++ b/packages/ts/test/bigInt.ts
@@ -122,7 +122,9 @@ export function testBigInt(): void {
   longArray[3] = 255;
   longArray[4] = 0;
   assert(longArray.toU32() == 4_294_705_147);
-  assert(longArray.toI32() == 4_294_705_147);
+  // 4_294_705_147 is past i32.MAX_VALUE, so toI32 reports an overflow rather than
+  // returning the wrapped -262_149. The assert cannot be written here: an overflow
+  // aborts, and this harness has no way to expect one.
 
   const bytes = Bytes.fromHexString('0x56696b746f726961');
   assert((bytes[0] = 0x56));

--- a/packages/ts/test/bytes.ts
+++ b/packages/ts/test/bytes.ts
@@ -9,7 +9,34 @@ export function testBytesWithByteArray(): void {
   longArray[3] = 255;
   longArray[4] = 0;
   assert(longArray.toU32() == 4_294_705_147);
-  assert(longArray.toI32() == 4_294_705_147);
+  // 4_294_705_147 is past i32.MAX_VALUE, so toI32 reports an overflow rather than
+  // returning the wrapped -262_149. The assert cannot be written here: an overflow
+  // aborts, and this harness has no way to expect one.
+
+  // Widening a value with sign padding must keep converting - these all still fit.
+  const i32Max = new ByteArray(5);
+  i32Max[0] = 255;
+  i32Max[1] = 255;
+  i32Max[2] = 255;
+  i32Max[3] = 127;
+  i32Max[4] = 0;
+  assert(i32Max.toI32() == 2_147_483_647);
+
+  const i32Min = new ByteArray(5);
+  i32Min[0] = 0;
+  i32Min[1] = 0;
+  i32Min[2] = 0;
+  i32Min[3] = 128;
+  i32Min[4] = 255;
+  assert(i32Min.toI32() == -2_147_483_648);
+
+  // The same value in exactly four bytes is a plain i32 and is unaffected.
+  const i32MinNarrow = new ByteArray(4);
+  i32MinNarrow[0] = 0;
+  i32MinNarrow[1] = 0;
+  i32MinNarrow[2] = 0;
+  i32MinNarrow[3] = 128;
+  assert(i32MinNarrow.toI32() == -2_147_483_648);
 
   const bytes = Bytes.fromHexString('0x56696b746f726961');
   assert((bytes[0] = 0x56));


### PR DESCRIPTION
## The bug

`ByteArray.toI32` checks that every byte above the four it keeps matches the sign padding, and `toI64` does the same above eight:

```ts
const isNeg = this.length > 0 && this[this.length - 1] >> 7 == 1;
const padding = isNeg ? 255 : 0;
for (let i = 4; i < this.length; i++) {
  if (this[i] != padding) {
    assert(false, 'overflow converting ' + this.toHexString() + ' to i32');
  }
}
```

That is not sufficient. A **positive** value whose top kept byte has its high bit set is one bit too wide for the signed window — but the bytes above it are zero and match the padding, so the loop passes and the value comes back reinterpreted as negative. Both methods document *"Throws in case of overflow"*, and neither does here.

The shape is not exotic: `BigInt.fromUnsignedBytes` appends a zero byte, so **any `u32` at or above `2^31`** lands in exactly this state.

```
BigInt.fromUnsignedBytes(0x80000000)  ->  [0, 0, 0, 128, 0]
  .toI32()  ==  -2147483648        // silently, no throw
  .isI32()  ==  false              // the library already knows it does not fit
```

For a subgraph that means a large `uint32` — a counter, a packed field, a timestamp — is written to the store as a **negative number** with nothing raised. `isI32()` reports `false` for the same value, so the range check exists; only the conversion skips it.

## The fix

Also require the sign bit of the last byte *inside* the window to agree with the padding.

Values that genuinely fit are untouched, including the widened encodings:

| bytes (LE) | value | before | after |
| --- | --- | --- | --- |
| `[255,255,255,127]` | 2147483647 | 2147483647 | 2147483647 |
| `[0,0,0,128]` | −2147483648 | −2147483648 | −2147483648 |
| `[255,255,255,127,0]` | 2147483647 widened | 2147483647 | 2147483647 |
| `[0,0,0,128,255]` | −2147483648 widened | −2147483648 | −2147483648 |
| `[0,0,0,128,0]` | **2147483648** | **−2147483648** | overflow |
| `[251,255,251,255,0]` | **4294705147** | **−262149** | overflow |

A four-byte array is a plain `i32` and never consults the new check, so the common path is unchanged. `toI64` gets the same treatment at byte 7.

## This is a behavior change — worth your call

Values that silently wrapped now abort the mapping. I think that is right: it is the documented contract, `toU32` already throws for its own range, and a negative count in the store is worse than a loud failure. But it will stop a subgraph that is currently indexing wrapped values, so it is your call whether this rides a patch or waits for a major. Happy to gate it or downgrade it to a `log.warning` instead if you would rather not throw.

## About the tests

Two existing assertions asserted the wrapped result, in `test/bytes.ts` and again in `test/bigInt.ts`:

```ts
assert(longArray.toI32() == 4_294_705_147);
```

`4_294_705_147` does not fit an `i32`; the literal truncates to `-262_149`, which is exactly what `toI32` returned — so the assertion passed while reading as though the full value came back. Both copies are replaced with a note explaining why the value now overflows.

I could not add a positive "it throws" test: an overflow aborts, and this harness has no way to expect an abort. Worth knowing that this is **pre-existing** — I checked the already-shipped overflow path (a byte above the window that does not match the padding) on unmodified code and it surfaces the same way, as `RuntimeError: memory access out of bounds`, because the assert message calls `toHexString()` and the harness stubs that host function to a no-op. My change behaves identically to the existing overflow path.

What I did verify, by running it:

- every row in the table above, through both `ByteArray` and `BigInt`
- the overflow rows abort with the fix and return the wrapped value without it
- `pnpm run test:ts` — full suite green
- `pnpm run lint` — prettier and eslint clean

Changeset included.

---
🤖 Written with [Claude Code](https://claude.com/claude-code). All results above are from a local run.
